### PR TITLE
MODELINKS-45 Update links with all controlled subfields

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
       src/main/java/org/folio/entlinks/model/**
     </sonar.exclusions>
 
-    <folio-spring-base.version>6.0.0-SNAPSHOT</folio-spring-base.version>
+    <folio-spring-base.version>6.0.0</folio-spring-base.version>
     <hypersistence-utils-hibernate-60.version>3.0.1</hypersistence-utils-hibernate-60.version>
     <folio-service-tools.version>3.0.0-SNAPSHOT</folio-service-tools.version>
     <mapstruct.version>1.5.3.Final</mapstruct.version>

--- a/src/main/java/org/folio/entlinks/service/messaging/authority/model/FieldChangeHolder.java
+++ b/src/main/java/org/folio/entlinks/service/messaging/authority/model/FieldChangeHolder.java
@@ -39,9 +39,10 @@ public class FieldChangeHolder {
   }
 
   public char[] getBibSubfieldCodes() {
-    var bibSubfieldCodes = new char[authSubfields.size()];
-    for (int i = 0; i < authSubfields.size(); i++) {
-      bibSubfieldCodes[i] = authSubfields.get(i).getCode();
+    var authoritySubfields = linkingRule.getAuthoritySubfields();
+    var bibSubfieldCodes = new char[authoritySubfields.length];
+    for (int i = 0; i < authoritySubfields.length; i++) {
+      bibSubfieldCodes[i] = getCode(authoritySubfields[i]);
     }
     return bibSubfieldCodes;
   }

--- a/src/test/java/org/folio/entlinks/integration/kafka/AuthorityInventoryEventListenerIT.java
+++ b/src/test/java/org/folio/entlinks/integration/kafka/AuthorityInventoryEventListenerIT.java
@@ -73,6 +73,14 @@ class AuthorityInventoryEventListenerIT extends IntegrationTestBase {
     return value.getUpdateTargets();
   }
 
+  private static SubfieldChange subfieldChange(String code, String value) {
+    return new SubfieldChange().code(code).value(value);
+  }
+
+  private static SubfieldChange subfieldChangeEmpty(String code) {
+    return subfieldChange(code, EMPTY);
+  }
+
   @BeforeEach
   void setUp() {
     consumerRecords = new LinkedBlockingQueue<>();
@@ -342,7 +350,7 @@ class AuthorityInventoryEventListenerIT extends IntegrationTestBase {
         subfieldChangeEmpty("x"),
         subfieldChangeEmpty("y"),
         subfieldChangeEmpty("z")
-        )),
+      )),
       new FieldChange().field("700").subfields(List.of(
         subfieldChange("a", "Lansing, John"),
         subfieldChangeEmpty("b"),
@@ -396,7 +404,7 @@ class AuthorityInventoryEventListenerIT extends IntegrationTestBase {
         subfieldChangeEmpty("p"),
         subfieldChangeEmpty("r"),
         subfieldChangeEmpty("s")
-        ))
+      ))
     );
     assertions.then(value.getJobId()).as("Job ID").isNotNull();
     assertions.then(value.getTs()).as("Timestamp").isNotNull();
@@ -405,17 +413,11 @@ class AuthorityInventoryEventListenerIT extends IntegrationTestBase {
 
     // check that links were updated according to authority changes
     doGet(linksInstanceEndpoint(), instanceId1)
-      .andExpect(jsonPath("$.links[0].bibRecordSubfields", containsInAnyOrder("a", "d", "q")));
+      .andExpect(jsonPath("$.links[0].bibRecordSubfields",
+        containsInAnyOrder("a", "b", "c", "d", "j", "q")));
     doGet(linksInstanceEndpoint(), instanceId2)
-      .andExpect(jsonPath("$.links[0].bibRecordSubfields", containsInAnyOrder("a", "l")));
-  }
-
-  private static SubfieldChange subfieldChange(String code, String value) {
-    return new SubfieldChange().code(code).value(value);
-  }
-
-  private static SubfieldChange subfieldChangeEmpty(String code) {
-    return subfieldChange(code, EMPTY);
+      .andExpect(jsonPath("$.links[0].bibRecordSubfields",
+        containsInAnyOrder("f", "g", "h", "k", "l", "m", "n", "o", "p", "r", "s", "a")));
   }
 
   @Nullable


### PR DESCRIPTION
## Purpose
Fix issue when user can add controllable subfields to linked field of a "MARC bib" record after updating "1XX" in controlling "MARC authority" record. The cause of this is update of links in database was based on authority subfields and not on linking rules where all possible subfields defined.

### Changes checklist
- [ ] API paths, methods, request or response bodies changed, added, or removed
- [ ] Database schema changes
- [ ] Interface versions changes
- [ ] Interface dependencies added, or removed
- [ ] Permissions changed, added, or removed
- [ ] Check logging.

### TODOS and Open Questions
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.

### Learning
_Describe the research stage. Add links to blog posts, patterns, libraries or addons used to solve this problem._
