### PR TITLE
MODELINKS-69 "Not specified" is displayed instead of valid "Authority source file name" in the "Updates headings" report

### DIFF
--- a/src/main/java/org/folio/entlinks/client/AuthoritySourceFileClient.java
+++ b/src/main/java/org/folio/entlinks/client/AuthoritySourceFileClient.java
@@ -12,7 +12,7 @@ public interface AuthoritySourceFileClient {
 
 
   @GetMapping(produces = APPLICATION_JSON_VALUE)
-  AuthoritySourceFiles fetchAuthoritySourceFiles();
+  AuthoritySourceFiles fetchAuthoritySourceFiles(int limit);
 
   record AuthoritySourceFile(UUID id, String baseUrl, String name) { }
 

--- a/src/main/java/org/folio/entlinks/client/AuthoritySourceFileClient.java
+++ b/src/main/java/org/folio/entlinks/client/AuthoritySourceFileClient.java
@@ -6,13 +6,14 @@ import java.util.List;
 import java.util.UUID;
 import org.springframework.cloud.openfeign.FeignClient;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 
 @FeignClient("authority-source-files")
 public interface AuthoritySourceFileClient {
 
 
   @GetMapping(produces = APPLICATION_JSON_VALUE)
-  AuthoritySourceFiles fetchAuthoritySourceFiles(int limit);
+  AuthoritySourceFiles fetchAuthoritySourceFiles(@RequestParam int limit);
 
   record AuthoritySourceFile(UUID id, String baseUrl, String name) { }
 

--- a/src/main/java/org/folio/entlinks/integration/internal/AuthoritySourceFilesService.java
+++ b/src/main/java/org/folio/entlinks/integration/internal/AuthoritySourceFilesService.java
@@ -19,7 +19,7 @@ import org.springframework.stereotype.Service;
 @Service
 @RequiredArgsConstructor
 public class AuthoritySourceFilesService {
-
+  private static final int SOURCE_FILES_LIMIT = 100;
   private final AuthoritySourceFileClient client;
 
   @Cacheable(cacheNames = AUTHORITY_SOURCE_FILES_CACHE,
@@ -39,7 +39,9 @@ public class AuthoritySourceFilesService {
 
   private List<AuthoritySourceFile> fetchAuthoritySourceFiles() {
     try {
-      return client.fetchAuthoritySourceFiles().authoritySourceFiles();
+      return client
+        .fetchAuthoritySourceFiles(SOURCE_FILES_LIMIT)
+        .authoritySourceFiles();
     } catch (Exception e) {
       throw new FolioIntegrationException("Failed to fetch authority source files", e);
     }

--- a/src/test/java/org/folio/entlinks/integration/internal/AuthoritySourceFilesServiceTest.java
+++ b/src/test/java/org/folio/entlinks/integration/internal/AuthoritySourceFilesServiceTest.java
@@ -4,6 +4,7 @@ import static java.util.Collections.emptyList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assertions.entry;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
 import java.util.List;
@@ -32,7 +33,7 @@ class AuthoritySourceFilesServiceTest {
     var e2 = new AuthoritySourceFile(UUID.randomUUID(), "url2", "source-file-name-2");
     var sourceFiles = List.of(e1, e2);
 
-    when(client.fetchAuthoritySourceFiles()).thenReturn(new AuthoritySourceFiles(sourceFiles));
+    when(client.fetchAuthoritySourceFiles(any())).thenReturn(new AuthoritySourceFiles(sourceFiles));
 
     var actual = service.fetchAuthoritySources();
 
@@ -50,7 +51,7 @@ class AuthoritySourceFilesServiceTest {
     var validSourceFiles = List.of(e1, e3);
     var sourceFiles = List.of(e1, e2, e3, e4);
 
-    when(client.fetchAuthoritySourceFiles()).thenReturn(new AuthoritySourceFiles(sourceFiles));
+    when(client.fetchAuthoritySourceFiles(any())).thenReturn(new AuthoritySourceFiles(sourceFiles));
 
     var actual = service.fetchAuthoritySources();
 
@@ -61,7 +62,7 @@ class AuthoritySourceFilesServiceTest {
 
   @Test
   void fetchAuthoritySourceUrls_negative_emptyResponse() {
-    when(client.fetchAuthoritySourceFiles()).thenReturn(new AuthoritySourceFiles(emptyList()));
+    when(client.fetchAuthoritySourceFiles(any())).thenReturn(new AuthoritySourceFiles(emptyList()));
 
     assertThatThrownBy(() -> service.fetchAuthoritySources())
       .isInstanceOf(FolioIntegrationException.class)
@@ -71,7 +72,7 @@ class AuthoritySourceFilesServiceTest {
   @Test
   void fetchAuthoritySourceUrls_negative_clientException() {
     var cause = new IllegalArgumentException("test message");
-    when(client.fetchAuthoritySourceFiles()).thenThrow(cause);
+    when(client.fetchAuthoritySourceFiles(any())).thenThrow(cause);
 
     assertThatThrownBy(() -> service.fetchAuthoritySources())
       .isInstanceOf(FolioIntegrationException.class)

--- a/src/test/java/org/folio/entlinks/integration/internal/AuthoritySourceFilesServiceTest.java
+++ b/src/test/java/org/folio/entlinks/integration/internal/AuthoritySourceFilesServiceTest.java
@@ -4,7 +4,7 @@ import static java.util.Collections.emptyList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assertions.entry;
-import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.Mockito.when;
 
 import java.util.List;
@@ -33,7 +33,7 @@ class AuthoritySourceFilesServiceTest {
     var e2 = new AuthoritySourceFile(UUID.randomUUID(), "url2", "source-file-name-2");
     var sourceFiles = List.of(e1, e2);
 
-    when(client.fetchAuthoritySourceFiles(any())).thenReturn(new AuthoritySourceFiles(sourceFiles));
+    when(client.fetchAuthoritySourceFiles(anyInt())).thenReturn(new AuthoritySourceFiles(sourceFiles));
 
     var actual = service.fetchAuthoritySources();
 
@@ -51,7 +51,7 @@ class AuthoritySourceFilesServiceTest {
     var validSourceFiles = List.of(e1, e3);
     var sourceFiles = List.of(e1, e2, e3, e4);
 
-    when(client.fetchAuthoritySourceFiles(any())).thenReturn(new AuthoritySourceFiles(sourceFiles));
+    when(client.fetchAuthoritySourceFiles(anyInt())).thenReturn(new AuthoritySourceFiles(sourceFiles));
 
     var actual = service.fetchAuthoritySources();
 
@@ -62,7 +62,7 @@ class AuthoritySourceFilesServiceTest {
 
   @Test
   void fetchAuthoritySourceUrls_negative_emptyResponse() {
-    when(client.fetchAuthoritySourceFiles(any())).thenReturn(new AuthoritySourceFiles(emptyList()));
+    when(client.fetchAuthoritySourceFiles(anyInt())).thenReturn(new AuthoritySourceFiles(emptyList()));
 
     assertThatThrownBy(() -> service.fetchAuthoritySources())
       .isInstanceOf(FolioIntegrationException.class)
@@ -72,7 +72,7 @@ class AuthoritySourceFilesServiceTest {
   @Test
   void fetchAuthoritySourceUrls_negative_clientException() {
     var cause = new IllegalArgumentException("test message");
-    when(client.fetchAuthoritySourceFiles(any())).thenThrow(cause);
+    when(client.fetchAuthoritySourceFiles(anyInt())).thenThrow(cause);
 
     assertThatThrownBy(() -> service.fetchAuthoritySources())
       .isInstanceOf(FolioIntegrationException.class)

--- a/src/test/resources/mappings/authoritySourceFiles.json
+++ b/src/test/resources/mappings/authoritySourceFiles.json
@@ -3,7 +3,7 @@
     {
       "request": {
         "method": "GET",
-        "url": "/authority-source-files"
+        "url": "/authority-source-files?limit=100"
       },
       "response": {
         "status": 200,


### PR DESCRIPTION
## Purpose
"Not specified" is displayed instead of valid "Authority source file name" in the "Updates headings" report

## Approach
- Add source file limit. Because previously it took only 10 first files 

### Learning
https://issues.folio.org/browse/MODELINKS-69
