### PR TITLE
MODELINKS-28 Handle authority update when heading type changed

### DIFF
--- a/src/main/java/org/folio/entlinks/service/messaging/authority/InstanceAuthorityLinkUpdateService.java
+++ b/src/main/java/org/folio/entlinks/service/messaging/authority/InstanceAuthorityLinkUpdateService.java
@@ -1,14 +1,22 @@
 package org.folio.entlinks.service.messaging.authority;
 
+import static org.folio.entlinks.utils.ObjectUtils.getDifference;
+
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.stream.Collectors;
+import lombok.SneakyThrows;
 import lombok.extern.log4j.Log4j2;
 import org.apache.kafka.clients.producer.ProducerRecord;
+import org.folio.entlinks.domain.dto.AuthorityInventoryRecord;
 import org.folio.entlinks.domain.dto.InventoryEvent;
-import org.folio.entlinks.domain.dto.InventoryEventType;
 import org.folio.entlinks.domain.dto.LinksChangeEvent;
 import org.folio.entlinks.service.messaging.authority.handler.AuthorityChangeHandler;
+import org.folio.entlinks.service.messaging.authority.model.AuthorityChange;
+import org.folio.entlinks.service.messaging.authority.model.AuthorityChangeHolder;
+import org.folio.entlinks.service.messaging.authority.model.AuthorityChangeType;
 import org.folio.entlinks.utils.KafkaUtils;
 import org.folio.spring.FolioExecutionContext;
 import org.springframework.kafka.core.KafkaTemplate;
@@ -22,7 +30,7 @@ public class InstanceAuthorityLinkUpdateService {
 
   private final FolioExecutionContext context;
   private final KafkaTemplate<String, LinksChangeEvent> kafkaTemplate;
-  private final Map<InventoryEventType, AuthorityChangeHandler> changeHandlers;
+  private final Map<AuthorityChangeType, AuthorityChangeHandler> changeHandlers;
 
   public InstanceAuthorityLinkUpdateService(FolioExecutionContext context,
                                             KafkaTemplate<String, LinksChangeEvent> kafkaTemplate,
@@ -30,14 +38,18 @@ public class InstanceAuthorityLinkUpdateService {
     this.context = context;
     this.kafkaTemplate = kafkaTemplate;
     this.changeHandlers = changeHandlers.stream()
-      .collect(Collectors.toMap(AuthorityChangeHandler::supportedInventoryEventType, handler -> handler));
+      .collect(Collectors.toMap(AuthorityChangeHandler::supportedAuthorityChangeType, handler -> handler));
   }
 
   public void handleAuthoritiesChanges(List<InventoryEvent> events) {
-    var eventsByType = events.stream()
-      .collect(Collectors.groupingBy(event -> InventoryEventType.fromValue(event.getType())));
+    var changeHolders = events.stream()
+      .map(this::toAuthorityChangeHolder)
+      .toList();
 
-    for (var eventsByTypeEntry : eventsByType.entrySet()) {
+    var changesByType = changeHolders.stream()
+      .collect(Collectors.groupingBy(AuthorityChangeHolder::getChangeType));
+
+    for (var eventsByTypeEntry : changesByType.entrySet()) {
       var type = eventsByTypeEntry.getKey();
       var handler = changeHandlers.get(type);
       if (handler == null) {
@@ -50,7 +62,30 @@ public class InstanceAuthorityLinkUpdateService {
     }
   }
 
-  private void sendEvents(List<LinksChangeEvent> events, InventoryEventType type) {
+  private AuthorityChangeHolder toAuthorityChangeHolder(InventoryEvent event) {
+    if (event.getNew() == null) {
+      return new AuthorityChangeHolder(event, Collections.emptyList());
+    }
+    var difference = getAuthorityChanges(event.getNew(), event.getOld());
+    return new AuthorityChangeHolder(event, difference);
+  }
+
+  @SneakyThrows
+  private List<AuthorityChange> getAuthorityChanges(AuthorityInventoryRecord s1, AuthorityInventoryRecord s2) {
+    return getDifference(s1, s2).stream()
+      .map(fieldName -> {
+        try {
+          return AuthorityChange.fromValue(fieldName);
+        } catch (IllegalArgumentException e) {
+          log.debug("Not supported authority change [fieldName: {}]", fieldName);
+          return null;
+        }
+      })
+      .filter(Objects::nonNull)
+      .toList();
+  }
+
+  private void sendEvents(List<LinksChangeEvent> events, AuthorityChangeType type) {
     log.info("Sending {} {} events to Kafka", events.size(), type);
     events.stream()
       .map(this::toProducerRecord)

--- a/src/main/java/org/folio/entlinks/service/messaging/authority/handler/AbstractAuthorityChangeHandler.java
+++ b/src/main/java/org/folio/entlinks/service/messaging/authority/handler/AbstractAuthorityChangeHandler.java
@@ -8,6 +8,7 @@ import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.folio.entlinks.config.properties.InstanceAuthorityChangeProperties;
 import org.folio.entlinks.domain.dto.ChangeTarget;
+import org.folio.entlinks.domain.dto.ChangeTargetLink;
 import org.folio.entlinks.domain.dto.FieldChange;
 import org.folio.entlinks.domain.dto.LinksChangeEvent;
 import org.folio.entlinks.domain.entity.InstanceAuthorityLink;
@@ -54,7 +55,12 @@ public abstract class AbstractAuthorityChangeHandler implements AuthorityChangeH
       .collect(Collectors.groupingBy(InstanceAuthorityLink::getBibRecordTag))
       .entrySet().stream()
       .map(e -> new ChangeTarget().field(e.getKey())
-        .instanceIds(e.getValue().stream().map(InstanceAuthorityLink::getInstanceId).toList()))
+        .links(e.getValue().stream().map(AbstractAuthorityChangeHandler::toChangeTargetLink).toList()))
       .toList();
+  }
+
+  private static ChangeTargetLink toChangeTargetLink(InstanceAuthorityLink instanceAuthorityLink) {
+    return new ChangeTargetLink().linkId(instanceAuthorityLink.getId())
+      .instanceId(instanceAuthorityLink.getInstanceId());
   }
 }

--- a/src/main/java/org/folio/entlinks/service/messaging/authority/handler/AuthorityChangeHandler.java
+++ b/src/main/java/org/folio/entlinks/service/messaging/authority/handler/AuthorityChangeHandler.java
@@ -1,16 +1,16 @@
 package org.folio.entlinks.service.messaging.authority.handler;
 
 import java.util.List;
-import org.folio.entlinks.domain.dto.InventoryEvent;
-import org.folio.entlinks.domain.dto.InventoryEventType;
 import org.folio.entlinks.domain.dto.LinksChangeEvent;
+import org.folio.entlinks.service.messaging.authority.model.AuthorityChangeHolder;
+import org.folio.entlinks.service.messaging.authority.model.AuthorityChangeType;
 
 public interface AuthorityChangeHandler {
 
-  List<LinksChangeEvent> handle(List<InventoryEvent> events);
+  List<LinksChangeEvent> handle(List<AuthorityChangeHolder> changes);
 
   LinksChangeEvent.TypeEnum getReplyEventType();
 
-  InventoryEventType supportedInventoryEventType();
+  AuthorityChangeType supportedAuthorityChangeType();
 
 }

--- a/src/main/java/org/folio/entlinks/service/messaging/authority/model/AuthorityChangeType.java
+++ b/src/main/java/org/folio/entlinks/service/messaging/authority/model/AuthorityChangeType.java
@@ -1,0 +1,6 @@
+package org.folio.entlinks.service.messaging.authority.model;
+
+public enum AuthorityChangeType {
+
+  UPDATE, DELETE
+}

--- a/src/main/resources/swagger.api/mod-entities-links.yaml
+++ b/src/main/resources/swagger.api/mod-entities-links.yaml
@@ -315,12 +315,23 @@ components:
         field:
           description: MARC Bib's field that required change
           type: string
-        instanceIds:
-          description: Instance IDs
-          type: array
+        links:
+          description: Instance-authority links
           items:
-            format: uuid
-            type: string
+            $ref: '#/components/schemas/changeTargetLink'
+
+    changeTargetLink:
+      description: Instance-authority target link
+      type: object
+      properties:
+        linkId:
+          description: Link ID
+          type: integer
+          format: int64
+        instanceId:
+          description: Instance ID
+          type: string
+          format: uuid
 
     fieldChange:
       type: object

--- a/src/test/java/org/folio/entlinks/service/messaging/authority/handler/DeleteAuthorityChangeHandlerTest.java
+++ b/src/test/java/org/folio/entlinks/service/messaging/authority/handler/DeleteAuthorityChangeHandlerTest.java
@@ -18,6 +18,7 @@ import java.util.Set;
 import java.util.UUID;
 import org.folio.entlinks.config.properties.InstanceAuthorityChangeProperties;
 import org.folio.entlinks.domain.dto.ChangeTarget;
+import org.folio.entlinks.domain.dto.ChangeTargetLink;
 import org.folio.entlinks.domain.dto.InventoryEvent;
 import org.folio.entlinks.domain.dto.LinksChangeEvent;
 import org.folio.entlinks.service.links.InstanceAuthorityLinkingService;
@@ -107,6 +108,7 @@ class DeleteAuthorityChangeHandlerTest {
   }
 
   private ChangeTarget changeTarget(UUID instanceId, TestUtils.Link link) {
-    return new ChangeTarget().field(link.tag()).instanceIds(Collections.singletonList(instanceId));
+    return new ChangeTarget().field(link.tag()).links(
+      Collections.singletonList(new ChangeTargetLink().instanceId(instanceId)));
   }
 }

--- a/src/test/java/org/folio/entlinks/utils/ObjectUtilsTest.java
+++ b/src/test/java/org/folio/entlinks/utils/ObjectUtilsTest.java
@@ -40,7 +40,7 @@ class ObjectUtilsTest {
 
     var actual = ObjectUtils.getDifference(t1, t2);
 
-    assertThat(actual).containsExactly("A1", "A2");
+    assertThat(actual).containsExactlyInAnyOrder("A1", "A2");
   }
 
   @Value


### PR DESCRIPTION
## Purpose
Handle authority update when heading type changed

## Approach
When the authority heading type changed then the value of the heading migrated from one field of authority record to another. For example, a record had 100 field with a, b, c (personalName field in inventory record), after update this field has a, b, c, t subfields. After mapping the updated record to the inventory record, it will have already a personalNameTitle field instead of personalName.
So, when we check the authority update message and compare old and new records we will have more differences:
 - personalName: is null in new
 - personalNameTitle: is null in old
 - naturalId: could be changed or not.

So, if an event have more than 2 or 2 and any of them is not naturalId change. It becomes an authority heading type change and as requirements describe, it should be unlinked from bib records. That's why DELETE links event sends after processing this type of change.

### Changes checklist
- [ ] API paths, methods, request or response bodies changed, added, or removed
- [ ] Database schema changes
- [ ] Interface versions changes
- [ ] Interface dependencies added, or removed
- [ ] Permissions changed, added, or removed
- [x] Check logging.
