### PR TITLE
MODELINKS-64: Metadata generation is provided when startedByUser is deleted

### DIFF
--- a/src/main/java/org/folio/entlinks/controller/delegate/InstanceAuthorityStatServiceDelegate.java
+++ b/src/main/java/org/folio/entlinks/controller/delegate/InstanceAuthorityStatServiceDelegate.java
@@ -77,24 +77,25 @@ public class InstanceAuthorityStatServiceDelegate {
   }
 
   private Metadata getMetadata(ResultList<UsersClient.User> userResultList, AuthorityDataStat source) {
-    if (userResultList == null) {
-      return null;
+    UUID startedByUserId = source.getStartedByUserId();
+    Metadata metadata = new Metadata();
+    metadata.setStartedByUserId(startedByUserId);
+    metadata.setStartedAt(DateUtils.fromTimestamp(source.getStartedAt()));
+    metadata.setCompletedAt(DateUtils.fromTimestamp(source.getCompletedAt()));
+    if (userResultList == null || userResultList.getResult() == null) {
+      return metadata;
     }
 
     var user = userResultList.getResult()
       .stream()
-      .filter(u -> UUID.fromString(u.id()).equals(source.getStartedByUserId()))
+      .filter(u -> UUID.fromString(u.id()).equals(startedByUserId))
       .findFirst().orElse(null);
     if (user == null) {
-      return null;
+      return metadata;
     }
 
-    Metadata metadata = new Metadata();
     metadata.setStartedByUserFirstName(user.personal().firstName());
     metadata.setStartedByUserLastName(user.personal().lastName());
-    metadata.setStartedByUserId(UUID.fromString(user.id()));
-    metadata.setStartedAt(DateUtils.fromTimestamp(source.getStartedAt()));
-    metadata.setCompletedAt(DateUtils.fromTimestamp(source.getCompletedAt()));
     return metadata;
   }
 

--- a/src/test/java/org/folio/entlinks/controller/delegate/InstanceAuthorityStatServiceDelegateTest.java
+++ b/src/test/java/org/folio/entlinks/controller/delegate/InstanceAuthorityStatServiceDelegateTest.java
@@ -26,6 +26,7 @@ import org.folio.entlinks.integration.internal.AuthoritySourceFilesService;
 import org.folio.entlinks.service.links.AuthorityDataStatService;
 import org.folio.spring.test.type.UnitTest;
 import org.folio.spring.tools.client.UsersClient;
+import org.folio.spring.tools.model.ResultList;
 import org.folio.support.TestDataUtils;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -123,6 +124,47 @@ class InstanceAuthorityStatServiceDelegateTest {
       .toList();
     assertNull(authorityChangeStatDtoCollection.getNext());
     assertThat(List.of(USER_ID_1, USER_ID_2)).containsAll(resultUserIds);
+  }
+
+  @Test
+  void fetchStats_whenUpdatedUserIsNull() {
+    //  GIVEN
+    AuthoritySourceFile sourceFile = new AuthoritySourceFile(SOURCE_FILE_ID, BASE_URL, SOURCE_FILE_NAME);
+    Map<UUID, AuthoritySourceFile> expectedMap = new HashMap<>();
+    expectedMap.put(sourceFile.id(), sourceFile);
+
+    //  WHEN
+    when(sourceFilesService.fetchAuthoritySources()).thenReturn(expectedMap);
+    when(usersClient.query(anyString())).thenReturn(ResultList.of(0, null));
+    var authorityChangeStatDtoCollection = delegate
+      .fetchAuthorityLinksStats(FROM_DATE, TO_DATE, DATA_STAT_ACTION_DTO, LIMIT_SIZE);
+
+    //  THEN
+    assertNotNull(authorityChangeStatDtoCollection);
+    assertNotNull(authorityChangeStatDtoCollection.getStats());
+    assertEquals(LIMIT_SIZE, authorityChangeStatDtoCollection.getStats().size());
+    var resultStatDtos = authorityChangeStatDtoCollection.getStats();
+    for (AuthorityDataStatDto statDto : resultStatDtos) {
+      assertNotNull(statDto.getAction());
+      assertNotNull(statDto.getAuthorityId());
+      assertNotNull(statDto.getHeadingNew());
+      assertNotNull(statDto.getHeadingOld());
+      assertNotNull(statDto.getHeadingTypeNew());
+      assertNotNull(statDto.getHeadingTypeOld());
+      assertNotNull(statDto.getLbFailed());
+      assertNotNull(statDto.getLbTotal());
+      assertNotNull(statDto.getLbUpdated());
+      assertNotNull(statDto.getMetadata());
+      assertNotNull(statDto.getMetadata().getStartedByUserId());
+      assertNull(statDto.getMetadata().getStartedByUserFirstName());
+      assertNull(statDto.getMetadata().getStartedByUserLastName());
+      assertNotNull(statDto.getMetadata().getStartedAt());
+      assertNotNull(statDto.getMetadata().getCompletedAt());
+      assertNotNull(statDto.getNaturalIdNew());
+      assertNotNull(statDto.getNaturalIdOld());
+      assertNotNull(sourceFile.name());
+      assertNotNull(statDto.getSourceFileOld());
+    }
   }
 
   @Test


### PR DESCRIPTION
## Purpose
Make "Last Updated" field available for MARC update-headings report CSV file

## Approach
Provided metadata creation even when user does not exist

### Changes checklist
- [ ] API paths, methods, request or response bodies changed, added, or removed
- [ ] Database schema changes
- [ ] Interface versions changes
- [ ] Interface dependencies added, or removed
- [ ] Permissions changed, added, or removed
- [ ] Check logging.

### Learning
[https://issues.folio.org/browse/MODELINKS-64](https://issues.folio.org/browse/MODELINKS-64)
