### PR TITLE
MODELINKS-77 Change '/links/authority/stats' endpoint path to '/links/stats/authority'

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -113,13 +113,13 @@
     },
     {
       "id": "instance-authority-links-statistics",
-      "version": "1.0",
+      "version": "1.1",
       "handlers": [
         {
           "methods": [
             "GET"
           ],
-          "pathPattern": "/links/authority/stats",
+          "pathPattern": "/links/stats/authority",
           "permissionsRequired": [
             "instance-authority-links.authority-statistics.collection.get"
            ],

--- a/doc/documentation.md
+++ b/doc/documentation.md
@@ -279,7 +279,7 @@ The API enables possibility to retrieve default linking rules.
 
 | METHOD | URL                      | Required permissions                                           | DESCRIPTION                                                     |
 |:-------|:-------------------------|:---------------------------------------------------------------|:----------------------------------------------------------------|
-| GET    | `/links/authority/stats` | `instance-authority-links.authority-statistics.collection.get` | Get Instance to Authority links authority-statistics collection |
+| GET    | `/links/stats/authority` | `instance-authority-links.authority-statistics.collection.get` | Get Instance to Authority links authority-statistics collection |
 
 #### Instance to Authority linking rule parameters
 
@@ -294,7 +294,7 @@ The API enables possibility to retrieve default linking rules.
 
 ##### Retrieve instance to authority links statistics collection:
 
-`GET /links/authority/stats`
+`GET /links/stats/authority`
 
 Response:
 

--- a/src/main/resources/swagger.api/mod-entities-links.yaml
+++ b/src/main/resources/swagger.api/mod-entities-links.yaml
@@ -106,7 +106,7 @@ paths:
         '500':
           $ref: '#/components/responses/serverErrorResponse'
 
-  /links/authority/stats:
+  /links/stats/authority:
     get:
       description: Retrieve authority updates (related to links) statistics
       operationId: getAuthorityLinksStats
@@ -139,6 +139,7 @@ paths:
           description: Max number of items in collection
           schema:
             type: integer
+            minimum: 1
             default: 100
       responses:
         "200":
@@ -187,7 +188,7 @@ paths:
           schema:
             type: integer
             minimum: 1
-            default: 99
+            default: 100
       responses:
         "200":
           description: The linked bib update statistics collection

--- a/src/test/java/org/folio/support/base/TestConstants.java
+++ b/src/test/java/org/folio/support/base/TestConstants.java
@@ -23,7 +23,7 @@ public class TestConstants {
   private static final String AUTHORITY_LINKS_COUNT_ENDPOINT_PATH = "/links/authorities/bulk/count";
   private static final String LINKS_STATS_INSTANCE_ENDPOINT_PATH = "/links/stats/instance";
   private static final String LINKS_STATS_INSTANCE_ENDPOINT_PARAMS = "?status=%s&fromDate=%s&toDate=%s";
-  private static final String AUTH_STATS_ENDPOINT_PATH_PATTERN = "/links/authority/stats";
+  private static final String AUTH_STATS_ENDPOINT_PATH_PATTERN = "/links/stats/authority";
   private static final String AUTH_STATS_ENDPOINT_PARAMS = "?action=%s&fromDate=%s&toDate=%s&limit=%d";
   private static final String LINKING_RULES_ENDPOINT = "/linking-rules/instance-authority";
 


### PR DESCRIPTION
## Approach
`/links/authority/stats` changed to `/links/stats/authority`

### Learning
https://issues.folio.org/browse/MODELINKS-77
