### PR TITLE
MODELINKS-68 Extend GET /links/instances/{id} with link status, errorCause

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,11 +1,12 @@
 ## v2.0.0 In progress
 ### APIs versions
 * Provides `instance-authority-links-statistics v2.0`
-* Provides `instance-authority-links v2.0`
+* Provides `instance-authority-links v2.1`
 * Removes `linked-bib-update-statistics v1.0`
 
 ### Features
 * Remove field and subfields from links endpoint, use linking rule ([MODELINKS-47](https://issues.folio.org/browse/MODELINKS-47))
+* Extend GET /links/instances/{id} with link status, errorCause ([MODELINKS-68](https://issues.folio.org/browse/MODELINKS-68))
 
 ## v1.0.0 Released 2023-02-21
 ### APIs versions

--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -34,7 +34,7 @@
   "provides": [
     {
       "id": "instance-authority-links",
-      "version": "2.0",
+      "version": "2.1",
       "handlers": [
         {
           "methods": [

--- a/doc/documentation.md
+++ b/doc/documentation.md
@@ -165,11 +165,9 @@ Response:
       "authorityId": "0794f296-4094-4243-b9af-bb4bf51cbfae",
       "authorityNaturalId": "n92099941",
       "instanceId": "b2658a84-912b-4ed9-83d7-e8201f4d27ec",
-      "bibRecordTag": "100",
-      "bibRecordSubfields": [
-        "a",
-        "b"
-      ]
+      "linkingRuleId": 1,
+      "status": "ERROR",
+      "errorCause": "Some error"
     }
   ],
   "totalRecords": 1
@@ -189,21 +187,13 @@ Response:
       "authorityId": "875e86cf-599d-4293-b966-b34ac6a6d19e",
       "authorityNaturalId": "no50047988",
       "instanceId": "b2658a84-912b-4ed9-83d7-e8201f4d27ec",
-      "bibRecordTag": "700",
-      "bibRecordSubfields": [
-        "a",
-        "b"
-      ]
+      "linkingRuleId": 2
     },
     {
       "authorityId": "77398964-ee2d-4b28-ba2b-e30851d5d963",
       "authorityNaturalId": "mp96352145",
       "instanceId": "b2658a84-912b-4ed9-83d7-e8201f4d27ec",
-      "bibRecordTag": "710",
-      "bibRecordSubfields": [
-        "a",
-        "b"
-      ]
+      "linkingRuleId": 1
     }
   ]
 }

--- a/src/main/java/org/folio/entlinks/controller/converter/InstanceAuthorityLinkMapper.java
+++ b/src/main/java/org/folio/entlinks/controller/converter/InstanceAuthorityLinkMapper.java
@@ -29,6 +29,8 @@ public interface InstanceAuthorityLinkMapper {
   @Mapping(target = "authorityData.id", source = "authorityId")
   @Mapping(target = "authorityData.naturalId", source = "authorityNaturalId")
   @Mapping(target = "linkingRule.id", source = "linkingRuleId")
+  @Mapping(target = "status", ignore = true)
+  @Mapping(target = "errorCause", ignore = true)
   InstanceAuthorityLink convertDto(InstanceLinkDto source);
 
   List<InstanceAuthorityLink> convertDto(List<InstanceLinkDto> source);

--- a/src/main/resources/swagger.api/mod-entities-links.yaml
+++ b/src/main/resources/swagger.api/mod-entities-links.yaml
@@ -239,6 +239,12 @@ components:
         linkingRuleId:
           type: integer
           description: ID of linking rule by which link should be created
+        status:
+          type: string
+          description: Status of the link. Read-only
+        errorCause:
+          type: string
+          description: Link update error cause (if present). Read-only
       required:
         - authorityId
         - authorityNaturalId

--- a/src/test/java/org/folio/support/MatchUtils.java
+++ b/src/test/java/org/folio/support/MatchUtils.java
@@ -1,0 +1,65 @@
+package org.folio.support;
+
+import static org.hamcrest.Matchers.contains;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+
+import java.time.OffsetDateTime;
+import java.util.Collection;
+import java.util.LinkedHashMap;
+import java.util.Objects;
+import lombok.experimental.UtilityClass;
+import org.folio.entlinks.domain.dto.BibStatsDto;
+import org.folio.entlinks.domain.dto.BibStatsDtoCollection;
+import org.hamcrest.BaseMatcher;
+import org.hamcrest.Description;
+import org.hamcrest.Matcher;
+import org.springframework.test.web.servlet.ResultMatcher;
+
+@UtilityClass
+public class MatchUtils {
+
+  public static ResultMatcher statsMatch(Matcher<Collection<? extends BibStatsDto>> matcher) {
+    return jsonPath("$.stats", matcher);
+  }
+
+  @SuppressWarnings("unchecked")
+  public static ResultMatcher statsMatch(BibStatsDtoCollection stats) {
+    var statsMatchers = stats.getStats().stream()
+      .map(MatchUtils.StatsMatcher::statsMatch)
+      .toArray(Matcher[]::new);
+    return jsonPath("$.stats", contains(statsMatchers));
+  }
+
+  private static final class StatsMatcher extends BaseMatcher<BibStatsDto> {
+
+    private final BibStatsDto expectedStats;
+
+    private StatsMatcher(BibStatsDto expectedStats) {
+      this.expectedStats = expectedStats;
+    }
+
+    static MatchUtils.StatsMatcher statsMatch(BibStatsDto expectedStats) {
+      return new MatchUtils.StatsMatcher(expectedStats);
+    }
+
+    @Override
+    @SuppressWarnings("rawtypes")
+    public boolean matches(Object actual) {
+      if (actual instanceof LinkedHashMap actualStats) {
+        return Objects.equals(expectedStats.getInstanceId().toString(), actualStats.get("instanceId"))
+          && Objects.equals(expectedStats.getAuthorityNaturalId(), actualStats.get("authorityNaturalId"))
+          && Objects.equals(expectedStats.getBibRecordTag(), actualStats.get("bibRecordTag"))
+          && Objects.equals(expectedStats.getInstanceTitle(), actualStats.get("instanceTitle"))
+          && expectedStats.getUpdatedAt().isAfter(OffsetDateTime.parse((String) actualStats.get("updatedAt")))
+          && Objects.equals(expectedStats.getErrorCause(), actualStats.get("errorCause"));
+      }
+
+      return false;
+    }
+
+    @Override
+    public void describeTo(Description description) {
+      description.appendValue(expectedStats);
+    }
+  }
+}

--- a/src/test/java/org/folio/support/TestDataUtils.java
+++ b/src/test/java/org/folio/support/TestDataUtils.java
@@ -2,6 +2,7 @@ package org.folio.support;
 
 import static java.util.UUID.randomUUID;
 import static org.apache.commons.lang3.StringUtils.EMPTY;
+import static org.folio.entlinks.domain.entity.InstanceAuthorityLinkStatus.ACTUAL;
 import static org.folio.entlinks.utils.DateUtils.fromTimestamp;
 import static org.folio.support.base.TestConstants.TENANT_ID;
 
@@ -34,6 +35,7 @@ import org.folio.entlinks.domain.entity.AuthorityDataStat;
 import org.folio.entlinks.domain.entity.AuthorityDataStatAction;
 import org.folio.entlinks.domain.entity.AuthorityDataStatStatus;
 import org.folio.entlinks.domain.entity.InstanceAuthorityLink;
+import org.folio.entlinks.domain.entity.InstanceAuthorityLinkStatus;
 import org.folio.entlinks.domain.entity.InstanceAuthorityLinkingRule;
 import org.folio.spring.tools.client.UsersClient;
 import org.folio.spring.tools.model.ResultList;
@@ -221,7 +223,8 @@ public class TestDataUtils {
   }
 
   public record Link(UUID authorityId, String tag, String naturalId,
-                     char[] subfields, int linkingRuleId) {
+                     char[] subfields, int linkingRuleId,
+                     InstanceAuthorityLinkStatus status, String errorCause) {
 
     public static final UUID[] AUTH_IDS = new UUID[] {randomUUID(), randomUUID(), randomUUID(), randomUUID()};
     public static final String[] TAGS = new String[] {"100", "240", "700", "710"};
@@ -245,7 +248,7 @@ public class TestDataUtils {
     }
 
     public Link(UUID authorityId, String tag, String naturalId, char[] subfields) {
-      this(authorityId, tag, naturalId, subfields, RandomUtils.nextInt(1, 10));
+      this(authorityId, tag, naturalId, subfields, RandomUtils.nextInt(1, 10), ACTUAL, null);
     }
 
     public static Link of(int authIdNum, int tagNum) {
@@ -257,12 +260,19 @@ public class TestDataUtils {
       return new Link(AUTH_IDS[authIdNum], tag, naturalId, TAGS_TO_SUBFIELDS.get(tag).toCharArray());
     }
 
+    public static Link of(InstanceAuthorityLinkStatus status, String errorCause) {
+      return new Link(AUTH_IDS[0], TAGS[0], AUTH_IDS[0].toString(), TAGS_TO_SUBFIELDS.get(TAGS[0]).toCharArray(),
+        1, status, errorCause);
+    }
+
     public InstanceLinkDto toDto(UUID instanceId) {
       return new InstanceLinkDto()
         .instanceId(instanceId)
         .authorityId(authorityId)
         .authorityNaturalId(naturalId)
-        .linkingRuleId(TAGS_TO_RULE_IDS.get(tag));
+        .linkingRuleId(TAGS_TO_RULE_IDS.get(tag))
+        .status(status.toString())
+        .errorCause(errorCause);
     }
 
     public InstanceAuthorityLink toEntity(UUID instanceId) {
@@ -276,6 +286,8 @@ public class TestDataUtils {
           .id((long) TAGS_TO_RULE_IDS.get(tag))
           .bibField(tag)
           .build())
+        .status(status)
+        .errorCause(errorCause)
         .build();
     }
   }


### PR DESCRIPTION
## Purpose
Extend GET /links/instances/{id} with link status, errorCause

## Approach
- Extend the response of the GET endpoint to have `status` and `errorCause` fields
- Ignore newly added parameters on PUT endpoint

### Changes checklist
- [ ] API paths, methods, request or response bodies changed, added, or removed
- [ ] Database schema changes
- [ ] Interface versions changes
- [ ] Interface dependencies added, or removed
- [ ] Permissions changed, added, or removed
- [ ] Check logging.

### Learning
[MODELINKS-68](https://issues.folio.org/browse/MODELINKS-68)
