### PR TITLE
MODELINKS-94 Suggest links for MARC-bibliographic record. Bug fixes

### DIFF
--- a/src/main/java/org/folio/entlinks/controller/converter/SourceContentMapper.java
+++ b/src/main/java/org/folio/entlinks/controller/converter/SourceContentMapper.java
@@ -40,7 +40,6 @@ public interface SourceContentMapper {
 
   default SourceParsedContent convertToParsedContent(ParsedRecordContent content) {
     var fields = convertFieldsToOneMap(content.getFields());
-
     return new SourceParsedContent(UUID.randomUUID(), content.getLeader(), fields);
   }
 
@@ -62,26 +61,26 @@ public interface SourceContentMapper {
   }
 
   private List<Map<String, FieldContent>> convertFieldsToListOfMaps(Map<String, FieldParsedContent> fields) {
-    return fields.entrySet().stream()
+    return fields.entrySet().parallelStream()
       .map(this::convertFieldParsedContent)
       .toList();
   }
 
   private Map<String, FieldParsedContent> convertFieldsToOneMap(List<Map<String, FieldContent>> fields) {
-    return fields.stream()
+    return fields.parallelStream()
       .flatMap(m -> m.entrySet().stream())
       .map(this::convertFieldContent)
       .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
   }
 
   private List<Map<String, String>> convertSubfieldsToListOfMaps(Map<String, String> subfields) {
-    return subfields.entrySet().stream()
+    return subfields.entrySet().parallelStream()
       .map(m -> Map.of(m.getKey(), m.getValue()))
       .toList();
   }
 
   private Map<String, String> convertSubfieldsToOneMap(List<Map<String, String>> subfields) {
-    return subfields.stream()
+    return subfields.parallelStream()
       .flatMap(m -> m.entrySet().stream())
       .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
   }

--- a/src/main/java/org/folio/entlinks/controller/converter/SourceContentMapper.java
+++ b/src/main/java/org/folio/entlinks/controller/converter/SourceContentMapper.java
@@ -1,5 +1,8 @@
 package org.folio.entlinks.controller.converter;
 
+import static java.util.stream.Collectors.groupingBy;
+import static java.util.stream.Collectors.mapping;
+
 import java.util.AbstractMap;
 import java.util.List;
 import java.util.Map;
@@ -60,29 +63,33 @@ public interface SourceContentMapper {
     return new AuthorityParsedContent(authorityId, naturalId, leader, fields);
   }
 
-  private List<Map<String, FieldContent>> convertFieldsToListOfMaps(Map<String, FieldParsedContent> fields) {
+  private List<Map<String, FieldContent>> convertFieldsToListOfMaps(Map<String, List<FieldParsedContent>> fields) {
     return fields.entrySet().parallelStream()
-      .map(this::convertFieldParsedContent)
+      .map(this::convertParsedContent)
+      .flatMap(List::stream)
       .toList();
   }
 
-  private Map<String, FieldParsedContent> convertFieldsToOneMap(List<Map<String, FieldContent>> fields) {
+  private Map<String, List<FieldParsedContent>> convertFieldsToOneMap(List<Map<String, FieldContent>> fields) {
     return fields.parallelStream()
-      .flatMap(m -> m.entrySet().stream())
+      .flatMap(map -> map.entrySet().stream())
       .map(this::convertFieldContent)
-      .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+      .collect(groupingBy(Map.Entry::getKey, mapping(Map.Entry::getValue, Collectors.toList())));
   }
 
-  private List<Map<String, String>> convertSubfieldsToListOfMaps(Map<String, String> subfields) {
+  private List<Map<String, String>> convertSubfieldsToListOfMaps(Map<String, List<String>> subfields) {
     return subfields.entrySet().parallelStream()
-      .map(m -> Map.of(m.getKey(), m.getValue()))
+      .map(subfieldsByTag -> subfieldsByTag.getValue().stream()
+        .map(subfieldValue -> Map.of(subfieldsByTag.getKey(), subfieldValue))
+        .toList())
+      .flatMap(List::stream)
       .toList();
   }
 
-  private Map<String, String> convertSubfieldsToOneMap(List<Map<String, String>> subfields) {
+  private Map<String, List<String>> convertSubfieldsToOneMap(List<Map<String, String>> subfields) {
     return subfields.parallelStream()
-      .flatMap(m -> m.entrySet().stream())
-      .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+      .flatMap(map -> map.entrySet().stream())
+      .collect(groupingBy(Map.Entry::getKey, mapping(Map.Entry::getValue, Collectors.toList())));
   }
 
   private Map.Entry<String, FieldParsedContent> convertFieldContent(Map.Entry<String, FieldContent> fieldContent) {
@@ -96,18 +103,19 @@ public interface SourceContentMapper {
     return new AbstractMap.SimpleEntry<>(fieldContent.getKey(), fieldParsedContent);
   }
 
-  private Map<String, FieldContent> convertFieldParsedContent(Map.Entry<String, FieldParsedContent> fieldContent) {
-    var ind1 = fieldContent.getValue().getInd1();
-    var ind2 = fieldContent.getValue().getInd2();
-    var linkDetails = fieldContent.getValue().getLinkDetails();
-    var subfields = convertSubfieldsToListOfMaps(fieldContent.getValue().getSubfields());
+  private List<Map<String, FieldContent>> convertParsedContent(Map.Entry<String, List<FieldParsedContent>> fields) {
+    return fields.getValue().stream().map(field -> {
+      var ind1 = field.getInd1();
+      var ind2 = field.getInd2();
+      var linkDetails = field.getLinkDetails();
+      var subfields = convertSubfieldsToListOfMaps(field.getSubfields());
 
-    var fieldParsedContent = new FieldContent()
-      .ind1(ind1).ind2(ind2)
-      .linkDetails(linkDetails)
-      .subfields(subfields);
+      var fieldContent = new FieldContent().ind1(ind1).ind2(ind2)
+        .linkDetails(linkDetails)
+        .subfields(subfields);
 
-    return Map.of(fieldContent.getKey(), fieldParsedContent);
+      return Map.of(fields.getKey(), fieldContent);
+    }).toList();
   }
 
   private String extractNaturalId(List<AuthorityData> authorityData, UUID authorityId) {

--- a/src/main/java/org/folio/entlinks/controller/delegate/LinksSuggestionsServiceDelegate.java
+++ b/src/main/java/org/folio/entlinks/controller/delegate/LinksSuggestionsServiceDelegate.java
@@ -111,7 +111,7 @@ public class LinksSuggestionsServiceDelegate {
       }
       return value0;
     } else if (nonNull(fieldContent.getLinkDetails())) {
-      return fieldContent.getLinkDetails().getNaturalId();
+      return fieldContent.getLinkDetails().getAuthorityNaturalId();
     }
     return null;
   }

--- a/src/main/java/org/folio/entlinks/integration/dto/AuthorityParsedContent.java
+++ b/src/main/java/org/folio/entlinks/integration/dto/AuthorityParsedContent.java
@@ -1,5 +1,6 @@
 package org.folio.entlinks.integration.dto;
 
+import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import lombok.Getter;
@@ -8,7 +9,8 @@ import lombok.Getter;
 public class AuthorityParsedContent extends SourceParsedContent {
   private final String naturalId;
 
-  public AuthorityParsedContent(UUID id, String naturalId, String leader, Map<String, FieldParsedContent> fields) {
+  public AuthorityParsedContent(UUID id, String naturalId, String leader,
+                                Map<String, List<FieldParsedContent>> fields) {
     super(id, leader, fields);
     this.naturalId = naturalId;
   }

--- a/src/main/java/org/folio/entlinks/integration/dto/FieldParsedContent.java
+++ b/src/main/java/org/folio/entlinks/integration/dto/FieldParsedContent.java
@@ -1,5 +1,6 @@
 package org.folio.entlinks.integration.dto;
 
+import java.util.List;
 import java.util.Map;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -12,6 +13,6 @@ import org.folio.entlinks.domain.dto.LinkDetails;
 public class FieldParsedContent {
   private String ind1;
   private String ind2;
-  private Map<String, String> subfields;
+  private Map<String, List<String>> subfields;
   private LinkDetails linkDetails;
 }

--- a/src/main/java/org/folio/entlinks/integration/dto/SourceParsedContent.java
+++ b/src/main/java/org/folio/entlinks/integration/dto/SourceParsedContent.java
@@ -1,5 +1,6 @@
 package org.folio.entlinks.integration.dto;
 
+import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import lombok.AllArgsConstructor;
@@ -10,5 +11,5 @@ import lombok.Getter;
 public class SourceParsedContent {
   private final UUID id;
   private final String leader;
-  private final Map<String, FieldParsedContent> fields;
+  private final Map<String, List<FieldParsedContent>> fields;
 }

--- a/src/main/java/org/folio/entlinks/service/links/LinksSuggestionService.java
+++ b/src/main/java/org/folio/entlinks/service/links/LinksSuggestionService.java
@@ -114,7 +114,7 @@ public class LinksSuggestionService {
     bibSubfields.put("9", List.of(authority.getId().toString()));
 
     var modifications = rule.getSubfieldModifications();
-    if (nonNull(modifications)) {
+    if (isNotEmpty(modifications)) {
       modifications.forEach(modification -> {
         var modifiedSubfield = bibSubfields.remove(modification.getSource());
         bibSubfields.put(modification.getTarget(), modifiedSubfield);

--- a/src/main/java/org/folio/entlinks/service/links/LinksSuggestionService.java
+++ b/src/main/java/org/folio/entlinks/service/links/LinksSuggestionService.java
@@ -75,6 +75,7 @@ public class LinksSuggestionService {
             actualizeBibSubfields(bibField, authority, rule);
             bibField.setLinkDetails(linkDetails);
           });
+          break;
         }
       }
     }
@@ -85,7 +86,7 @@ public class LinksSuggestionService {
                                      InstanceAuthorityLinkingRule rule) {
     var linkDetails = bibField.getLinkDetails();
 
-    if (nonNull(linkDetails)) {
+    if (nonNull(linkDetails) && linkDetails.getStatus() == ACTUAL) {
       linkDetails.setStatus(ACTUAL);
     } else {
       linkDetails = new LinkDetails();

--- a/src/main/java/org/folio/entlinks/service/links/LinksSuggestionService.java
+++ b/src/main/java/org/folio/entlinks/service/links/LinksSuggestionService.java
@@ -81,19 +81,19 @@ public class LinksSuggestionService {
     var linkDetails = bibField.getLinkDetails();
 
     if (nonNull(linkDetails)) {
-      linkDetails.setLinksStatus(ACTUAL);
+      linkDetails.setStatus(ACTUAL);
     } else {
       linkDetails = new LinkDetails();
-      linkDetails.setLinksStatus(NEW);
+      linkDetails.setStatus(NEW);
     }
-    linkDetails.setRuleId(rule.getId());
+    linkDetails.setLinkingRuleId(rule.getId());
     linkDetails.setAuthorityId(authority.getId());
-    linkDetails.setNaturalId(authority.getNaturalId());
+    linkDetails.setAuthorityNaturalId(authority.getNaturalId());
     return linkDetails;
   }
 
   private LinkDetails getErrorDetails(String errorCode) {
-    return new LinkDetails().linksStatus(ERROR).errorStatusCode(errorCode);
+    return new LinkDetails().status(ERROR).errorCause(errorCode);
   }
 
   private void actualizeBibSubfields(FieldParsedContent bibField,

--- a/src/main/resources/swagger.api/schemas/authority/control/linkDetails.json
+++ b/src/main/resources/swagger.api/schemas/authority/control/linkDetails.json
@@ -8,19 +8,19 @@
       "type": "string",
       "format": "uuid"
     },
-    "naturalId": {
+    "authorityNaturalId": {
       "description": "Authority Natural ID",
       "type": "string"
     },
-    "linksStatus": {
+    "status": {
       "description": "Link status",
       "$ref": "linkStatus.json"
     },
-    "ruleId": {
+    "linkingRuleId": {
       "description": "Linking rule ID",
       "type": "integer"
     },
-    "errorStatusCode": {
+    "errorCause": {
       "description": "Error status code",
       "type": "string"
     }

--- a/src/test/java/org/folio/entlinks/controller/LinksSuggestionsIT.java
+++ b/src/test/java/org/folio/entlinks/controller/LinksSuggestionsIT.java
@@ -70,7 +70,7 @@ class LinksSuggestionsIT extends IntegrationTestBase {
     var givenSubfields = Map.of("0", "oneAuthority");
     var givenRecord = getRecord("110", null, givenSubfields);
 
-    var expectedLinkDetails = new LinkDetails().linksStatus(ERROR).errorStatusCode(NO_SUGGESTIONS_ERROR_CODE);
+    var expectedLinkDetails = new LinkDetails().status(ERROR).errorCause(NO_SUGGESTIONS_ERROR_CODE);
     var expectedSubfields = Map.of("0", "oneAuthority");
     var expectedRecord = getRecord("110", expectedLinkDetails, expectedSubfields);
 
@@ -87,7 +87,7 @@ class LinksSuggestionsIT extends IntegrationTestBase {
     var givenSubfields = Map.of("0", "twoAuthority");
     var givenRecord = getRecord("100", null, givenSubfields);
 
-    var expectedLinkDetails = new LinkDetails().linksStatus(ERROR).errorStatusCode(MORE_THEN_ONE_SUGGESTION_ERROR_CODE);
+    var expectedLinkDetails = new LinkDetails().status(ERROR).errorCause(MORE_THEN_ONE_SUGGESTION_ERROR_CODE);
     var expectedSubfields = Map.of("0", "twoAuthority");
     var expectedRecord = getRecord("100", expectedLinkDetails, expectedSubfields);
 
@@ -109,9 +109,9 @@ class LinksSuggestionsIT extends IntegrationTestBase {
   }
 
   private LinkDetails getLinkDetails(LinkStatus linkStatus, String naturalId) {
-    return new LinkDetails().ruleId(1)
+    return new LinkDetails().linkingRuleId(1)
       .authorityId(UUID.fromString(LINKABLE_AUTHORITY_ID))
-      .naturalId(naturalId)
-      .linksStatus(linkStatus);
+      .authorityNaturalId(naturalId)
+      .status(linkStatus);
   }
 }

--- a/src/test/java/org/folio/entlinks/controller/delegate/LinksSuggestionsServiceDelegateTest.java
+++ b/src/test/java/org/folio/entlinks/controller/delegate/LinksSuggestionsServiceDelegateTest.java
@@ -190,7 +190,7 @@ class LinksSuggestionsServiceDelegateTest {
   private ParsedRecordContent getRecord(String bibField, Map<String, String> subfields) {
     var field = new FieldContent();
     field.setSubfields(List.of(subfields));
-    field.setLinkDetails(new LinkDetails().naturalId(NATURAL_ID));
+    field.setLinkDetails(new LinkDetails().authorityNaturalId(NATURAL_ID));
 
     var fields = Map.of(bibField, field);
     return new ParsedRecordContent(List.of(fields), "default leader");

--- a/src/test/java/org/folio/entlinks/service/links/LinksSuggestionsServiceTest.java
+++ b/src/test/java/org/folio/entlinks/service/links/LinksSuggestionsServiceTest.java
@@ -56,17 +56,17 @@ class LinksSuggestionsServiceTest {
     linksSuggestionService
       .fillLinkDetailsWithSuggestedAuthorities(List.of(bib), List.of(authority), rules);
 
-    var bibField = bib.getFields().get("100");
+    var bibField = bib.getFields().get("100").get(0);
     var linkDetails = bibField.getLinkDetails();
-    assertEquals(LinkStatus.NEW, linkDetails.getLinksStatus());
+    assertEquals(LinkStatus.NEW, linkDetails.getStatus());
     assertEquals(AUTHORITY_ID, linkDetails.getAuthorityId());
-    assertEquals(NATURAL_ID, linkDetails.getNaturalId());
-    assertEquals(1, linkDetails.getRuleId());
-    assertNull(linkDetails.getErrorStatusCode());
+    assertEquals(NATURAL_ID, linkDetails.getAuthorityNaturalId());
+    assertEquals(1, linkDetails.getLinkingRuleId());
+    assertNull(linkDetails.getErrorCause());
 
     var bibSubfields = bibField.getSubfields();
-    assertEquals(AUTHORITY_ID.toString(), bibSubfields.get("9"));
-    assertEquals(BASE_URL + NATURAL_ID, bibSubfields.get("0"));
+    assertEquals(AUTHORITY_ID.toString(), bibSubfields.get("9").get(0));
+    assertEquals(BASE_URL + NATURAL_ID, bibSubfields.get("0").get(0));
     assertFalse(bibSubfields.containsKey("a"));
     assertTrue(bibSubfields.containsKey("b"));
   }
@@ -83,17 +83,17 @@ class LinksSuggestionsServiceTest {
     linksSuggestionService
       .fillLinkDetailsWithSuggestedAuthorities(List.of(bib), List.of(authority), rules);
 
-    var bibField = bib.getFields().get("100");
+    var bibField = bib.getFields().get("100").get(0);
     var linkDetails = bibField.getLinkDetails();
-    assertEquals(LinkStatus.ACTUAL, linkDetails.getLinksStatus());
+    assertEquals(LinkStatus.ACTUAL, linkDetails.getStatus());
     assertEquals(AUTHORITY_ID, linkDetails.getAuthorityId());
-    assertEquals(NATURAL_ID, linkDetails.getNaturalId());
-    assertEquals(1, linkDetails.getRuleId());
-    assertNull(linkDetails.getErrorStatusCode());
+    assertEquals(NATURAL_ID, linkDetails.getAuthorityNaturalId());
+    assertEquals(1, linkDetails.getLinkingRuleId());
+    assertNull(linkDetails.getErrorCause());
 
     var bibSubfields = bibField.getSubfields();
-    assertEquals(AUTHORITY_ID.toString(), bibSubfields.get("9"));
-    assertEquals(BASE_URL + NATURAL_ID, bibSubfields.get("0"));
+    assertEquals(AUTHORITY_ID.toString(), bibSubfields.get("9").get(0));
+    assertEquals(BASE_URL + NATURAL_ID, bibSubfields.get("0").get(0));
     assertFalse(bibSubfields.containsKey("a"));
     assertTrue(bibSubfields.containsKey("b"));
   }
@@ -107,9 +107,9 @@ class LinksSuggestionsServiceTest {
     linksSuggestionService
       .fillLinkDetailsWithSuggestedAuthorities(List.of(bib), List.of(authority), rules);
 
-    var linkDetails = bib.getFields().get("100").getLinkDetails();
-    assertEquals(LinkStatus.ERROR, linkDetails.getLinksStatus());
-    assertEquals(NO_SUGGESTIONS_ERROR_CODE, linkDetails.getErrorStatusCode());
+    var linkDetails = bib.getFields().get("100").get(0).getLinkDetails();
+    assertEquals(LinkStatus.ERROR, linkDetails.getStatus());
+    assertEquals(NO_SUGGESTIONS_ERROR_CODE, linkDetails.getErrorCause());
   }
 
   @Test
@@ -122,12 +122,12 @@ class LinksSuggestionsServiceTest {
     linksSuggestionService
       .fillLinkDetailsWithSuggestedAuthorities(List.of(bib), List.of(authority, secondAuthority), rules);
 
-    var linkDetails = bib.getFields().get("100").getLinkDetails();
-    assertEquals(LinkStatus.ERROR, linkDetails.getLinksStatus());
-    assertEquals(MORE_THEN_ONE_SUGGESTIONS_ERROR_CODE, linkDetails.getErrorStatusCode());
+    var linkDetails = bib.getFields().get("100").get(0).getLinkDetails();
+    assertEquals(LinkStatus.ERROR, linkDetails.getStatus());
+    assertEquals(MORE_THEN_ONE_SUGGESTIONS_ERROR_CODE, linkDetails.getErrorCause());
     assertNull(linkDetails.getAuthorityId());
-    assertNull(linkDetails.getNaturalId());
-    assertNull(linkDetails.getRuleId());
+    assertNull(linkDetails.getAuthorityNaturalId());
+    assertNull(linkDetails.getLinkingRuleId());
   }
 
   @Test
@@ -139,32 +139,32 @@ class LinksSuggestionsServiceTest {
     linksSuggestionService
       .fillLinkDetailsWithSuggestedAuthorities(List.of(bib), List.of(authority), rules);
 
-    var linkDetails = bib.getFields().get("100").getLinkDetails();
-    assertEquals(LinkStatus.ERROR, linkDetails.getLinksStatus());
-    assertEquals(NO_SUGGESTIONS_ERROR_CODE, linkDetails.getErrorStatusCode());
+    var linkDetails = bib.getFields().get("100").get(0).getLinkDetails();
+    assertEquals(LinkStatus.ERROR, linkDetails.getStatus());
+    assertEquals(NO_SUGGESTIONS_ERROR_CODE, linkDetails.getErrorCause());
   }
 
   private AuthorityParsedContent getAuthorityParsedRecordContent(String authorityField) {
-    return getAuthorityParsedRecordContent(authorityField, Map.of("a", "test"));
+    return getAuthorityParsedRecordContent(authorityField, Map.of("a", List.of("test")));
   }
 
-  private AuthorityParsedContent getAuthorityParsedRecordContent(String authorityField, Map<String, String> subfields) {
+  private AuthorityParsedContent getAuthorityParsedRecordContent(String authorityField, Map<String, List<String>> subfields) {
     var field = new FieldParsedContent("//", "//", subfields, null);
-    var fields = Map.of(authorityField, field);
+    var fields = Map.of(authorityField, List.of(field));
     return new AuthorityParsedContent(AUTHORITY_ID, NATURAL_ID, "", fields);
   }
 
   private SourceParsedContent getBibParsedRecordContent(String bibField, LinkDetails linkDetails) {
     var field = new FieldParsedContent("//", "//", new HashMap<>(), linkDetails);
-    var fields = Map.of(bibField, field);
+    var fields = Map.of(bibField, List.of(field));
     return new SourceParsedContent(UUID.randomUUID(), "", fields);
   }
 
   private LinkDetails getActualLinksDetails() {
-    return new LinkDetails().ruleId(2)
-      .linksStatus(LinkStatus.ACTUAL)
+    return new LinkDetails().linkingRuleId(2)
+      .status(LinkStatus.ACTUAL)
       .authorityId(UUID.randomUUID())
-      .naturalId(NATURAL_ID);
+      .authorityNaturalId(NATURAL_ID);
   }
 
   private Map<String, List<InstanceAuthorityLinkingRule>> getMapRule(String bibField, String authorityField) {

--- a/src/test/java/org/folio/entlinks/service/links/LinksSuggestionsServiceTest.java
+++ b/src/test/java/org/folio/entlinks/service/links/LinksSuggestionsServiceTest.java
@@ -148,7 +148,8 @@ class LinksSuggestionsServiceTest {
     return getAuthorityParsedRecordContent(authorityField, Map.of("a", List.of("test")));
   }
 
-  private AuthorityParsedContent getAuthorityParsedRecordContent(String authorityField, Map<String, List<String>> subfields) {
+  private AuthorityParsedContent getAuthorityParsedRecordContent(String authorityField,
+                                                                 Map<String, List<String>> subfields) {
     var field = new FieldParsedContent("//", "//", subfields, null);
     var fields = Map.of(authorityField, List.of(field));
     return new AuthorityParsedContent(AUTHORITY_ID, NATURAL_ID, "", fields);


### PR DESCRIPTION
## Squash message 
fix(automate-linking): Suggest links for MARC-bibliographic record

- Fix `NullPointerException` when linking-rules have empty modifications
- Fix `ACTUAL` status for fields that have multiple rules
- Save fields/subfields order 
- Rename `link-details` fields to match with quick-marc schema

Closes MODELINKS-95

### Learning
https://issues.folio.org/browse/MODELINKS-94
