### PR TITLE
fix(automate-linking): Suggest links for MARC-bibliographic record 

### DIFF
--- a/src/main/java/org/folio/entlinks/client/SearchClient.java
+++ b/src/main/java/org/folio/entlinks/client/SearchClient.java
@@ -21,6 +21,7 @@ public interface SearchClient {
 
   default String buildNaturalIdsQuery(Set<String> naturalIds) {
     return AUTHORIZED_REF_TYPE + AND + naturalIds.stream()
+      .map(id -> String.format("\"%s\"", id))
       .map(id -> String.format(NATURAL_ID, id))
       .collect(Collectors.joining(OR, "(", ")"));
   }

--- a/src/main/java/org/folio/entlinks/client/SearchClient.java
+++ b/src/main/java/org/folio/entlinks/client/SearchClient.java
@@ -12,7 +12,7 @@ public interface SearchClient {
 
   String OR = " or ";
   String AND = " and ";
-  String NATURAL_ID = "naturalId=%s";
+  String NATURAL_ID = "naturalId=\"%s\"";
   String AUTHORIZED_REF_TYPE = "authRefType=Authorized";
 
   @GetMapping("/authorities")
@@ -21,7 +21,6 @@ public interface SearchClient {
 
   default String buildNaturalIdsQuery(Set<String> naturalIds) {
     return AUTHORIZED_REF_TYPE + AND + naturalIds.stream()
-      .map(id -> String.format("\"%s\"", id))
       .map(id -> String.format(NATURAL_ID, id))
       .collect(Collectors.joining(OR, "(", ")"));
   }

--- a/src/main/java/org/folio/entlinks/controller/converter/SourceContentMapper.java
+++ b/src/main/java/org/folio/entlinks/controller/converter/SourceContentMapper.java
@@ -4,6 +4,7 @@ import static java.util.stream.Collectors.groupingBy;
 import static java.util.stream.Collectors.mapping;
 
 import java.util.AbstractMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
@@ -74,7 +75,7 @@ public interface SourceContentMapper {
     return fields.stream()
       .flatMap(map -> map.entrySet().stream())
       .map(this::convertFieldContent)
-      .collect(groupingBy(Map.Entry::getKey, mapping(Map.Entry::getValue, Collectors.toList())));
+      .collect(groupingBy(Map.Entry::getKey, LinkedHashMap::new, mapping(Map.Entry::getValue, Collectors.toList())));
   }
 
   private List<Map<String, String>> convertSubfieldsToListOfMaps(Map<String, List<String>> subfields) {
@@ -89,7 +90,7 @@ public interface SourceContentMapper {
   private Map<String, List<String>> convertSubfieldsToOneMap(List<Map<String, String>> subfields) {
     return subfields.stream()
       .flatMap(map -> map.entrySet().stream())
-      .collect(groupingBy(Map.Entry::getKey, mapping(Map.Entry::getValue, Collectors.toList())));
+      .collect(groupingBy(Map.Entry::getKey, LinkedHashMap::new, mapping(Map.Entry::getValue, Collectors.toList())));
   }
 
   private Map.Entry<String, FieldParsedContent> convertFieldContent(Map.Entry<String, FieldContent> fieldContent) {

--- a/src/main/java/org/folio/entlinks/controller/delegate/LinksSuggestionsServiceDelegate.java
+++ b/src/main/java/org/folio/entlinks/controller/delegate/LinksSuggestionsServiceDelegate.java
@@ -62,12 +62,12 @@ public class LinksSuggestionsServiceDelegate {
 
   private List<AuthorityData> findAuthoritiesByNaturalIds(Set<String> naturalIds) {
     var authorityData = dataRepository.findByNaturalIds(naturalIds);
+    var existNaturalIds = authorityData.stream()
+      .map(AuthorityData::getNaturalId)
+      .collect(Collectors.toSet());
     log.info("{} authority data found by natural ids", authorityData.size());
-    if (authorityData.size() < naturalIds.size()) {
-      var existNaturalIds = authorityData.stream()
-        .map(AuthorityData::getNaturalId)
-        .collect(Collectors.toSet());
 
+    if (!existNaturalIds.containsAll(naturalIds)) {
       var naturalIdsToSearch = new HashSet<>(removeAll(naturalIds, existNaturalIds));
       var authoritiesFromSearch = searchAndSaveAuthorities(naturalIdsToSearch);
       log.info("{} authority data was saved", authoritiesFromSearch.size());

--- a/src/main/java/org/folio/entlinks/controller/delegate/LinksSuggestionsServiceDelegate.java
+++ b/src/main/java/org/folio/entlinks/controller/delegate/LinksSuggestionsServiceDelegate.java
@@ -63,7 +63,7 @@ public class LinksSuggestionsServiceDelegate {
   private List<AuthorityData> findAuthoritiesByNaturalIds(Set<String> naturalIds) {
     var authorityData = dataRepository.findByNaturalIds(naturalIds);
     log.info("{} authority data found by natural ids", authorityData.size());
-    if (authorityData.size() != naturalIds.size()) {
+    if (authorityData.size() < naturalIds.size()) {
       var existNaturalIds = authorityData.stream()
         .map(AuthorityData::getNaturalId)
         .collect(Collectors.toSet());

--- a/src/main/java/org/folio/entlinks/controller/delegate/LinksSuggestionsServiceDelegate.java
+++ b/src/main/java/org/folio/entlinks/controller/delegate/LinksSuggestionsServiceDelegate.java
@@ -114,7 +114,6 @@ public class LinksSuggestionsServiceDelegate {
   private Set<String> extractNaturalIds(List<FieldParsedContent> fields) {
     return fields.stream()
       .map(this::extractNaturalIds)
-      .distinct()
       .flatMap(Set::stream)
       .collect(Collectors.toSet());
   }

--- a/src/main/java/org/folio/entlinks/controller/delegate/LinksSuggestionsServiceDelegate.java
+++ b/src/main/java/org/folio/entlinks/controller/delegate/LinksSuggestionsServiceDelegate.java
@@ -113,21 +113,24 @@ public class LinksSuggestionsServiceDelegate {
 
   private Set<String> extractNaturalIds(List<FieldParsedContent> fields) {
     return fields.stream()
-      .map(field -> {
-        var naturalIds = new HashSet<String>();
-        var zeroValues = field.getSubfields().get("0");
-        if (isNotEmpty(zeroValues)) {
-          naturalIds.addAll(zeroValues.stream()
-            .map(FieldUtils::trimSubfield0Value)
-            .collect(Collectors.toSet()));
-        }
-        if (nonNull(field.getLinkDetails())) {
-          naturalIds.add(field.getLinkDetails().getAuthorityNaturalId());
-        }
-        return naturalIds;
-      })
+      .map(this::extractNaturalIds)
+      .distinct()
       .flatMap(Set::stream)
       .collect(Collectors.toSet());
+  }
+
+  private Set<String> extractNaturalIds(FieldParsedContent field) {
+    var naturalIds = new HashSet<String>();
+    var zeroValues = field.getSubfields().get("0");
+    if (isNotEmpty(zeroValues)) {
+      naturalIds.addAll(zeroValues.stream()
+        .map(FieldUtils::trimSubfield0Value)
+        .collect(Collectors.toSet()));
+    }
+    if (nonNull(field.getLinkDetails())) {
+      naturalIds.add(field.getLinkDetails().getAuthorityNaturalId());
+    }
+    return naturalIds;
   }
 
   private boolean isAutoLinkingEnabled(List<InstanceAuthorityLinkingRule> rules) {

--- a/src/main/java/org/folio/entlinks/service/links/InstanceAuthorityLinkingRulesService.java
+++ b/src/main/java/org/folio/entlinks/service/links/InstanceAuthorityLinkingRulesService.java
@@ -20,7 +20,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class InstanceAuthorityLinkingRulesService {
 
   private static final String MIN_AVAILABLE_AUTHORITY_FIELD = "100";
-  private static final String MAX_AVAILABLE_AUTHORITY_FIELD = "150";
+  private static final String MAX_AVAILABLE_AUTHORITY_FIELD = "155";
   private final LinkingRulesRepository repository;
 
   @Cacheable(cacheNames = AUTHORITY_LINKING_RULES_CACHE,

--- a/src/main/java/org/folio/entlinks/service/links/LinksSuggestionService.java
+++ b/src/main/java/org/folio/entlinks/service/links/LinksSuggestionService.java
@@ -151,7 +151,11 @@ public class LinksSuggestionService {
   }
 
   private boolean validateZeroSubfields(String naturalId, FieldParsedContent bibField) {
-    return bibField.getSubfields().get("0").stream()
+    var zeroValues = bibField.getSubfields().get("0");
+    if (isNull(zeroValues)) {
+      return false;
+    }
+    return zeroValues.stream()
       .map(FieldUtils::trimSubfield0Value)
       .anyMatch(zeroValue -> zeroValue.equals(naturalId));
   }

--- a/src/test/java/org/folio/entlinks/controller/delegate/LinksSuggestionsServiceDelegateTest.java
+++ b/src/test/java/org/folio/entlinks/controller/delegate/LinksSuggestionsServiceDelegateTest.java
@@ -51,7 +51,7 @@ class LinksSuggestionsServiceDelegateTest {
 
   private static final UUID AUTHORITY_ID = UUID.randomUUID();
   private static final String MIN_AUTHORITY_FIELD = "100";
-  private static final String MAX_AUTHORITY_FIELD = "150";
+  private static final String MAX_AUTHORITY_FIELD = "155";
   private static final String NATURAL_ID = "e12345";
   private static final String BASE_URL = "https://base/url/";
   private static final String EXPECTED_SEARCH_QUERY = "authRefType=Authorized and (naturalId=" + NATURAL_ID + ')';

--- a/src/test/resources/mappings/mod-search.json
+++ b/src/test/resources/mappings/mod-search.json
@@ -16,7 +16,7 @@
     {
       "request": {
         "method": "GET",
-        "url": "/search/authorities?query=authRefType%3DAuthorized%20and%20%28naturalId%3DoneAuthority%29&includeNumberOfTitles=false"
+        "url": "/search/authorities?query=authRefType%3DAuthorized%20and%20%28naturalId%3D%22oneAuthority%22%29&includeNumberOfTitles=false"
       },
       "response": {
         "status": 200,
@@ -29,7 +29,7 @@
     {
       "request": {
         "method": "GET",
-        "url": "/search/authorities?query=authRefType%3DAuthorized%20and%20%28naturalId%3DtwoAuthority%29&includeNumberOfTitles=false"
+        "url": "/search/authorities?query=authRefType%3DAuthorized%20and%20%28naturalId%3D%22twoAuthority%22%29&includeNumberOfTitles=false"
       },
       "response": {
         "status": 200,


### PR DESCRIPTION
## Squash message 
fix(automate-linking): Suggest links for MARC-bibliographic record

- Fix `NullPointerException` when field doesn't have $0 subfield
- Don't suggest links for fields with NEW status
- Save fields/subfields order
- Fix cql build query by adding quotes

Closes MODELINKS-95

### Learning
https://issues.folio.org/browse/MODELINKS-94
