### PR TITLE
MODELINKS-35 Link update report: Create endpoint for fetching links stats (Instance)

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -25,6 +25,10 @@
     {
       "id": "authority-source-files",
       "version": "1.0"
+    },
+    {
+      "id": "instance-storage",
+      "version": "10.0"
     }
   ],
   "provides": [
@@ -124,6 +128,24 @@
           ]
         }
       ]
+    },
+    {
+      "id": "linked-bib-update-statistics",
+      "version": "1.0",
+      "handlers": [
+        {
+          "methods": [
+            "GET"
+          ],
+          "pathPattern": "/links/stats/instance",
+          "permissionsRequired": [
+            "instance-authority-links.instance-statistics.collection.get"
+           ],
+          "modulePermissions": [
+            "inventory-storage.instances.collection.get"
+          ]
+        }
+      ]
     }
   ],
   "permissionSets": [
@@ -148,6 +170,16 @@
       "description": "Get instance-authority linking rules"
     },
     {
+      "permissionName":"instance-authority-links.authority-statistics.collection.get",
+      "displayName": "Entities Authority Links Statistics - get instance-authority links statistics",
+      "description": "Get instance-authority links statistics"
+    },
+    {
+      "permissionName":"instance-authority-links.instance-statistics.collection.get",
+      "displayName": "Entities Instance Links Statistics - get instance-authority links statistics",
+      "description": "Get instance-authority links (Instance) statistics"
+    },
+    {
       "permissionName": "instance-authority-links.instances.all",
       "displayName": "Entities Links - all instance-authority links permissions",
       "description": "Entire set of permissions needed to use instance-links operations",
@@ -155,13 +187,10 @@
         "instance-authority-links.instances.collection.get",
         "instance-authority-links.instances.collection.put",
         "instance-authority-links.authorities.bulk.post",
-        "instance-authority.linking-rules.collection.get"
+        "instance-authority.linking-rules.collection.get",
+        "instance-authority-links.authority-statistics.collection.get",
+        "instance-authority-links.instance-statistics.collection.get"
       ]
-    },
-    {
-      "permissionName":"instance-authority-links.authority-statistics.collection.get",
-      "displayName": "Entities Authority Links Statistics - get instance-authority links statistics",
-      "description": "Get instance-authority links statistics"
     }
   ],
   "launchDescriptor": {

--- a/doc/documentation.md
+++ b/doc/documentation.md
@@ -24,6 +24,14 @@
       * [Instance to Authority linking rule parameters](#instance-to-authority-linking-rule-parameters)
       * [Examples](#examples-1)
         * [Retrieve instance to authority linking rules collection:](#retrieve-instance-to-authority-linking-rules-collection-)
+    * [API instance-authority-links-statistics](#api-instance-authority-links-statistics)
+      * [Instance to Authority linking rule parameters](#instance-to-authority-linking-rule-parameters-1)
+      * [Examples](#examples-2)
+        * [Retrieve instance to authority links statistics collection:](#retrieve-instance-to-authority-links-statistics-collection-)
+    * [API linked-bib-update-statistics](#api-linked-bib-update-statistics)
+      * [Linked bib updates statistics parameters](#linked-bib-updates-statistics-parameters)
+      * [Examples](#examples-3)
+        * [Retrieve linked bib updates statistics collection:](#retrieve-linked-bib-updates-statistics-collection-)
 <!-- TOC -->
 
 ## Compiling
@@ -87,6 +95,7 @@ docker run -t -i -p 8081:8081 mod-entities-links
 | KAFKA_AUTHORITIES_CONSUMER_CONCURRENCY                  | 1                  | Number of kafka concurrent threads for `inventory.authority` message consuming                                                                                                        |
 | KAFKA_INSTANCE_AUTHORITY_STATS_CONSUMER_CONCURRENCY     | 1                  | Number of kafka concurrent threads for `links.instance-authority-stats` message consuming                                                                                             |
 | KAFKA_INSTANCE_AUTHORITY_CHANGE_PARTITIONS              | 100                | Number of instance-authority links `links.instance-authority` event contains while processing authority link source change.                                                           |
+| INSTANCE_STORAGE_QUERY_BATCH_SIZE                       | 100                | Number of instances to retrieve from inventory storage per one request                                                                                                                |
 
 ### Configuring spring-boot
 
@@ -337,6 +346,57 @@ Response:
         "headingTypeOld" : "headingTypeOld",
         "sourceFileOld" : "sourceFileOld",
         "headingNew" : "headingNew"
+      }
+    ]
+  }
+]
+```
+
+### API linked-bib-update-statistics
+
+The API provides statistics for linked bib updates.
+
+| METHOD | URL                     | Required permissions                                          | DESCRIPTION                                           |
+|:-------|:------------------------|:--------------------------------------------------------------|:------------------------------------------------------|
+| GET    | `/links/stats/instance` | `instance-authority-links.instance-statistics.collection.get` | Get linked bib update statistics collection           |
+
+#### Linked bib updates statistics parameters
+
+* `fromDate` - Start date to seek from
+* `toDate` - End date to seek to
+* `status` - Link status to filter by
+* `limit` - Max number of items in collection
+
+#### Examples
+
+<a name="retrieve-linked-bib-update-statistics"></a>
+
+##### Retrieve linked bib updates statistics collection:
+
+`GET /links/stats/instance`
+
+Response:
+
+```json
+[
+  { 
+    "next" : "2000-01-23T04:56:07.000+00:00",
+    "stats" : [
+      {
+        "instanceId": "046b6c7f-0b8a-43b9-b35d-6489e6daee91",
+        "instanceTitle": "Some title",
+        "bibRecordTag": "123",
+        "authorityNaturalId": "nr123123",
+        "updatedAt": "2000-01-23T04:56:07.000+00:00",
+        "errorCause": "Error cause"
+      },
+      {
+        "instanceId": "054b6c7f-0b8a-43b9-b35d-6489e6daee91",
+        "instanceTitle": "Some title 1",
+        "bibRecordTag": "321",
+        "authorityNaturalId": "nr321321",
+        "updatedAt": "2000-01-23T04:57:07.000+00:00",
+        "errorCause": "Error cause 1"
       }
     ]
   }

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
 
     <folio-spring-base.version>6.0.0</folio-spring-base.version>
     <hypersistence-utils-hibernate-60.version>3.0.1</hypersistence-utils-hibernate-60.version>
-    <folio-service-tools.version>3.0.0-SNAPSHOT</folio-service-tools.version>
+    <folio-service-tools.version>3.0.0</folio-service-tools.version>
     <mapstruct.version>1.5.3.Final</mapstruct.version>
     <lombok.mapstruct-binding.version>0.2.0</lombok.mapstruct-binding.version>
     <marc4j.version>2.9.2</marc4j.version>

--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
       src/main/java/org/folio/entlinks/model/**
     </sonar.exclusions>
 
-    <folio-spring-base.version>6.0.0-SNAPSHOT</folio-spring-base.version>
+    <folio-spring-base.version>6.0.0</folio-spring-base.version>
     <hypersistence-utils-hibernate-60.version>3.0.1</hypersistence-utils-hibernate-60.version>
     <folio-service-tools.version>3.0.0-SNAPSHOT</folio-service-tools.version>
     <mapstruct.version>1.5.3.Final</mapstruct.version>

--- a/src/main/java/org/folio/entlinks/client/InstanceStorageClient.java
+++ b/src/main/java/org/folio/entlinks/client/InstanceStorageClient.java
@@ -1,0 +1,19 @@
+package org.folio.entlinks.client;
+
+import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
+
+import java.util.List;
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+
+@FeignClient("instance-storage")
+public interface InstanceStorageClient {
+
+  @GetMapping(value = "/instances", produces = APPLICATION_JSON_VALUE)
+  InventoryInstanceDtoCollection getInstanceStorageInstances(@RequestParam String query, @RequestParam int limit);
+
+  record InventoryInstanceDto(String id, String title) { }
+
+  record InventoryInstanceDtoCollection(List<InventoryInstanceDto> instances) { }
+}

--- a/src/main/java/org/folio/entlinks/controller/LinksStatisticsInstanceController.java
+++ b/src/main/java/org/folio/entlinks/controller/LinksStatisticsInstanceController.java
@@ -1,0 +1,24 @@
+package org.folio.entlinks.controller;
+
+import java.time.OffsetDateTime;
+import lombok.RequiredArgsConstructor;
+import org.folio.entlinks.controller.delegate.LinkingServiceDelegate;
+import org.folio.entlinks.domain.dto.BibStatsDtoCollection;
+import org.folio.entlinks.domain.dto.LinkedBibUpdateStatus;
+import org.folio.entlinks.rest.resource.LinkedBibUpdateStatisticsApi;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class LinksStatisticsInstanceController implements LinkedBibUpdateStatisticsApi {
+
+  private final LinkingServiceDelegate delegate;
+
+  @Override
+  public ResponseEntity<BibStatsDtoCollection> getLinkedBibUpdateStats(OffsetDateTime fromDate, OffsetDateTime toDate,
+                                                                       LinkedBibUpdateStatus status, Integer limit) {
+    return ResponseEntity.ok(delegate.getLinkedBibUpdateStats(status, fromDate, toDate, limit));
+  }
+}
+

--- a/src/main/java/org/folio/entlinks/controller/LinksStatisticsInstanceController.java
+++ b/src/main/java/org/folio/entlinks/controller/LinksStatisticsInstanceController.java
@@ -4,7 +4,7 @@ import java.time.OffsetDateTime;
 import lombok.RequiredArgsConstructor;
 import org.folio.entlinks.controller.delegate.LinkingServiceDelegate;
 import org.folio.entlinks.domain.dto.BibStatsDtoCollection;
-import org.folio.entlinks.domain.dto.LinkedBibUpdateStatus;
+import org.folio.entlinks.domain.dto.LinkStatus;
 import org.folio.entlinks.rest.resource.LinkedBibUpdateStatisticsApi;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.RestController;
@@ -17,7 +17,7 @@ public class LinksStatisticsInstanceController implements LinkedBibUpdateStatist
 
   @Override
   public ResponseEntity<BibStatsDtoCollection> getLinkedBibUpdateStats(OffsetDateTime fromDate, OffsetDateTime toDate,
-                                                                       LinkedBibUpdateStatus status, Integer limit) {
+                                                                       LinkStatus status, Integer limit) {
     return ResponseEntity.ok(delegate.getLinkedBibUpdateStats(status, fromDate, toDate, limit));
   }
 }

--- a/src/main/java/org/folio/entlinks/controller/converter/LinkedBibUpdateStatsMapper.java
+++ b/src/main/java/org/folio/entlinks/controller/converter/LinkedBibUpdateStatsMapper.java
@@ -1,0 +1,29 @@
+package org.folio.entlinks.controller.converter;
+
+import static org.folio.entlinks.utils.DateUtils.fromTimestamp;
+
+import java.sql.Timestamp;
+import java.time.OffsetDateTime;
+import java.util.List;
+import org.folio.entlinks.domain.dto.BibStatsDto;
+import org.folio.entlinks.domain.entity.InstanceAuthorityLink;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+
+@Mapper(componentModel = "spring")
+public interface LinkedBibUpdateStatsMapper {
+
+  @Mapping(target = "authorityNaturalId", source = "authorityData.naturalId")
+  BibStatsDto convertToDto(InstanceAuthorityLink source);
+
+  default List<BibStatsDto> convertToDto(List<InstanceAuthorityLink> source) {
+    return source.stream()
+      .map(this::convertToDto)
+      .toList();
+  }
+
+  default OffsetDateTime map(Timestamp timestamp) {
+    return fromTimestamp(timestamp);
+  }
+
+}

--- a/src/main/java/org/folio/entlinks/controller/delegate/LinkingServiceDelegate.java
+++ b/src/main/java/org/folio/entlinks/controller/delegate/LinkingServiceDelegate.java
@@ -18,7 +18,7 @@ import org.folio.entlinks.domain.dto.BibStatsDto;
 import org.folio.entlinks.domain.dto.BibStatsDtoCollection;
 import org.folio.entlinks.domain.dto.InstanceLinkDto;
 import org.folio.entlinks.domain.dto.InstanceLinkDtoCollection;
-import org.folio.entlinks.domain.dto.LinkedBibUpdateStatus;
+import org.folio.entlinks.domain.dto.LinkStatus;
 import org.folio.entlinks.domain.dto.LinksCountDtoCollection;
 import org.folio.entlinks.domain.dto.UuidCollection;
 import org.folio.entlinks.exception.RequestBodyValidationException;
@@ -43,7 +43,7 @@ public class LinkingServiceDelegate {
     return mapper.convertToDto(links);
   }
 
-  public BibStatsDtoCollection getLinkedBibUpdateStats(LinkedBibUpdateStatus status, OffsetDateTime fromDate,
+  public BibStatsDtoCollection getLinkedBibUpdateStats(LinkStatus status, OffsetDateTime fromDate,
                                         OffsetDateTime toDate, int limit) {
     validateDateRange(fromDate, toDate);
 

--- a/src/main/java/org/folio/entlinks/controller/delegate/LinkingServiceDelegate.java
+++ b/src/main/java/org/folio/entlinks/controller/delegate/LinkingServiceDelegate.java
@@ -1,32 +1,65 @@
 package org.folio.entlinks.controller.delegate;
 
+import static java.util.Objects.isNull;
+import static org.apache.commons.lang3.StringUtils.isBlank;
+import static org.folio.entlinks.utils.DateUtils.fromTimestamp;
+
+import java.time.OffsetDateTime;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
 import org.folio.entlinks.controller.converter.InstanceAuthorityLinkMapper;
+import org.folio.entlinks.controller.converter.LinkedBibUpdateStatsMapper;
+import org.folio.entlinks.domain.dto.BibStatsDto;
+import org.folio.entlinks.domain.dto.BibStatsDtoCollection;
 import org.folio.entlinks.domain.dto.InstanceLinkDto;
 import org.folio.entlinks.domain.dto.InstanceLinkDtoCollection;
+import org.folio.entlinks.domain.dto.LinkedBibUpdateStatus;
 import org.folio.entlinks.domain.dto.LinksCountDtoCollection;
 import org.folio.entlinks.domain.dto.UuidCollection;
 import org.folio.entlinks.exception.RequestBodyValidationException;
+import org.folio.entlinks.integration.internal.InstanceStorageService;
 import org.folio.entlinks.service.links.InstanceAuthorityLinkingService;
 import org.folio.tenant.domain.dto.Parameter;
 import org.jetbrains.annotations.NotNull;
 import org.springframework.stereotype.Service;
 
+@Log4j2
 @Service
 @RequiredArgsConstructor
 public class LinkingServiceDelegate {
 
   private final InstanceAuthorityLinkingService linkingService;
+  private final InstanceStorageService instanceService;
   private final InstanceAuthorityLinkMapper mapper;
+  private final LinkedBibUpdateStatsMapper statsMapper;
 
   public InstanceLinkDtoCollection getLinks(UUID instanceId) {
     var links = linkingService.getLinksByInstanceId(instanceId);
     return mapper.convertToDto(links);
+  }
+
+  public BibStatsDtoCollection getLinkedBibUpdateStats(LinkedBibUpdateStatus status, OffsetDateTime fromDate,
+                                        OffsetDateTime toDate, int limit) {
+    validateDateRange(fromDate, toDate);
+
+    var bibStatsCollection = new BibStatsDtoCollection();
+    var links = linkingService.getLinks(status, fromDate, toDate, limit + 1);
+    log.debug("Retrieved links count {}", links.size());
+    if (links.size() > limit) {
+      var nextDate = fromTimestamp(links.get(limit).getUpdatedAt());
+      bibStatsCollection.setNext(nextDate);
+      links = links.subList(0, limit);
+    }
+
+    var stats = statsMapper.convertToDto(links);
+    fillInstanceTitles(stats);
+
+    return bibStatsCollection.stats(stats);
   }
 
   public void updateLinks(UUID instanceId, @NotNull InstanceLinkDtoCollection instanceLinkCollection) {
@@ -78,5 +111,42 @@ public class LinkingServiceDelegate {
     if (!invalidParams.isEmpty()) {
       throw new RequestBodyValidationException("Link should have instanceId = " + instanceId, invalidParams);
     }
+  }
+
+  private void validateDateRange(OffsetDateTime fromDate,
+                                 OffsetDateTime toDate) {
+    if (isNull(fromDate) || isNull(toDate)) {
+      return;
+    }
+    if (fromDate.isAfter(toDate)) {
+      var params = List.of(
+        new Parameter().key("fromDate").value(fromDate.toString()),
+        new Parameter().key("toDate").value(toDate.toString())
+      );
+      throw new RequestBodyValidationException("'to' date should be not less than 'from' date.", params);
+    }
+  }
+
+  private void fillInstanceTitles(List<BibStatsDto> bibStatsList) {
+    var instanceIds = bibStatsList.stream()
+      .map(BibStatsDto::getInstanceId)
+      .map(UUID::toString)
+      .distinct()
+      .toList();
+
+    var instanceTitles = instanceService.getInstanceTitles(instanceIds);
+
+
+    bibStatsList.forEach(bibStatsDto -> {
+      var instanceId = bibStatsDto.getInstanceId().toString();
+      var title = instanceTitles.get(instanceId);
+
+      if (isBlank(title)) {
+        log.warn("Title for instance {} is blank", instanceId);
+        return;
+      }
+
+      bibStatsDto.setInstanceTitle(title);
+    });
   }
 }

--- a/src/main/java/org/folio/entlinks/domain/entity/InstanceAuthorityLink.java
+++ b/src/main/java/org/folio/entlinks/domain/entity/InstanceAuthorityLink.java
@@ -61,6 +61,7 @@ public class InstanceAuthorityLink extends AuditableEntity {
   @Convert(converter = StringToCharArrayConverter.class)
   private char[] bibRecordSubfields;
 
+  @Builder.Default
   @Enumerated(EnumType.STRING)
   @Type(PostgreSQLEnumType.class)
   @Column(name = "status", nullable = false)

--- a/src/main/java/org/folio/entlinks/domain/repository/InstanceLinkRepository.java
+++ b/src/main/java/org/folio/entlinks/domain/repository/InstanceLinkRepository.java
@@ -9,11 +9,13 @@ import org.folio.entlinks.domain.entity.projection.LinkCountView;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
-public interface InstanceLinkRepository extends JpaRepository<InstanceAuthorityLink, Long> {
+public interface InstanceLinkRepository extends JpaRepository<InstanceAuthorityLink, Long>,
+  JpaSpecificationExecutor<InstanceAuthorityLink> {
 
   List<InstanceAuthorityLink> findByInstanceId(UUID instanceId);
 

--- a/src/main/java/org/folio/entlinks/integration/internal/InstanceStorageService.java
+++ b/src/main/java/org/folio/entlinks/integration/internal/InstanceStorageService.java
@@ -1,0 +1,52 @@
+package org.folio.entlinks.integration.internal;
+
+import com.google.common.collect.Lists;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
+import org.folio.entlinks.client.InstanceStorageClient;
+import org.folio.entlinks.client.InstanceStorageClient.InventoryInstanceDto;
+import org.folio.entlinks.client.InstanceStorageClient.InventoryInstanceDtoCollection;
+import org.folio.entlinks.exception.FolioIntegrationException;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+@Log4j2
+@Service
+@RequiredArgsConstructor
+public class InstanceStorageService {
+
+  private static final String CQL_TEMPLATE = "id==(%s)";
+  private static final String CQL_DELIMITER = " or ";
+
+  @Value("${folio.instance-storage.batch-size:100}")
+  private int instanceBatchSize;
+
+  private final InstanceStorageClient client;
+
+  public Map<String, String> getInstanceTitles(List<String> instanceIds) {
+    log.info("Fetching instance titles [count: {}, with batch size: {}]", instanceIds.size(), instanceBatchSize);
+    log.trace("Fetching instance titles for [instance ids: {}]", instanceIds);
+    return Lists.partition(instanceIds, instanceBatchSize).stream()
+      .map(ids -> fetchInstances(buildCql(ids), ids.size()).instances())
+      .flatMap(Collection::stream)
+      .collect(Collectors.toMap(InventoryInstanceDto::id, InventoryInstanceDto::title));
+  }
+
+  private String buildCql(List<String> instanceIds) {
+    var instanceIdsString = String.join(CQL_DELIMITER, instanceIds);
+    return String.format(CQL_TEMPLATE, instanceIdsString);
+  }
+
+  private InventoryInstanceDtoCollection fetchInstances(String query, int limit) {
+    try {
+      log.info("Fetching instances for query: {}, limit: {}", query, limit);
+      return client.getInstanceStorageInstances(query, limit);
+    } catch (Exception e) {
+      throw new FolioIntegrationException("Failed to fetch instances", e);
+    }
+  }
+}

--- a/src/main/java/org/folio/entlinks/service/links/InstanceAuthorityLinkingService.java
+++ b/src/main/java/org/folio/entlinks/service/links/InstanceAuthorityLinkingService.java
@@ -1,8 +1,14 @@
 package org.folio.entlinks.service.links;
 
+import static org.folio.entlinks.utils.DateUtils.toTimestamp;
+
+import jakarta.persistence.criteria.Predicate;
+import java.sql.Timestamp;
+import java.time.OffsetDateTime;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.LinkedHashSet;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -10,11 +16,16 @@ import java.util.UUID;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
+import org.folio.entlinks.domain.dto.LinkedBibUpdateStatus;
 import org.folio.entlinks.domain.entity.InstanceAuthorityLink;
+import org.folio.entlinks.domain.entity.InstanceAuthorityLinkStatus;
 import org.folio.entlinks.domain.entity.projection.LinkCountView;
 import org.folio.entlinks.domain.repository.InstanceLinkRepository;
 import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.jpa.domain.Specification;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -22,6 +33,8 @@ import org.springframework.transaction.annotation.Transactional;
 @Service
 @RequiredArgsConstructor
 public class InstanceAuthorityLinkingService {
+
+  private static final String SEEK_FIELD = "updatedAt";
 
   private final InstanceLinkRepository instanceLinkRepository;
   private final AuthorityDataService authorityDataService;
@@ -108,6 +121,20 @@ public class InstanceAuthorityLinkingService {
     instanceLinkRepository.saveAll(links);
   }
 
+  public List<InstanceAuthorityLink> getLinks(LinkedBibUpdateStatus status, OffsetDateTime fromDate,
+                                              OffsetDateTime toDate, int limit) {
+    log.info("Fetching links for [status: {}, fromDate: {}, toDate: {}, limit: {}]",
+      status, fromDate, toDate, limit);
+
+    var linkStatus = status == null ? null : InstanceAuthorityLinkStatus.valueOf(status.getValue());
+    var linkFromDate = fromDate == null ? null : toTimestamp(fromDate);
+    var linkToDate = toDate == null ? null : toTimestamp(toDate);
+    var pageable = PageRequest.of(0, limit, Sort.by(Sort.Order.desc(SEEK_FIELD)));
+
+    var specification = getSpecFromStatusAndDates(linkStatus, linkFromDate, linkToDate);
+    return instanceLinkRepository.findAll(specification, pageable).getContent();
+  }
+
   private List<InstanceAuthorityLink> getLinksToSave(List<InstanceAuthorityLink> incomingLinks,
                                                      List<InstanceAuthorityLink> existedLinks,
                                                      List<InstanceAuthorityLink> linksToDelete) {
@@ -135,4 +162,23 @@ public class InstanceAuthorityLinkingService {
       .toList();
   }
 
+  private Specification<InstanceAuthorityLink> getSpecFromStatusAndDates(
+    InstanceAuthorityLinkStatus status, Timestamp from, Timestamp to) {
+
+    return (root, query, builder) -> {
+      var predicates = new LinkedList<>();
+
+      if (status != null) {
+        predicates.add(builder.equal(root.get("status"), status));
+      }
+      if (from != null) {
+        predicates.add(builder.greaterThanOrEqualTo(root.get(SEEK_FIELD), from));
+      }
+      if (to != null) {
+        predicates.add(builder.lessThanOrEqualTo(root.get(SEEK_FIELD), to));
+      }
+
+      return builder.and(predicates.toArray(new Predicate[0]));
+    };
+  }
 }

--- a/src/main/java/org/folio/entlinks/service/links/InstanceAuthorityLinkingService.java
+++ b/src/main/java/org/folio/entlinks/service/links/InstanceAuthorityLinkingService.java
@@ -16,7 +16,7 @@ import java.util.UUID;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
-import org.folio.entlinks.domain.dto.LinkedBibUpdateStatus;
+import org.folio.entlinks.domain.dto.LinkStatus;
 import org.folio.entlinks.domain.entity.InstanceAuthorityLink;
 import org.folio.entlinks.domain.entity.InstanceAuthorityLinkStatus;
 import org.folio.entlinks.domain.entity.projection.LinkCountView;
@@ -121,7 +121,7 @@ public class InstanceAuthorityLinkingService {
     instanceLinkRepository.saveAll(links);
   }
 
-  public List<InstanceAuthorityLink> getLinks(LinkedBibUpdateStatus status, OffsetDateTime fromDate,
+  public List<InstanceAuthorityLink> getLinks(LinkStatus status, OffsetDateTime fromDate,
                                               OffsetDateTime toDate, int limit) {
     log.info("Fetching links for [status: {}, fromDate: {}, toDate: {}, limit: {}]",
       status, fromDate, toDate, limit);

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -79,6 +79,8 @@ folio:
   instance-authority:
     change:
       numPartitions: ${KAFKA_INSTANCE_AUTHORITY_CHANGE_PARTITIONS:100}
+  instance-storage:
+    batch-size: ${INSTANCE_STORAGE_QUERY_BATCH_SIZE:100}
 
   retry:
     enabled: true

--- a/src/main/resources/swagger.api/mod-entities-links.yaml
+++ b/src/main/resources/swagger.api/mod-entities-links.yaml
@@ -179,7 +179,7 @@ paths:
           required: false
           description: Status to filter by
           schema:
-            $ref: "#/components/schemas/linkedBibUpdateStatus"
+            $ref: "#/components/schemas/linkStatus"
         - name: limit
           in: query
           required: false
@@ -553,7 +553,7 @@ components:
     linkUpdateReport:
       $ref: schemas/linkUpdateReport.json
 
-    linkedBibUpdateStatus:
+    linkStatus:
       type: string
       enum:
         - ACTUAL

--- a/src/main/resources/swagger.api/mod-entities-links.yaml
+++ b/src/main/resources/swagger.api/mod-entities-links.yaml
@@ -153,6 +153,53 @@ paths:
         '500':
           $ref: '#/components/responses/serverErrorResponse'
 
+  /links/stats/instance:
+    get:
+      description: Retrieve linked bib update statistics
+      operationId: getLinkedBibUpdateStats
+      tags:
+        - linked-bib-update-statistics
+      parameters:
+        - name: fromDate
+          in: query
+          required: false
+          description: Start date to seek from
+          schema:
+            type: string
+            format: date-time
+        - name: toDate
+          in: query
+          required: false
+          description: End date to seek to
+          schema:
+            type: string
+            format: date-time
+        - name: status
+          in: query
+          required: false
+          description: Status to filter by
+          schema:
+            $ref: "#/components/schemas/linkedBibUpdateStatus"
+        - name: limit
+          in: query
+          required: false
+          description: Max number of items in collection
+          schema:
+            type: integer
+            minimum: 1
+            default: 99
+      responses:
+        "200":
+          description: The linked bib update statistics collection
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/bibStatsDtoCollection'
+        '400':
+          $ref: '#/components/responses/badRequestResponse'
+        '500':
+          $ref: '#/components/responses/serverErrorResponse'
+
 components:
   schemas:
     instanceLinkDtoCollection:
@@ -499,6 +546,25 @@ components:
 
     linkUpdateReport:
       $ref: schemas/linkUpdateReport.json
+
+    linkedBibUpdateStatus:
+      type: string
+      enum:
+        - ACTUAL
+        - ERROR
+
+    bibStatsDtoCollection:
+      description: Collection of linked bibs update statistics
+      type: object
+      properties:
+        stats:
+          type: array
+          items:
+            $ref: schemas/bibStatsDto.json
+        next:
+          description: Next response item date to seek by
+          type: string
+          format: date-time
 
   responses:
     badRequestResponse:

--- a/src/main/resources/swagger.api/schemas/bibStatsDto.json
+++ b/src/main/resources/swagger.api/schemas/bibStatsDto.json
@@ -11,9 +11,11 @@
       "format": "uuid"
     },
     "instanceTitle": {
+      "description": "Instance title",
       "type": "string"
     },
     "bibRecordTag": {
+      "description": "Bib record tag",
       "type": "string"
     },
     "authorityNaturalId": {
@@ -21,6 +23,7 @@
       "type": "string"
     },
     "updatedAt": {
+      "description": "Link last updated at",
       "type": "string",
       "format": "date-time"
     },

--- a/src/main/resources/swagger.api/schemas/bibStatsDto.json
+++ b/src/main/resources/swagger.api/schemas/bibStatsDto.json
@@ -1,0 +1,32 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "description": "Linked bib statistics",
+  "type": "object",
+  "properties": {
+    "instanceId": {
+      "description": "Linked instance id, UUID",
+      "$schema": "http://json-schema.org/draft-04/schema#",
+      "id": "uuid.schema",
+      "type": "string",
+      "format": "uuid"
+    },
+    "instanceTitle": {
+      "type": "string"
+    },
+    "bibRecordTag": {
+      "type": "string"
+    },
+    "authorityNaturalId": {
+      "description": "Linked authority natural id",
+      "type": "string"
+    },
+    "updatedAt": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "errorCause": {
+      "description": "Cause of error for updating linked bib",
+      "type": "string"
+    }
+  }
+}

--- a/src/test/java/org/folio/entlinks/controller/LinksStatisticsInstanceIT.java
+++ b/src/test/java/org/folio/entlinks/controller/LinksStatisticsInstanceIT.java
@@ -1,0 +1,272 @@
+package org.folio.entlinks.controller;
+
+import static java.util.Collections.singletonList;
+import static org.folio.support.TestUtils.linksDto;
+import static org.folio.support.TestUtils.linksDtoCollection;
+import static org.folio.support.TestUtils.stats;
+import static org.folio.support.base.TestConstants.linksInstanceEndpoint;
+import static org.folio.support.base.TestConstants.linksStatsInstanceEndpoint;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.startsWith;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.time.Duration;
+import java.time.OffsetDateTime;
+import java.time.temporal.ChronoUnit;
+import java.util.Collection;
+import java.util.LinkedHashMap;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Objects;
+import java.util.UUID;
+import java.util.stream.Stream;
+import org.apache.commons.lang3.ThreadUtils;
+import org.folio.entlinks.domain.dto.BibStatsDto;
+import org.folio.entlinks.domain.dto.BibStatsDtoCollection;
+import org.folio.entlinks.domain.dto.LinkedBibUpdateStatus;
+import org.folio.entlinks.exception.type.ErrorCode;
+import org.folio.spring.test.extension.DatabaseCleanup;
+import org.folio.spring.test.type.IntegrationTest;
+import org.folio.support.TestUtils;
+import org.folio.support.base.IntegrationTestBase;
+import org.hamcrest.BaseMatcher;
+import org.hamcrest.Description;
+import org.hamcrest.Matcher;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.web.servlet.ResultMatcher;
+import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
+
+@IntegrationTest
+@DatabaseCleanup(tables = "instance_authority_link")
+class LinksStatisticsInstanceIT extends IntegrationTestBase {
+
+  private static final List<UUID> INSTANCE_IDS = List.of(
+    UUID.fromString("fea1c418-ba1f-438e-85bb-c6ae1011bf5c"),
+    UUID.fromString("e083463e-96d4-4fa0-8ee1-13bfd4f674cf"),
+    UUID.fromString("68de093d-8c0d-44c2-b3a8-79393f6cb195")
+  );
+  private static final List<String> INSTANCE_TITLES = List.of("title1", "title2", "title3");
+
+  @Test
+  void getLinkedBibUpdateStats_positive_noStatsFound() throws Exception {
+    perform(getStatsRequest())
+      .andExpect(statsMatch(empty()))
+      .andExpect(nextMatch(null));
+  }
+
+  @Test
+  void getLinkedBibUpdateStats_positive_noStatsFoundForStatus() throws Exception {
+    var instanceId = INSTANCE_IDS.get(0);
+    var links = linksDtoCollection(linksDto(instanceId,
+      TestUtils.Link.of(0, 0), TestUtils.Link.of(1, 1)));
+    doPut(linksInstanceEndpoint(), links, instanceId);
+
+    var toDate = OffsetDateTime.now();
+    var fromDate = toDate.minus(1, ChronoUnit.DAYS);
+    perform(getStatsRequest(LinkedBibUpdateStatus.ERROR, fromDate, toDate))
+      .andExpect(statsMatch(empty()))
+      .andExpect(nextMatch(null));
+  }
+
+  @Test
+  void getLinkedBibUpdateStats_positive() throws Exception {
+    var instanceId = INSTANCE_IDS.get(0);
+    var links = linksDtoCollection(linksDto(instanceId,
+      TestUtils.Link.of(0, 0), TestUtils.Link.of(1, 1)));
+    doPut(linksInstanceEndpoint(), links, instanceId);
+
+    var stats = stats(links.getLinks(), null, null, INSTANCE_TITLES.get(0));
+
+    perform(getStatsRequest())
+      .andExpect(statsMatch(hasSize(2)))
+      .andExpect(statsMatch(stats))
+      .andExpect(nextMatch(stats.getNext()));
+  }
+
+  @Test
+  void getLinkedBibUpdateStats_positive_noParams() throws Exception {
+    var instanceId = INSTANCE_IDS.get(0);
+    var links = linksDtoCollection(linksDto(instanceId,
+      TestUtils.Link.of(0, 0), TestUtils.Link.of(1, 1)));
+    doPut(linksInstanceEndpoint(), links, instanceId);
+
+    var stats = stats(links.getLinks(), null, null, INSTANCE_TITLES.get(0));
+
+    perform(get(linksStatsInstanceEndpoint()))
+      .andExpect(statsMatch(hasSize(2)))
+      .andExpect(statsMatch(stats))
+      .andExpect(nextMatch(stats.getNext()));
+  }
+
+  @Test
+  void getLinkedBibUpdateStats_positive_differentInstances() throws Exception {
+    var instanceId1 = INSTANCE_IDS.get(0);
+    var instanceId2 = INSTANCE_IDS.get(1);
+    var links1 = linksDtoCollection(linksDto(instanceId1,
+      TestUtils.Link.of(0, 0), TestUtils.Link.of(1, 1)));
+    var links2 = linksDtoCollection(linksDto(instanceId2,
+      TestUtils.Link.of(0, 0), TestUtils.Link.of(1, 1)));
+    doPut(linksInstanceEndpoint(), links1, instanceId1);
+    doPut(linksInstanceEndpoint(), links2, instanceId2);
+
+    var stats1 = stats(links1.getLinks(), null, null, INSTANCE_TITLES.get(0));
+    var stats2 = stats(links2.getLinks(), null, null, INSTANCE_TITLES.get(1));
+    var stats = new BibStatsDtoCollection()
+      .stats(Stream.concat(stats2.getStats().stream(), stats1.getStats().stream()).toList())
+        .next(null);
+
+    perform(getStatsRequest())
+      .andExpect(statsMatch(hasSize(4)))
+      .andExpect(statsMatch(stats))
+      .andExpect(nextMatch(stats.getNext()));
+  }
+
+  @Test
+  void getLinkedBibUpdateStats_positive_withSkippedAndNext() throws Exception {
+    var instanceId1 = INSTANCE_IDS.get(0);
+    var links1 = linksDtoCollection(linksDto(instanceId1,
+      TestUtils.Link.of(0, 0), TestUtils.Link.of(1, 1)));
+    doPut(linksInstanceEndpoint(), links1, instanceId1);
+
+    final var fromDate = OffsetDateTime.now();
+    ThreadUtils.sleep(Duration.ofSeconds(1));
+
+    var instanceId2 = INSTANCE_IDS.get(1);
+    var links2 = linksDtoCollection(linksDto(instanceId2,
+      TestUtils.Link.of(0, 0), TestUtils.Link.of(1, 1)));
+    doPut(linksInstanceEndpoint(), links2, instanceId2);
+
+    ThreadUtils.sleep(Duration.ofSeconds(1));
+
+    var instanceId3 = INSTANCE_IDS.get(2);
+    var links3 = linksDtoCollection(linksDto(instanceId3,
+      TestUtils.Link.of(0, 0), TestUtils.Link.of(1, 1)));
+    doPut(linksInstanceEndpoint(), links3, instanceId3);
+    var toDate = OffsetDateTime.now();
+
+    var stats1 = stats(links3.getLinks(), null, OffsetDateTime.now(), INSTANCE_TITLES.get(2))
+      .getStats();
+    var stats2 = stats(singletonList(links2.getLinks().get(1)),
+      null, OffsetDateTime.now(), INSTANCE_TITLES.get(1))
+      .getStats();
+    var next = toDate.minus(1, ChronoUnit.SECONDS);
+    var nextStartsWith = next.toString().substring(0, 19);
+    var stats = new BibStatsDtoCollection()
+      .stats(new LinkedList<>(stats1))
+      .next(next);
+    stats.getStats().add(stats2.get(0));
+
+    perform(getStatsRequest(LinkedBibUpdateStatus.ACTUAL, fromDate, toDate).param("limit", "3"))
+      .andExpect(statsMatch(hasSize(3)))
+      .andExpect(statsMatch(stats))
+      .andExpect(jsonPath("$.next", startsWith(nextStartsWith)));
+  }
+
+  @Test
+  void getLinkedBibUpdateStats_positive_onlyOneDateAndLinksSkipped() throws Exception {
+    var instanceId1 = INSTANCE_IDS.get(0);
+    var links1 = linksDtoCollection(linksDto(instanceId1,
+      TestUtils.Link.of(0, 0), TestUtils.Link.of(1, 1)));
+    doPut(linksInstanceEndpoint(), links1, instanceId1);
+
+    ThreadUtils.sleep(Duration.ofSeconds(1));
+
+    var fromDate = OffsetDateTime.now();
+    var instanceId2 = INSTANCE_IDS.get(1);
+    var links2 = linksDtoCollection(linksDto(instanceId2,
+      TestUtils.Link.of(0, 0), TestUtils.Link.of(1, 1)));
+    doPut(linksInstanceEndpoint(), links2, instanceId2);
+
+    var stats = stats(links2.getLinks(), null, OffsetDateTime.now(), INSTANCE_TITLES.get(1));
+
+    perform(get(linksStatsInstanceEndpoint()).param("fromDate", fromDate.toString()))
+      .andExpect(statsMatch(hasSize(2)))
+      .andExpect(statsMatch(stats))
+      .andExpect(nextMatch(null));
+  }
+
+  @Test
+  void getLinkedBibUpdateStats_negative_invalidDates() throws Exception {
+    var fromDate = OffsetDateTime.now();
+    var toDate = fromDate.minus(1, ChronoUnit.DAYS);
+    perform(getStatsRequest(LinkedBibUpdateStatus.ACTUAL, fromDate, toDate))
+      .andExpect(status().isUnprocessableEntity())
+      .andExpect(errorTotalMatch(1))
+      .andExpect(errorTypeMatch(is("RequestBodyValidationException")))
+      .andExpect(errorCodeMatch(is(ErrorCode.VALIDATION_ERROR.getValue())))
+      .andExpect(errorMessageMatch(containsString("'to' date should be not less than 'from' date.")));
+  }
+
+  private MockHttpServletRequestBuilder getStatsRequest() {
+    var toDate = OffsetDateTime.now();
+    var fromDate = toDate.minus(1, ChronoUnit.DAYS);
+    return getStatsRequest(LinkedBibUpdateStatus.ACTUAL, fromDate, toDate);
+  }
+
+  private MockHttpServletRequestBuilder getStatsRequest(LinkedBibUpdateStatus status,
+                                                        OffsetDateTime fromDate, OffsetDateTime toDate) {
+    return get(linksStatsInstanceEndpoint())
+      .param("fromDate", fromDate.toString())
+      .param("toDate", toDate.toString())
+      .param("status", status.getValue());
+  }
+
+  private ResultMatcher nextMatch(OffsetDateTime next) {
+    if (next == null) {
+      return jsonPath("$.next").doesNotExist();
+    }
+    return jsonPath("$.next", is(next));
+  }
+
+  private ResultMatcher statsMatch(Matcher<Collection<? extends BibStatsDto>> matcher) {
+    return jsonPath("$.stats", matcher);
+  }
+
+  @SuppressWarnings("unchecked")
+  private ResultMatcher statsMatch(BibStatsDtoCollection stats) {
+    var statsMatchers = stats.getStats().stream()
+      .map(LinksStatisticsInstanceIT.StatsMatcher::statsMatch)
+      .toArray(Matcher[]::new);
+    return jsonPath("$.stats", contains(statsMatchers));
+  }
+
+  private static final class StatsMatcher extends BaseMatcher<BibStatsDto> {
+
+    private final BibStatsDto expectedStats;
+
+    private StatsMatcher(BibStatsDto expectedStats) {
+      this.expectedStats = expectedStats;
+    }
+
+    static LinksStatisticsInstanceIT.StatsMatcher statsMatch(BibStatsDto expectedStats) {
+      return new LinksStatisticsInstanceIT.StatsMatcher(expectedStats);
+    }
+
+    @Override
+    @SuppressWarnings("rawtypes")
+    public boolean matches(Object actual) {
+      if (actual instanceof LinkedHashMap actualStats) {
+        return Objects.equals(expectedStats.getInstanceId().toString(), actualStats.get("instanceId"))
+          && Objects.equals(expectedStats.getAuthorityNaturalId(), actualStats.get("authorityNaturalId"))
+          && Objects.equals(expectedStats.getBibRecordTag(), actualStats.get("bibRecordTag"))
+          && Objects.equals(expectedStats.getInstanceTitle(), actualStats.get("instanceTitle"))
+          && expectedStats.getUpdatedAt().isAfter(OffsetDateTime.parse((String) actualStats.get("updatedAt")))
+          && Objects.equals(expectedStats.getErrorCause(), actualStats.get("errorCause"));
+      }
+
+      return false;
+    }
+
+    @Override
+    public void describeTo(Description description) {
+      description.appendValue(expectedStats);
+    }
+  }
+
+}

--- a/src/test/java/org/folio/entlinks/controller/LinksStatisticsInstanceIT.java
+++ b/src/test/java/org/folio/entlinks/controller/LinksStatisticsInstanceIT.java
@@ -29,7 +29,7 @@ import java.util.stream.Stream;
 import org.apache.commons.lang3.ThreadUtils;
 import org.folio.entlinks.domain.dto.BibStatsDto;
 import org.folio.entlinks.domain.dto.BibStatsDtoCollection;
-import org.folio.entlinks.domain.dto.LinkedBibUpdateStatus;
+import org.folio.entlinks.domain.dto.LinkStatus;
 import org.folio.entlinks.exception.type.ErrorCode;
 import org.folio.spring.test.extension.DatabaseCleanup;
 import org.folio.spring.test.type.IntegrationTest;
@@ -69,7 +69,7 @@ class LinksStatisticsInstanceIT extends IntegrationTestBase {
 
     var toDate = OffsetDateTime.now();
     var fromDate = toDate.minus(1, ChronoUnit.DAYS);
-    perform(getStatsRequest(LinkedBibUpdateStatus.ERROR, fromDate, toDate))
+    perform(getStatsRequest(LinkStatus.ERROR, fromDate, toDate))
       .andExpect(statsMatch(empty()))
       .andExpect(nextMatch(null));
   }
@@ -162,7 +162,7 @@ class LinksStatisticsInstanceIT extends IntegrationTestBase {
       .next(next);
     stats.getStats().add(stats2.get(0));
 
-    perform(getStatsRequest(LinkedBibUpdateStatus.ACTUAL, fromDate, toDate).param("limit", "3"))
+    perform(getStatsRequest(LinkStatus.ACTUAL, fromDate, toDate).param("limit", "3"))
       .andExpect(statsMatch(hasSize(3)))
       .andExpect(statsMatch(stats))
       .andExpect(jsonPath("$.next", startsWith(nextStartsWith)));
@@ -195,7 +195,7 @@ class LinksStatisticsInstanceIT extends IntegrationTestBase {
   void getLinkedBibUpdateStats_negative_invalidDates() throws Exception {
     var fromDate = OffsetDateTime.now();
     var toDate = fromDate.minus(1, ChronoUnit.DAYS);
-    perform(getStatsRequest(LinkedBibUpdateStatus.ACTUAL, fromDate, toDate))
+    perform(getStatsRequest(LinkStatus.ACTUAL, fromDate, toDate))
       .andExpect(status().isUnprocessableEntity())
       .andExpect(errorTotalMatch(1))
       .andExpect(errorTypeMatch(is("RequestBodyValidationException")))
@@ -206,10 +206,10 @@ class LinksStatisticsInstanceIT extends IntegrationTestBase {
   private MockHttpServletRequestBuilder getStatsRequest() {
     var toDate = OffsetDateTime.now();
     var fromDate = toDate.minus(1, ChronoUnit.DAYS);
-    return getStatsRequest(LinkedBibUpdateStatus.ACTUAL, fromDate, toDate);
+    return getStatsRequest(LinkStatus.ACTUAL, fromDate, toDate);
   }
 
-  private MockHttpServletRequestBuilder getStatsRequest(LinkedBibUpdateStatus status,
+  private MockHttpServletRequestBuilder getStatsRequest(LinkStatus status,
                                                         OffsetDateTime fromDate, OffsetDateTime toDate) {
     return get(linksStatsInstanceEndpoint())
       .param("fromDate", fromDate.toString())

--- a/src/test/java/org/folio/entlinks/controller/delegate/LinkingServiceDelegateTest.java
+++ b/src/test/java/org/folio/entlinks/controller/delegate/LinkingServiceDelegateTest.java
@@ -27,7 +27,7 @@ import org.folio.entlinks.controller.converter.InstanceAuthorityLinkMapper;
 import org.folio.entlinks.controller.converter.LinkedBibUpdateStatsMapper;
 import org.folio.entlinks.domain.dto.BibStatsDtoCollection;
 import org.folio.entlinks.domain.dto.InstanceLinkDtoCollection;
-import org.folio.entlinks.domain.dto.LinkedBibUpdateStatus;
+import org.folio.entlinks.domain.dto.LinkStatus;
 import org.folio.entlinks.domain.dto.LinksCountDto;
 import org.folio.entlinks.domain.dto.UuidCollection;
 import org.folio.entlinks.domain.entity.InstanceAuthorityLink;
@@ -132,7 +132,7 @@ class LinkingServiceDelegateTest {
 
   @Test
   void getLinkedBibUpdateStats_negative_invalidDates() {
-    var status = LinkedBibUpdateStatus.ACTUAL;
+    var status = LinkStatus.ACTUAL;
     var fromDate = OffsetDateTime.now();
     var toDate = fromDate.minus(1, ChronoUnit.DAYS);
     var limit = 2;
@@ -226,7 +226,7 @@ class LinkingServiceDelegateTest {
                                                     List<String> instanceIds,
                                                     Map<String, String> instanceTitles,
                                                     OffsetDateTime next) {
-    var status = LinkedBibUpdateStatus.ACTUAL;
+    var status = LinkStatus.ACTUAL;
     var fromDate = OffsetDateTime.now();
     var toDate = fromDate.plus(1, ChronoUnit.DAYS);
     var limit = 2;

--- a/src/test/java/org/folio/entlinks/controller/delegate/LinkingServiceDelegateTest.java
+++ b/src/test/java/org/folio/entlinks/controller/delegate/LinkingServiceDelegateTest.java
@@ -1,26 +1,38 @@
 package org.folio.entlinks.controller.delegate;
 
+import static java.util.Collections.singletonList;
 import static java.util.UUID.randomUUID;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.from;
 import static org.assertj.core.api.Assertions.tuple;
+import static org.folio.entlinks.utils.DateUtils.fromTimestamp;
 import static org.folio.support.TestUtils.links;
 import static org.folio.support.TestUtils.linksDto;
 import static org.folio.support.TestUtils.linksDtoCollection;
+import static org.folio.support.TestUtils.stats;
 import static org.mockito.ArgumentMatchers.anyMap;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import java.time.OffsetDateTime;
+import java.time.temporal.ChronoUnit;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
+import java.util.stream.Collectors;
+import org.apache.commons.lang3.RandomStringUtils;
 import org.folio.entlinks.controller.converter.InstanceAuthorityLinkMapper;
+import org.folio.entlinks.controller.converter.LinkedBibUpdateStatsMapper;
+import org.folio.entlinks.domain.dto.BibStatsDtoCollection;
 import org.folio.entlinks.domain.dto.InstanceLinkDtoCollection;
+import org.folio.entlinks.domain.dto.LinkedBibUpdateStatus;
 import org.folio.entlinks.domain.dto.LinksCountDto;
 import org.folio.entlinks.domain.dto.UuidCollection;
+import org.folio.entlinks.domain.entity.InstanceAuthorityLink;
 import org.folio.entlinks.exception.RequestBodyValidationException;
+import org.folio.entlinks.integration.internal.InstanceStorageService;
 import org.folio.entlinks.service.links.InstanceAuthorityLinkingService;
 import org.folio.spring.test.type.UnitTest;
 import org.folio.support.TestUtils;
@@ -39,6 +51,8 @@ class LinkingServiceDelegateTest {
 
   private @Mock InstanceAuthorityLinkingService linkingService;
   private @Mock InstanceAuthorityLinkMapper mapper;
+  private @Mock InstanceStorageService instanceService;
+  private @Mock LinkedBibUpdateStatsMapper statsMapper;
 
   private @InjectMocks LinkingServiceDelegate delegate;
 
@@ -62,6 +76,74 @@ class LinkingServiceDelegateTest {
     assertThat(actual.getLinks())
       .hasSize(1)
       .containsExactlyInAnyOrder(linkDto);
+  }
+
+  @Test
+  void getLinkedBibUpdateStats_positive() {
+    var linksMock = links(3, "error");
+    var linksForStats = linksMock.subList(0, 2);
+    var instanceIds = linksForStats.stream()
+      .map(InstanceAuthorityLink::getInstanceId)
+      .map(UUID::toString)
+      .toList();
+    var instanceTitles = instanceIds.stream()
+      .collect(Collectors.toMap(id -> id, id -> RandomStringUtils.randomAlphanumeric(5)));
+    var nextLinkTime = fromTimestamp(linksMock.get(linksMock.size() - 1).getUpdatedAt());
+
+    testGetLinkedBibUpdateStats_positive(linksMock, linksForStats, instanceIds, instanceTitles, nextLinkTime);
+  }
+
+  @Test
+  void getLinkedBibUpdateStats_positive_noNext() {
+    var linksMock = links(2, "error");
+    var instanceIds = linksMock.stream()
+      .map(InstanceAuthorityLink::getInstanceId)
+      .map(UUID::toString)
+      .toList();
+    var instanceTitles = instanceIds.stream()
+      .collect(Collectors.toMap(id -> id, id -> RandomStringUtils.randomAlphanumeric(5)));
+
+    testGetLinkedBibUpdateStats_positive(linksMock, linksMock, instanceIds, instanceTitles, null);
+  }
+
+  @Test
+  void getLinkedBibUpdateStats_positive_sameInstance() {
+    var linksMock = links(2, "error");
+    var instanceId = linksMock.get(0).getInstanceId();
+    linksMock.get(1).setInstanceId(instanceId);
+    var instanceTitle = RandomStringUtils.randomAlphanumeric(5);
+    var instanceTitles = Map.of(instanceId.toString(), instanceTitle);
+
+    testGetLinkedBibUpdateStats_positive(linksMock, linksMock,
+      singletonList(instanceId.toString()), instanceTitles, null);
+  }
+
+  @Test
+  void getLinkedBibUpdateStats_positive_noTitle() {
+    var linksMock = links(2, "error");
+    var instanceIds = linksMock.stream()
+      .map(InstanceAuthorityLink::getInstanceId)
+      .map(UUID::toString)
+      .toList();
+    var instanceTitles = Map.of(instanceIds.get(0), RandomStringUtils.randomAlphanumeric(5));
+
+    testGetLinkedBibUpdateStats_positive(linksMock, linksMock, instanceIds, instanceTitles, null);
+  }
+
+  @Test
+  void getLinkedBibUpdateStats_negative_invalidDates() {
+    var status = LinkedBibUpdateStatus.ACTUAL;
+    var fromDate = OffsetDateTime.now();
+    var toDate = fromDate.minus(1, ChronoUnit.DAYS);
+    var limit = 2;
+
+    var exception = Assertions.assertThrows(RequestBodyValidationException.class,
+      () -> delegate.getLinkedBibUpdateStats(status, fromDate, toDate, limit));
+
+    assertThat(exception)
+      .hasMessage("'to' date should be not less than 'from' date.")
+      .extracting(RequestBodyValidationException::getInvalidParameters)
+      .returns(2, from(List::size));
   }
 
   @Test
@@ -137,5 +219,36 @@ class LinkingServiceDelegateTest {
       .hasSize(ids.size())
       .extracting(LinksCountDto::getId, LinksCountDto::getTotalLinks)
       .containsExactlyInAnyOrder(tuple(ids.get(0), 2), tuple(ids.get(1), 1), tuple(ids.get(2), 0));
+  }
+
+  private void testGetLinkedBibUpdateStats_positive(List<InstanceAuthorityLink> linksMock,
+                                                    List<InstanceAuthorityLink> linksForStats,
+                                                    List<String> instanceIds,
+                                                    Map<String, String> instanceTitles,
+                                                    OffsetDateTime next) {
+    var status = LinkedBibUpdateStatus.ACTUAL;
+    var fromDate = OffsetDateTime.now();
+    var toDate = fromDate.plus(1, ChronoUnit.DAYS);
+    var limit = 2;
+    var stats = stats(linksForStats);
+
+    when(linkingService.getLinks(status, fromDate, toDate, limit + 1))
+      .thenReturn(linksMock);
+    when(statsMapper.convertToDto(linksForStats))
+      .thenReturn(stats);
+    when(instanceService.getInstanceTitles(instanceIds))
+      .thenReturn(instanceTitles);
+
+    stats.forEach(bibStatsDto -> {
+      var instanceId = bibStatsDto.getInstanceId();
+      bibStatsDto.setInstanceTitle(instanceTitles.get(instanceId.toString()));
+    });
+
+    var actual = delegate.getLinkedBibUpdateStats(status, fromDate, toDate, limit);
+
+    assertThat(actual)
+      .isEqualTo(new BibStatsDtoCollection()
+        .stats(stats)
+        .next(next));
   }
 }

--- a/src/test/java/org/folio/entlinks/integration/internal/InstanceStorageServiceTest.java
+++ b/src/test/java/org/folio/entlinks/integration/internal/InstanceStorageServiceTest.java
@@ -1,0 +1,112 @@
+package org.folio.entlinks.integration.internal;
+
+import static java.util.Collections.singletonList;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.entry;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import java.util.UUID;
+import org.folio.entlinks.client.InstanceStorageClient;
+import org.folio.entlinks.client.InstanceStorageClient.InventoryInstanceDto;
+import org.folio.entlinks.client.InstanceStorageClient.InventoryInstanceDtoCollection;
+import org.folio.entlinks.exception.FolioIntegrationException;
+import org.folio.spring.test.type.UnitTest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@UnitTest
+@ExtendWith(MockitoExtension.class)
+class InstanceStorageServiceTest {
+
+  private @Mock InstanceStorageClient client;
+  private @InjectMocks InstanceStorageService service;
+
+  @BeforeEach
+  public void setUp() {
+    ReflectionTestUtils.setField(service, "instanceBatchSize", 2);
+  }
+
+  @Test
+  void getInstanceTitles_positive() {
+    var e1 = new InventoryInstanceDto(UUID.randomUUID().toString(), "title1");
+    var e2 = new InventoryInstanceDto(UUID.randomUUID().toString(), "title2");
+    var instances = List.of(e1, e2);
+
+    when(client.getInstanceStorageInstances(anyString(), anyInt()))
+      .thenReturn(new InventoryInstanceDtoCollection(instances));
+
+    var instanceIds = List.of(e1.id(), e2.id());
+    var actual = service.getInstanceTitles(instanceIds);
+
+    verify(client)
+      .getInstanceStorageInstances(String.format("id==(%s or %s)", e1.id(), e2.id()), instanceIds.size());
+    assertThat(actual)
+      .hasSize(instanceIds.size())
+      .contains(entry(e1.id(), e1.title()), entry(e2.id(), e2.title()));
+  }
+
+  @Test
+  void getInstanceTitles_positive_singleRecord() {
+    var e1 = new InventoryInstanceDto(UUID.randomUUID().toString(), "title1");
+    var instances = singletonList(e1);
+
+    when(client.getInstanceStorageInstances(anyString(), anyInt()))
+      .thenReturn(new InventoryInstanceDtoCollection(instances));
+
+    var instanceIds = singletonList(e1.id());
+    var actual = service.getInstanceTitles(instanceIds);
+
+    verify(client)
+      .getInstanceStorageInstances(String.format("id==(%s)", e1.id()), instanceIds.size());
+    assertThat(actual)
+      .hasSize(instanceIds.size())
+      .contains(entry(e1.id(), e1.title()));
+  }
+
+  @Test
+  void getInstanceTitles_positive_multipleBatches() {
+    var e1 = new InventoryInstanceDto(UUID.randomUUID().toString(), "title1");
+    var e2 = new InventoryInstanceDto(UUID.randomUUID().toString(), "title2");
+    var e3 = new InventoryInstanceDto(UUID.randomUUID().toString(), "title3");
+    var instancesBatch1 = List.of(e1, e2);
+    var instancesBatch2 = singletonList(e3);
+
+    when(client.getInstanceStorageInstances(anyString(), anyInt()))
+      .thenReturn(new InventoryInstanceDtoCollection(instancesBatch1))
+      .thenReturn(new InventoryInstanceDtoCollection(instancesBatch2));
+
+    var instanceIds = List.of(e1.id(), e2.id(), e3.id());
+    var actual = service.getInstanceTitles(instanceIds);
+
+    verify(client)
+      .getInstanceStorageInstances(String.format("id==(%s or %s)", e1.id(), e2.id()), instancesBatch1.size());
+    verify(client)
+      .getInstanceStorageInstances(String.format("id==(%s)", e3.id()), instancesBatch2.size());
+    assertThat(actual)
+      .hasSize(instanceIds.size())
+      .contains(entry(e1.id(), e1.title()), entry(e2.id(), e2.title()), entry(e3.id(), e3.title()));
+  }
+
+  @Test
+  void getInstanceTitles_negative_clientException() {
+    var cause = new IllegalArgumentException("test message");
+    when(client.getInstanceStorageInstances(anyString(), anyInt())).thenThrow(cause);
+
+    var instanceIds = singletonList(UUID.randomUUID().toString());
+    assertThatThrownBy(() -> service.getInstanceTitles(instanceIds))
+      .isInstanceOf(FolioIntegrationException.class)
+      .hasCauseExactlyInstanceOf(cause.getClass())
+      .hasMessage("Failed to fetch instances");
+
+  }
+}

--- a/src/test/java/org/folio/entlinks/service/links/InstanceAuthorityLinkingServiceTest.java
+++ b/src/test/java/org/folio/entlinks/service/links/InstanceAuthorityLinkingServiceTest.java
@@ -21,7 +21,7 @@ import java.util.List;
 import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Collectors;
-import org.folio.entlinks.domain.dto.LinkedBibUpdateStatus;
+import org.folio.entlinks.domain.dto.LinkStatus;
 import org.folio.entlinks.domain.entity.AuthorityData;
 import org.folio.entlinks.domain.entity.InstanceAuthorityLink;
 import org.folio.entlinks.domain.entity.projection.LinkCountView;
@@ -331,7 +331,7 @@ class InstanceAuthorityLinkingServiceTest {
   @Test
   @SuppressWarnings("unchecked")
   void getLinks_positive() {
-    var status = LinkedBibUpdateStatus.ACTUAL;
+    var status = LinkStatus.ACTUAL;
     var fromDate = OffsetDateTime.now();
     var toDate = fromDate.plus(1, ChronoUnit.DAYS);
     var limit = 1;

--- a/src/test/java/org/folio/entlinks/service/links/InstanceAuthorityLinkingServiceTest.java
+++ b/src/test/java/org/folio/entlinks/service/links/InstanceAuthorityLinkingServiceTest.java
@@ -1,22 +1,27 @@
 package org.folio.entlinks.service.links;
 
 import static java.util.Collections.emptyList;
+import static java.util.Collections.singletonList;
 import static java.util.UUID.randomUUID;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.entry;
 import static org.folio.support.TestUtils.links;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anySet;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import java.time.OffsetDateTime;
+import java.time.temporal.ChronoUnit;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Collectors;
+import org.folio.entlinks.domain.dto.LinkedBibUpdateStatus;
 import org.folio.entlinks.domain.entity.AuthorityData;
 import org.folio.entlinks.domain.entity.InstanceAuthorityLink;
 import org.folio.entlinks.domain.entity.projection.LinkCountView;
@@ -30,7 +35,10 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.jpa.domain.Specification;
 
 @UnitTest
 @ExtendWith(MockitoExtension.class)
@@ -318,6 +326,27 @@ class InstanceAuthorityLinkingServiceTest {
     service.saveAll(instanceId, links);
 
     verify(instanceLinkRepository).saveAll(links);
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  void getLinks_positive() {
+    var status = LinkedBibUpdateStatus.ACTUAL;
+    var fromDate = OffsetDateTime.now();
+    var toDate = fromDate.plus(1, ChronoUnit.DAYS);
+    var limit = 1;
+    var pageable = PageRequest.of(0, limit, Sort.by(Sort.Order.desc("updatedAt")));
+    var expectedLinks = singletonList(InstanceAuthorityLink.builder()
+      .id(1L)
+      .build());
+
+    when(instanceLinkRepository.findAll(any(Specification.class), eq(pageable)))
+      .thenReturn(new PageImpl<>(expectedLinks, pageable, 0));
+
+    var links = service.getLinks(status, fromDate, toDate, limit);
+
+    assertThat(links)
+      .isEqualTo(expectedLinks);
   }
 
   @SuppressWarnings("unchecked")

--- a/src/test/java/org/folio/support/base/IntegrationTestBase.java
+++ b/src/test/java/org/folio/support/base/IntegrationTestBase.java
@@ -45,6 +45,7 @@ import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.test.web.servlet.ResultMatcher;
+import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
 
 @EnableKafka
 @EnableOkapi
@@ -94,6 +95,14 @@ public class IntegrationTestBase {
 
   protected static WireMockServer getWireMock() {
     return okapi.wireMockServer();
+  }
+
+  //use if params contain special characters that should be encoded
+  @SneakyThrows
+  protected static ResultActions perform(MockHttpServletRequestBuilder rb) {
+    return mockMvc.perform(rb
+        .headers(defaultHeaders()).accept(APPLICATION_JSON))
+      .andDo(log());
   }
 
   @SneakyThrows

--- a/src/test/java/org/folio/support/base/TestConstants.java
+++ b/src/test/java/org/folio/support/base/TestConstants.java
@@ -15,6 +15,7 @@ public class TestConstants {
 
   private static final String INSTANCE_LINKS_ENDPOINT_PATH = "/links/instances/{id}";
   private static final String AUTHORITY_LINKS_COUNT_ENDPOINT_PATH = "/links/authorities/bulk/count";
+  private static final String LINKS_STATS_INSTANCE_ENDPOINT_PATH = "/links/stats/instance";
 
   public static String inventoryAuthorityTopic() {
     return String.format("%s.%s.%s", getFolioEnvName(), TENANT_ID, AUTHORITY_TOPIC);
@@ -30,5 +31,9 @@ public class TestConstants {
 
   public static String authoritiesLinksCountEndpoint() {
     return AUTHORITY_LINKS_COUNT_ENDPOINT_PATH;
+  }
+
+  public static String linksStatsInstanceEndpoint() {
+    return LINKS_STATS_INSTANCE_ENDPOINT_PATH;
   }
 }

--- a/src/test/resources/mappings/instance-storage.json
+++ b/src/test/resources/mappings/instance-storage.json
@@ -1,0 +1,17 @@
+{
+  "mappings": [
+    {
+      "request": {
+        "method": "GET",
+        "urlPath": "/instance-storage/instances"
+      },
+      "response": {
+        "status": 200,
+        "body": "{\"instances\":[{\"id\":\"fea1c418-ba1f-438e-85bb-c6ae1011bf5c\",\"title\":\"title1\"},{\"id\":\"e083463e-96d4-4fa0-8ee1-13bfd4f674cf\",\"title\":\"title2\"},{\"id\":\"68de093d-8c0d-44c2-b3a8-79393f6cb195\",\"title\":\"title3\"}]}",
+        "headers": {
+          "Content-Type": "application/json"
+        }
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Purpose
Needs to support reporting that allows catalogers to know about updates on linked Bibliographic fields and Authorities over a period of time. The module will consume statistics of instance-authority links updates and provide an endpoint for fetching this data.

## Approach
- Add Client for instance-storage
- Create GET /links/stats/instance endpoint
- Update ModuleDescriptor-template.json
- Update documentation.md

### Changes checklist
- [x] API paths, methods, request or response bodies changed, added, or removed
- [ ] Database schema changes
- [ ] Interface versions changes
- [x] Interface dependencies added, or removed
- [x] Permissions changed, added, or removed
- [x] Check logging.

### Learning
[MODELINKS-35](https://issues.folio.org/browse/MODELINKS-35)
