### PR TITLE
Modelinks 8 - Create bulk API to retrieve total links count map for authority

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -23,6 +23,15 @@
           "permissionsRequired": [
             "instance-authority-links.instances.collection.put"
           ]
+        },
+        {
+          "methods": [
+            "POST"
+          ],
+          "pathPattern": "/links/authorities/bulk/count",
+          "permissionsRequired": [
+            "instance-authority-links.authorities.bulk.post"
+          ]
         }
       ]
     },
@@ -61,12 +70,18 @@
       "description": "Update instance-authority links collection"
     },
     {
+      "permissionName": "instance-authority-links.authorities.bulk.post",
+      "displayName": "Entities Links - count instance-authority links for each authority",
+      "description": "Count instance-authority links for each authority"
+    },
+    {
       "permissionName": "instance-authority-links.instances.all",
       "displayName": "Entities Links - all instance-authority links permissions",
       "description": "Entire set of permissions needed to use instance-links operations",
       "subPermissions": [
         "instance-authority-links.instances.collection.get",
-        "instance-authority-links.instances.collection.put"
+        "instance-authority-links.instances.collection.put",
+        "instance-authority-links.authorities.bulk.post"
       ]
     }
   ],

--- a/src/main/java/org/folio/entlinks/controller/InstanceLinksController.java
+++ b/src/main/java/org/folio/entlinks/controller/InstanceLinksController.java
@@ -4,7 +4,7 @@ import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.folio.entlinks.service.InstanceLinkService;
 import org.folio.qm.domain.dto.InstanceLinkDtoCollection;
-import org.folio.qm.domain.dto.LinkCountMapDtoCollection;
+import org.folio.qm.domain.dto.LinksCountDtoCollection;
 import org.folio.qm.domain.dto.UuidCollection;
 import org.folio.qm.rest.resource.InstanceLinksApi;
 import org.springframework.http.ResponseEntity;
@@ -29,8 +29,8 @@ public class InstanceLinksController implements InstanceLinksApi {
   }
 
   @Override
-  public ResponseEntity<LinkCountMapDtoCollection> countNumberOfTitles(UuidCollection authorityIdCollection){
-    var linkCountMapDtoCollection = instanceLinkService.countNumberOfTitles(authorityIdCollection);
+  public ResponseEntity<LinksCountDtoCollection> countNumberOfTitles(UuidCollection authorityIdCollection){
+    var linkCountMapDtoCollection = instanceLinkService.countLinksByAuthorityIds(authorityIdCollection);
     return ResponseEntity.ok(linkCountMapDtoCollection);
   }
 }

--- a/src/main/java/org/folio/entlinks/controller/InstanceLinksController.java
+++ b/src/main/java/org/folio/entlinks/controller/InstanceLinksController.java
@@ -4,6 +4,8 @@ import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.folio.entlinks.service.InstanceLinkService;
 import org.folio.qm.domain.dto.InstanceLinkDtoCollection;
+import org.folio.qm.domain.dto.LinkCountMapDtoCollection;
+import org.folio.qm.domain.dto.UuidCollection;
 import org.folio.qm.rest.resource.InstanceLinksApi;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.RestController;
@@ -24,5 +26,11 @@ public class InstanceLinksController implements InstanceLinksApi {
   public ResponseEntity<Void> updateInstanceLinks(UUID instanceId, InstanceLinkDtoCollection instanceLinkCollection) {
     instanceLinkService.updateInstanceLinks(instanceId, instanceLinkCollection);
     return ResponseEntity.noContent().build();
+  }
+
+  @Override
+  public ResponseEntity<LinkCountMapDtoCollection> countNumberOfTitles(UuidCollection authorityIdCollection){
+    var linkCountMapDtoCollection = instanceLinkService.countNumberOfTitles(authorityIdCollection);
+    return ResponseEntity.ok(linkCountMapDtoCollection);
   }
 }

--- a/src/main/java/org/folio/entlinks/controller/InstanceLinksController.java
+++ b/src/main/java/org/folio/entlinks/controller/InstanceLinksController.java
@@ -29,7 +29,7 @@ public class InstanceLinksController implements InstanceLinksApi {
   }
 
   @Override
-  public ResponseEntity<LinksCountDtoCollection> countNumberOfTitles(UuidCollection authorityIdCollection){
+  public ResponseEntity<LinksCountDtoCollection> countLinksByAuthorityIds(UuidCollection authorityIdCollection){
     var linkCountMapDtoCollection = instanceLinkService.countLinksByAuthorityIds(authorityIdCollection);
     return ResponseEntity.ok(linkCountMapDtoCollection);
   }

--- a/src/main/java/org/folio/entlinks/model/converter/InstanceLinkMapper.java
+++ b/src/main/java/org/folio/entlinks/model/converter/InstanceLinkMapper.java
@@ -5,7 +5,7 @@ import org.folio.entlinks.model.entity.InstanceLink;
 import org.folio.entlinks.model.projection.LinkCountView;
 import org.folio.qm.domain.dto.InstanceLinkDto;
 import org.folio.qm.domain.dto.InstanceLinkDtoCollection;
-import org.folio.qm.domain.dto.LinkCountMapDto;
+import org.folio.qm.domain.dto.LinksCountDto;
 import org.mapstruct.Mapper;
 
 @Mapper(componentModel = "spring")
@@ -23,5 +23,5 @@ public interface InstanceLinkMapper {
           .totalRecords(source.size());
     }
 
-    LinkCountMapDto convert(LinkCountView source);
+    LinksCountDto convert(LinkCountView source);
 }

--- a/src/main/java/org/folio/entlinks/model/converter/InstanceLinkMapper.java
+++ b/src/main/java/org/folio/entlinks/model/converter/InstanceLinkMapper.java
@@ -2,8 +2,10 @@ package org.folio.entlinks.model.converter;
 
 import java.util.List;
 import org.folio.entlinks.model.entity.InstanceLink;
+import org.folio.entlinks.model.projection.LinkCountView;
 import org.folio.qm.domain.dto.InstanceLinkDto;
 import org.folio.qm.domain.dto.InstanceLinkDtoCollection;
+import org.folio.qm.domain.dto.LinkCountMapDto;
 import org.mapstruct.Mapper;
 
 @Mapper(componentModel = "spring")
@@ -20,4 +22,6 @@ public interface InstanceLinkMapper {
           .links(convertedLinks)
           .totalRecords(source.size());
     }
+
+    LinkCountMapDto convert(LinkCountView source);
 }

--- a/src/main/java/org/folio/entlinks/model/projection/LinkCountView.java
+++ b/src/main/java/org/folio/entlinks/model/projection/LinkCountView.java
@@ -1,0 +1,10 @@
+package org.folio.entlinks.model.projection;
+
+import java.util.UUID;
+
+public interface LinkCountView {
+
+  UUID getId();
+
+  Long getTotalLinks();
+}

--- a/src/main/java/org/folio/entlinks/repository/InstanceLinkRepository.java
+++ b/src/main/java/org/folio/entlinks/repository/InstanceLinkRepository.java
@@ -3,10 +3,18 @@ package org.folio.entlinks.repository;
 import java.util.List;
 import java.util.UUID;
 import org.folio.entlinks.model.entity.InstanceLink;
+import org.folio.entlinks.model.projection.LinkCountView;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface InstanceLinkRepository extends JpaRepository<InstanceLink, Long> {
 
   List<InstanceLink> findByInstanceId(UUID instanceId);
+
+  @Query("SELECT il.authorityId AS id, COUNT(id) AS totalLinks"
+      + " FROM InstanceLink il WHERE il.authorityId IN :ids"
+      + " GROUP BY id")
+  List<LinkCountView> countNumberOfTitlesByAuthorityIds(@Param("ids") List<UUID> ids);
 
 }

--- a/src/main/java/org/folio/entlinks/repository/InstanceLinkRepository.java
+++ b/src/main/java/org/folio/entlinks/repository/InstanceLinkRepository.java
@@ -15,6 +15,6 @@ public interface InstanceLinkRepository extends JpaRepository<InstanceLink, Long
   @Query("SELECT il.authorityId AS id, COUNT(id) AS totalLinks"
       + " FROM InstanceLink il WHERE il.authorityId IN :ids"
       + " GROUP BY id")
-  List<LinkCountView> countNumberOfTitlesByAuthorityIds(@Param("ids") List<UUID> ids);
+  List<LinkCountView> countLinksByAuthorityIds(@Param("ids") List<UUID> ids);
 
 }

--- a/src/main/java/org/folio/entlinks/service/InstanceLinkService.java
+++ b/src/main/java/org/folio/entlinks/service/InstanceLinkService.java
@@ -12,8 +12,8 @@ import org.folio.entlinks.model.entity.InstanceLink;
 import org.folio.entlinks.repository.InstanceLinkRepository;
 import org.folio.qm.domain.dto.InstanceLinkDto;
 import org.folio.qm.domain.dto.InstanceLinkDtoCollection;
-import org.folio.qm.domain.dto.LinkCountMapDto;
-import org.folio.qm.domain.dto.LinkCountMapDtoCollection;
+import org.folio.qm.domain.dto.LinksCountDto;
+import org.folio.qm.domain.dto.LinksCountDtoCollection;
 import org.folio.qm.domain.dto.UuidCollection;
 import org.folio.tenant.domain.dto.Parameter;
 import org.jetbrains.annotations.NotNull;
@@ -45,24 +45,23 @@ public class InstanceLinkService {
     repository.saveAll(linksToCreate);
   }
 
-  @Transactional
-  public LinkCountMapDtoCollection countNumberOfTitles(UuidCollection authorityIdCollection) {
+  public LinksCountDtoCollection countLinksByAuthorityIds(UuidCollection authorityIdCollection) {
     var ids = authorityIdCollection.getIds();
-    var linkCountMap = repository.countNumberOfTitlesByAuthorityIds(ids)
+    var linkCountMap = repository.countLinksByAuthorityIds(ids)
         .stream().map(mapper::convert).toList();
 
     linkCountMap = fillInMissingIdsWithZeros(linkCountMap, ids);
 
-    return new LinkCountMapDtoCollection().links(linkCountMap);
+    return new LinksCountDtoCollection().links(linkCountMap);
   }
 
-  private List<LinkCountMapDto> fillInMissingIdsWithZeros(List<LinkCountMapDto> linksCountMap, List<UUID> ids) {
-    var foundIds = linksCountMap.stream().map(LinkCountMapDto::getId).toList();
+  private List<LinksCountDto> fillInMissingIdsWithZeros(List<LinksCountDto> linksCountMap, List<UUID> ids) {
+    var foundIds = linksCountMap.stream().map(LinksCountDto::getId).toList();
     var notFoundIds = ids.stream().filter(uuid -> foundIds.stream().noneMatch(uuid::equals)).toList();
 
     if (!notFoundIds.isEmpty()) {
       var tempList = new ArrayList<>(linksCountMap);
-      notFoundIds.forEach(uuid -> tempList.add(new LinkCountMapDto().id(uuid).totalLinks(0L)));
+      notFoundIds.forEach(uuid -> tempList.add(new LinksCountDto().id(uuid).totalLinks(0L)));
       linksCountMap = tempList;
     }
     return linksCountMap;

--- a/src/main/java/org/folio/entlinks/service/InstanceLinkService.java
+++ b/src/main/java/org/folio/entlinks/service/InstanceLinkService.java
@@ -1,5 +1,6 @@
 package org.folio.entlinks.service;
 
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -11,6 +12,9 @@ import org.folio.entlinks.model.entity.InstanceLink;
 import org.folio.entlinks.repository.InstanceLinkRepository;
 import org.folio.qm.domain.dto.InstanceLinkDto;
 import org.folio.qm.domain.dto.InstanceLinkDtoCollection;
+import org.folio.qm.domain.dto.LinkCountMapDto;
+import org.folio.qm.domain.dto.LinkCountMapDtoCollection;
+import org.folio.qm.domain.dto.UuidCollection;
 import org.folio.tenant.domain.dto.Parameter;
 import org.jetbrains.annotations.NotNull;
 import org.springframework.stereotype.Service;
@@ -39,6 +43,29 @@ public class InstanceLinkService {
     var linksToCreate = subtract(incomingLinks, existedLinks);
     repository.deleteAllInBatch(linksToDelete);
     repository.saveAll(linksToCreate);
+  }
+
+  @Transactional
+  public LinkCountMapDtoCollection countNumberOfTitles(UuidCollection authorityIdCollection) {
+    var ids = authorityIdCollection.getIds();
+    var linkCountMap = repository.countNumberOfTitlesByAuthorityIds(ids)
+        .stream().map(mapper::convert).toList();
+
+    linkCountMap = fillInMissingIdsWithZeros(linkCountMap, ids);
+
+    return new LinkCountMapDtoCollection().links(linkCountMap);
+  }
+
+  private List<LinkCountMapDto> fillInMissingIdsWithZeros(List<LinkCountMapDto> linksCountMap, List<UUID> ids) {
+    var foundIds = linksCountMap.stream().map(LinkCountMapDto::getId).toList();
+    var notFoundIds = ids.stream().filter(uuid -> foundIds.stream().noneMatch(uuid::equals)).toList();
+
+    if (!notFoundIds.isEmpty()) {
+      var tempList = new ArrayList<>(linksCountMap);
+      notFoundIds.forEach(uuid -> tempList.add(new LinkCountMapDto().id(uuid).totalLinks(0L)));
+      linksCountMap = tempList;
+    }
+    return linksCountMap;
   }
 
   private List<InstanceLink> subtract(Collection<InstanceLink> source, Collection<InstanceLink> target) {

--- a/src/main/resources/swagger.api/mod-entities-links.yaml
+++ b/src/main/resources/swagger.api/mod-entities-links.yaml
@@ -60,6 +60,30 @@ paths:
         '500':
           $ref: '#/components/responses/serverErrorResponse'
 
+  /links/authorities/bulk/count:
+    post:
+      description: Retrieve number of links by authority IDs
+      operationId: countNumberOfTitles
+      tags:
+        - instance-links
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/uuidCollection"
+        required: true
+      responses:
+        "200":
+          description: The links collection related to Instance
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/linkCountMapDtoCollection"
+        '400':
+          $ref: '#/components/responses/badRequestResponse'
+        '500':
+          $ref: '#/components/responses/serverErrorResponse'
+
 components:
   schemas:
     instanceLinkDtoCollection:
@@ -110,6 +134,43 @@ components:
         - instanceId
         - bibRecordTag
         - bibRecordSubfields
+
+    uuidCollection:
+      type: object
+      title: Collection of UUIDs
+      description: Collection of UUIDs
+      properties:
+        ids:
+          type: array
+          items:
+            $ref: '#/components/schemas/uuid'
+      required:
+        - ids
+
+    linkCountMapDtoCollection:
+      type: object
+      title: Collection of links count map for authorities
+      description: Collection of links count map for authorities
+      properties:
+        links:
+          type: array
+          items:
+            $ref: '#/components/schemas/linkCountMapDto'
+      required:
+        - links
+
+    linkCountMapDto:
+      type: object
+      title: Total links count map for one authority
+      description: Total links count map for one authority
+      properties:
+        id:
+          $ref: '#/components/schemas/uuid'
+          description: Authority ID
+        totalLinks:
+          type: integer
+          format: int64
+          description: Number of titles linked to the authority
 
     uuid:
       type: string

--- a/src/main/resources/swagger.api/mod-entities-links.yaml
+++ b/src/main/resources/swagger.api/mod-entities-links.yaml
@@ -63,7 +63,7 @@ paths:
   /links/authorities/bulk/count:
     post:
       description: Retrieve number of links by authority IDs
-      operationId: countNumberOfTitles
+      operationId: countLinksByAuthorityIds
       tags:
         - instance-links
       requestBody:

--- a/src/main/resources/swagger.api/mod-entities-links.yaml
+++ b/src/main/resources/swagger.api/mod-entities-links.yaml
@@ -78,7 +78,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/linkCountMapDtoCollection"
+                $ref: "#/components/schemas/linksCountDtoCollection"
         '400':
           $ref: '#/components/responses/badRequestResponse'
         '500':
@@ -147,7 +147,7 @@ components:
       required:
         - ids
 
-    linkCountMapDtoCollection:
+    linksCountDtoCollection:
       type: object
       title: Collection of links count map for authorities
       description: Collection of links count map for authorities
@@ -155,11 +155,11 @@ components:
         links:
           type: array
           items:
-            $ref: '#/components/schemas/linkCountMapDto'
+            $ref: '#/components/schemas/linksCountDto'
       required:
         - links
 
-    linkCountMapDto:
+    linksCountDto:
       type: object
       title: Total links count map for one authority
       description: Total links count map for one authority

--- a/src/test/java/org/folio/entlinks/service/InstanceLinkServiceTest.java
+++ b/src/test/java/org/folio/entlinks/service/InstanceLinkServiceTest.java
@@ -10,9 +10,7 @@ import static org.folio.support.TestUtils.linksDtoCollection;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyList;
-import static org.mockito.Mockito.atLeast;
 import static org.mockito.Mockito.doNothing;
-import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -25,7 +23,7 @@ import org.folio.entlinks.model.entity.InstanceLink;
 import org.folio.entlinks.model.projection.LinkCountView;
 import org.folio.entlinks.repository.InstanceLinkRepository;
 import org.folio.qm.domain.dto.InstanceLinkDto;
-import org.folio.qm.domain.dto.LinkCountMapDto;
+import org.folio.qm.domain.dto.LinksCountDto;
 import org.folio.qm.domain.dto.UuidCollection;
 import org.folio.support.TestUtils.Link;
 import org.folio.support.types.UnitTest;
@@ -263,16 +261,16 @@ class InstanceLinkServiceTest {
     var resultSet = List.of(
         linkCountView(authorityId1, 10),
         linkCountView(authorityId2, 15));
-    when(repository.countNumberOfTitlesByAuthorityIds(anyList())).thenReturn(resultSet);
+    when(repository.countLinksByAuthorityIds(anyList())).thenReturn(resultSet);
 
     var requestBody = new UuidCollection().ids(List.of(authorityId1, authorityId2, authorityId3));
-    var result = service.countNumberOfTitles(requestBody);
+    var result = service.countLinksByAuthorityIds(requestBody);
 
     assertThat(result.getLinks()).hasSize(3);
     assertThat(result.getLinks()).contains(
-        new LinkCountMapDto().id(authorityId1).totalLinks(10L),
-        new LinkCountMapDto().id(authorityId2).totalLinks(15L),
-        new LinkCountMapDto().id(authorityId3).totalLinks(0L));
+        new LinksCountDto().id(authorityId1).totalLinks(10L),
+        new LinksCountDto().id(authorityId2).totalLinks(15L),
+        new LinksCountDto().id(authorityId3).totalLinks(0L));
   }
 
   private ArgumentCaptor<List<InstanceLink>> linksCaptor() {

--- a/src/test/java/org/folio/entlinks/service/InstanceLinkServiceTest.java
+++ b/src/test/java/org/folio/entlinks/service/InstanceLinkServiceTest.java
@@ -9,7 +9,10 @@ import static org.folio.support.TestUtils.linksDto;
 import static org.folio.support.TestUtils.linksDtoCollection;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.Mockito.atLeast;
 import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -19,8 +22,11 @@ import java.util.UUID;
 import org.folio.entlinks.exception.RequestBodyValidationException;
 import org.folio.entlinks.model.converter.InstanceLinkMapperImpl;
 import org.folio.entlinks.model.entity.InstanceLink;
+import org.folio.entlinks.model.projection.LinkCountView;
 import org.folio.entlinks.repository.InstanceLinkRepository;
 import org.folio.qm.domain.dto.InstanceLinkDto;
+import org.folio.qm.domain.dto.LinkCountMapDto;
+import org.folio.qm.domain.dto.UuidCollection;
 import org.folio.support.TestUtils.Link;
 import org.folio.support.types.UnitTest;
 import org.junit.jupiter.api.Assertions;
@@ -249,9 +255,43 @@ class InstanceLinkServiceTest {
       .returns(4, from(List::size));
   }
 
+  @Test
+  void countNumberOfTitles_positive_whenSomeIdsNotFoundThenFillInThemWithZeros() {
+    var authorityId1 = randomUUID();
+    var authorityId2 = randomUUID();
+    var authorityId3 = randomUUID();
+    var resultSet = List.of(
+        linkCountView(authorityId1, 10),
+        linkCountView(authorityId2, 15));
+    when(repository.countNumberOfTitlesByAuthorityIds(anyList())).thenReturn(resultSet);
+
+    var requestBody = new UuidCollection().ids(List.of(authorityId1, authorityId2, authorityId3));
+    var result = service.countNumberOfTitles(requestBody);
+
+    assertThat(result.getLinks()).hasSize(3);
+    assertThat(result.getLinks()).contains(
+        new LinkCountMapDto().id(authorityId1).totalLinks(10L),
+        new LinkCountMapDto().id(authorityId2).totalLinks(15L),
+        new LinkCountMapDto().id(authorityId3).totalLinks(0L));
+  }
+
   private ArgumentCaptor<List<InstanceLink>> linksCaptor() {
     @SuppressWarnings("unchecked") var listClass = (Class<List<InstanceLink>>) (Class<?>) List.class;
     return ArgumentCaptor.forClass(listClass);
+  }
+
+  private LinkCountView linkCountView(UUID id, long totalLinks){
+    return new LinkCountView() {
+      @Override
+      public UUID getId() {
+        return id;
+      }
+
+      @Override
+      public Long getTotalLinks() {
+        return totalLinks;
+      }
+    };
   }
 
 }


### PR DESCRIPTION
## Purpose
As described [MODELINKS-8](https://issues.folio.org/browse/MODELINKS-8), created bulk API to retrieve total links count map for authority

### Changes checklist
- [x] API paths, methods, request or response bodies changed, added, or removed
- [ ] Database schema changes
- [ ] Interface versions changes
- [ ] Interface dependencies added, or removed
- [ ] Permissions changed, added, or removed
