### PR TITLE
MODELINKS-83: Fixed stable unit test by time delay.

### DIFF
--- a/src/test/java/org/folio/entlinks/controller/InstanceAuthorityLinkStatisticsIT.java
+++ b/src/test/java/org/folio/entlinks/controller/InstanceAuthorityLinkStatisticsIT.java
@@ -56,8 +56,8 @@ import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilde
 
 @IntegrationTest
 @DatabaseCleanup(tables = {DatabaseHelper.AUTHORITY_DATA_STAT_TABLE,
-  DatabaseHelper.INSTANCE_AUTHORITY_LINK_TABLE,
-  DatabaseHelper.AUTHORITY_DATA_TABLE})
+                           DatabaseHelper.INSTANCE_AUTHORITY_LINK_TABLE,
+                           DatabaseHelper.AUTHORITY_DATA_TABLE})
 class InstanceAuthorityLinkStatisticsIT extends IntegrationTestBase {
 
   private static final UUID SOURCE_FILE_ID = UUID.randomUUID();
@@ -231,7 +231,7 @@ class InstanceAuthorityLinkStatisticsIT extends IntegrationTestBase {
 
     OffsetDateTime now = OffsetDateTime.now();
     String millisStr = String.valueOf(now.getNano()).substring(0, 3);
-    long duration = (1000 - Integer.parseInt(millisStr));
+    long duration = 1000 - Integer.parseInt(millisStr);
     ThreadUtils.sleep(Duration.ofMillis(duration));
 
     final var fromDate = OffsetDateTime.now();


### PR DESCRIPTION
## Purpose
_Unstable test: InstanceAuthorityLinkStatisticsIT.getLinkedBibUpdateStats_positive_withSkippedAndNext_

## Approach
_Added time delay to fit the millis at the start of the second. Checked by 100 tries and passed success_
<img width="613" alt="image" src="https://user-images.githubusercontent.com/42607045/236146177-809721d0-26e1-491d-9a13-6c61a6eb8b0b.png">

### Changes checklist
- [ ] API paths, methods, request or response bodies changed, added, or removed
- [ ] Database schema changes
- [ ] Interface versions changes
- [ ] Interface dependencies added, or removed
- [ ] Permissions changed, added, or removed
- [ ] Check logging.