### PR TITLE
MODELINKS-3 Create an API endpoint to return all links MARC bib has

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -3,6 +3,22 @@
   "name": "Entities Links",
   "provides": [
     {
+      "id": "instance-links",
+      "version": "1.0",
+      "handlers": [
+        {
+          "methods": [ "GET" ],
+          "pathPattern": "/links/instances/{instanceId}",
+          "permissionsRequired": [ "entities-links.instances.collection.get" ]
+        },
+        {
+          "methods": [ "PUT" ],
+          "pathPattern": "/links/instances/{instanceId}",
+          "permissionsRequired": [ "entities-links.instances.collection.put" ]
+        }
+      ]
+    },
+    {
       "id": "_tenant",
       "version": "2.0",
       "interfaceType": "system",

--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -3,18 +3,26 @@
   "name": "Entities Links",
   "provides": [
     {
-      "id": "instance-links",
+      "id": "instance-authority-links",
       "version": "1.0",
       "handlers": [
         {
-          "methods": [ "GET" ],
+          "methods": [
+            "GET"
+          ],
           "pathPattern": "/links/instances/{instanceId}",
-          "permissionsRequired": [ "entities-links.instances.collection.get" ]
+          "permissionsRequired": [
+            "instance-authority-links.collection.get"
+          ]
         },
         {
-          "methods": [ "PUT" ],
+          "methods": [
+            "PUT"
+          ],
           "pathPattern": "/links/instances/{instanceId}",
-          "permissionsRequired": [ "entities-links.instances.collection.put" ]
+          "permissionsRequired": [
+            "instance-authority-links.collection.put"
+          ]
         }
       ]
     },
@@ -24,12 +32,17 @@
       "interfaceType": "system",
       "handlers": [
         {
-          "methods": ["POST"],
+          "methods": [
+            "POST"
+          ],
           "pathPattern": "/_/tenant",
           "permissionsRequired": []
         },
         {
-          "methods": ["GET", "DELETE"],
+          "methods": [
+            "GET",
+            "DELETE"
+          ],
           "pathPattern": "/_/tenant/{id}",
           "permissionsRequired": []
         }
@@ -37,7 +50,21 @@
     }
   ],
   "permissionSets": [
-
+    {
+      "permissionName": "instance-authority-links.instances.collection.get",
+      "displayName": "Entities Links - get instance-authority links",
+      "description": "Get instance-authority links collection"
+    },
+    {
+      "permissionName": "instance-authority-links.instances.collection.put",
+      "displayName": "Entities Links - update instance-authority links",
+      "description": "Update instance-authority links collection"
+    },
+    {
+      "permissionName": "instance-authority-links.instances.all",
+      "displayName": "Entities Links - all instance-authority links permissions",
+      "description": "Entire set of permissions needed to use instance-links operations"
+    }
   ],
   "launchDescriptor": {
     "dockerImage": "@artifactId@:@version@",

--- a/doc/documentation.md
+++ b/doc/documentation.md
@@ -1,2 +1,77 @@
 # Entities-Links Documentation
 
+## Table of contents
+
+- [API](#api)
+  * [instance-links API](#instance-links-api)
+    + [Retrieve links](#retrieve-instance-links)
+    + [Modify links](#modify-instance-links)
+
+## API
+
+### instance-links API
+The API enables possibility to link a MARC bib field(s) to MARC authority heading(s)/reference(s) because authority records are seen as the source of truth about a person/place/corporation/conference/subject/genre.
+This allows to indicate on any MARC bib records' 1XX/6XX/7XX/8XX fields that they are controlled by the linked/matched MARC authority field 1XX/4XX.
+Which means that the fields are not editable on bib side, instead manual edits to a MARC authority field 1XX/4XX are reflected on them.
+
+| METHOD | URL                                   | Required permissions                      | DESCRIPTION                                 |
+|:-------|:--------------------------------------|:------------------------------------------|:--------------------------------------------|
+| GET    | `/links/instances/{instanceId}`       | `entities-links.instances.collection.get` | Get links collection related to Instance    |
+| PUT    | `/links/instances/{instanceId}`       | `entities-links.instances.collection.put` | Update links collection related to Instance |
+
+#### Examples:
+
+<a name="retrieve-instance-links"></a>
+##### Retrieve all links by the given instance id:
+`GET /links/instances/b2658a84-912b-4ed9-83d7-e8201f4d27ec`
+
+Response:
+
+```json
+{
+  "links": [
+    {
+      "id": 1,
+      "authorityId": "0794f296-4094-4243-b9af-bb4bf51cbfae",
+      "authorityNaturalId": "n92099941",
+      "instanceId": "b2658a84-912b-4ed9-83d7-e8201f4d27ec",
+      "bibRecordTag": "100",
+      "bibRecordSubfields": [
+        "a",
+        "b"
+      ]
+    }
+  ],
+  "totalRecords": 1
+}
+```
+<a name='modify-instance-links'></a>
+##### Modify links by the given instance id:
+`PUT /links/instances/b2658a84-912b-4ed9-83d7-e8201f4d27ec`
+
+```json
+{
+  "links": [
+    {
+      "authorityId": "875e86cf-599d-4293-b966-b34ac6a6d19e",
+      "authorityNaturalId": "no50047988",
+      "instanceId": "b2658a84-912b-4ed9-83d7-e8201f4d27ec",
+      "bibRecordTag": "700",
+      "bibRecordSubfields": [
+        "a",
+        "b"
+      ]
+    },
+    {
+      "authorityId": "77398964-ee2d-4b28-ba2b-e30851d5d963",
+      "authorityNaturalId": "mp96352145",
+      "instanceId": "b2658a84-912b-4ed9-83d7-e8201f4d27ec",
+      "bibRecordTag": "710",
+      "bibRecordSubfields": [
+        "a",
+        "b"
+      ]
+    }
+  ]
+}
+```

--- a/src/main/java/org/folio/entlinks/controller/InstanceLinksController.java
+++ b/src/main/java/org/folio/entlinks/controller/InstanceLinksController.java
@@ -15,6 +15,12 @@ public class InstanceLinksController implements InstanceLinksApi {
   private final InstanceLinkService instanceLinkService;
 
   @Override
+  public ResponseEntity<InstanceLinkDtoCollection> getInstanceLinks(UUID instanceId) {
+    var links = instanceLinkService.getInstanceLinks(instanceId);
+    return ResponseEntity.ok(links);
+  }
+
+  @Override
   public ResponseEntity<Void> updateInstanceLinks(UUID instanceId, InstanceLinkDtoCollection instanceLinkCollection) {
     instanceLinkService.updateInstanceLinks(instanceId, instanceLinkCollection);
     return ResponseEntity.noContent().build();

--- a/src/main/java/org/folio/entlinks/model/converter/InstanceLinkMapper.java
+++ b/src/main/java/org/folio/entlinks/model/converter/InstanceLinkMapper.java
@@ -1,7 +1,9 @@
 package org.folio.entlinks.model.converter;
 
+import java.util.List;
 import org.folio.entlinks.model.entity.InstanceLink;
 import org.folio.qm.domain.dto.InstanceLinkDto;
+import org.folio.qm.domain.dto.InstanceLinkDtoCollection;
 import org.mapstruct.Mapper;
 
 @Mapper(componentModel = "spring")
@@ -10,4 +12,12 @@ public interface InstanceLinkMapper {
     InstanceLinkDto convert(InstanceLink source);
 
     InstanceLink convert(InstanceLinkDto source);
+
+    default InstanceLinkDtoCollection convert(List<InstanceLink> source) {
+      var convertedLinks = source.stream().map(this::convert).toList();
+
+      return new InstanceLinkDtoCollection()
+          .links(convertedLinks)
+          .totalRecords(source.size());
+    }
 }

--- a/src/main/java/org/folio/entlinks/service/InstanceLinkService.java
+++ b/src/main/java/org/folio/entlinks/service/InstanceLinkService.java
@@ -23,6 +23,11 @@ public class InstanceLinkService {
   private final InstanceLinkRepository repository;
   private final InstanceLinkMapper mapper;
 
+  public InstanceLinkDtoCollection getInstanceLinks(UUID instanceId) {
+    var links = repository.findByInstanceId(instanceId);
+    return mapper.convert(links);
+  }
+
   @Transactional
   public void updateInstanceLinks(UUID instanceId, @NotNull InstanceLinkDtoCollection instanceLinkCollection) {
     var links = instanceLinkCollection.getLinks();

--- a/src/main/resources/swagger.api/mod-entities-links.yaml
+++ b/src/main/resources/swagger.api/mod-entities-links.yaml
@@ -34,6 +34,31 @@ paths:
           $ref: '#/components/responses/badRequestResponse'
         '422':
           $ref: '#/components/responses/unprocessableEntityResponse'
+        '500':
+          $ref: '#/components/responses/serverErrorResponse'
+    get:
+      description: Get links collection related to Instance
+      operationId: getInstanceLinks
+      tags:
+        - instance-links
+      parameters:
+        - name: instanceId
+          in: path
+          required: true
+          description: UUID of the Instance that is related to the MARC record
+          schema:
+            $ref: "#/components/schemas/uuid"
+      responses:
+        "200":
+          description: The links collection related to Instance
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/instanceLinkDtoCollection"
+        '400':
+          $ref: '#/components/responses/badRequestResponse'
+        '500':
+          $ref: '#/components/responses/serverErrorResponse'
 
 components:
   schemas:
@@ -112,6 +137,12 @@ components:
             $ref: "#/components/schemas/errorResponse"
     unprocessableEntityResponse:
       description: Validation error for the request.
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/errorResponse'
+    serverErrorResponse:
+      description: Internal server error.
       content:
         application/json:
           schema:


### PR DESCRIPTION
## Purpose
Create an API endpoint to return all links MARC bib has

JIRA: https://issues.folio.org/browse/MODELINKS-3
## Approach
- describe API definition for GET /links/instances/<instanceId> endpoint;
- implement a service layer to retrieve all MARC bib links from the database.
- add endpoints to descriptor
- update tests
- update documentation

### Changes checklist
- [x] API paths, methods, request or response bodies changed, added, or removed
- [ ] Database schema changes
- [x] Interface versions changes
- [ ] Interface dependencies added, or removed
- [x] Permissions changed, added, or removed
