### PR TITLE
MODELINKS-37 The controlled "MARC Bib" record doesn't respond to update of "010" field of "MARC Authority" record

### DIFF
--- a/src/main/java/org/folio/entlinks/integration/internal/AuthoritySourceFilesService.java
+++ b/src/main/java/org/folio/entlinks/integration/internal/AuthoritySourceFilesService.java
@@ -1,5 +1,6 @@
 package org.folio.entlinks.integration.internal;
 
+import static java.util.Objects.nonNull;
 import static org.folio.entlinks.config.constants.CacheNames.AUTHORITY_SOURCE_FILES_CACHE;
 
 import java.util.List;
@@ -32,6 +33,7 @@ public class AuthoritySourceFilesService {
     }
 
     return authoritySourceFiles.stream()
+      .filter(file -> nonNull(file.id()) && nonNull(file.baseUrl()))
       .collect(Collectors.toMap(AuthoritySourceFile::id, AuthoritySourceFile::baseUrl));
   }
 

--- a/src/test/java/org/folio/entlinks/integration/internal/AuthoritySourceFilesServiceTest.java
+++ b/src/test/java/org/folio/entlinks/integration/internal/AuthoritySourceFilesServiceTest.java
@@ -42,6 +42,24 @@ class AuthoritySourceFilesServiceTest {
   }
 
   @Test
+  void fetchAuthoritySourceUrls_positive_ignoreNullValues() {
+    var e1 = new AuthoritySourceFile(UUID.randomUUID(), "url1");
+    var e2 = new AuthoritySourceFile(null, "url2");
+    var e3 = new AuthoritySourceFile(UUID.randomUUID(), "url3");
+    var e4 = new AuthoritySourceFile(UUID.randomUUID(), null);
+    var validSourceFiles = List.of(e1, e3);
+    var sourceFiles = List.of(e1, e2, e3, e4);
+
+    when(client.fetchAuthoritySourceFiles()).thenReturn(new AuthoritySourceFiles(sourceFiles));
+
+    var actual = service.fetchAuthoritySourceUrls();
+
+    assertThat(actual)
+      .hasSize(validSourceFiles.size())
+      .contains(entry(e1.id(), e1.baseUrl()), entry(e3.id(), e3.baseUrl()));
+  }
+
+  @Test
   void fetchAuthoritySourceUrls_negative_emptyResponse() {
     when(client.fetchAuthoritySourceFiles()).thenReturn(new AuthoritySourceFiles(emptyList()));
 


### PR DESCRIPTION
## Purpose
Fix

## Approach
- ignore authority source files with `null` in `id` or `baseUrl` fields

### Changes checklist
- [ ] API paths, methods, request or response bodies changed, added, or removed
- [ ] Database schema changes
- [ ] Interface versions changes
- [ ] Interface dependencies added, or removed
- [ ] Permissions changed, added, or removed
- [ ] Check logging.

### Learning
[MODELINKS-37](https://issues.folio.org/browse/MODELINKS-37)
