### PR TITLE
fix(automate-linking): too-long url exception in search requests

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -18,7 +18,7 @@
 
 ### Dependencies
 Bump `folio-spring-base` from `6.0.1` to `7.1.0`
-Bump `spring-boot` from `3.0.2` to `3.1.0`
+Bump `spring-boot` from `3.0.2` to `3.1.1`
 Bump `hypersistence-utils` from `3.2.0` to `3.5.0`
 
 ---

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.springframework.boot</groupId>
     <artifactId>spring-boot-starter-parent</artifactId>
-    <version>3.1.0</version>
+    <version>3.1.1</version>
     <relativePath /> <!-- lookup parent from repository -->
   </parent>
 

--- a/src/main/java/org/folio/entlinks/client/SearchClient.java
+++ b/src/main/java/org/folio/entlinks/client/SearchClient.java
@@ -2,6 +2,7 @@ package org.folio.entlinks.client;
 
 import java.util.Set;
 import java.util.UUID;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 import org.folio.entlinks.domain.dto.AuthoritySearchResult;
 import org.springframework.cloud.openfeign.FeignClient;
@@ -13,23 +14,25 @@ public interface SearchClient {
 
   String OR = " or ";
   String AND = " and ";
-  String ID = "id=%s";
-  String NATURAL_ID = "naturalId=\"%s\"";
-  String AUTHORIZED_REF_TYPE = "authRefType=Authorized";
+  String ID_CQL = "id=%s";
+  String NATURAL_ID_CQL = "naturalId=\"%s\"";
+  String AUTHORIZED_REF_TYPE_CQL = "authRefType=Authorized";
 
   @GetMapping("/authorities")
   AuthoritySearchResult searchAuthorities(@RequestParam String query,
                                           @RequestParam boolean includeNumberOfTitles);
 
   default String buildNaturalIdsQuery(Set<String> naturalIds) {
-    return AUTHORIZED_REF_TYPE + AND + naturalIds.stream()
-      .map(id -> String.format(NATURAL_ID, id))
-      .collect(Collectors.joining(OR, "(", ")"));
+    return buildQuery(naturalIds, id -> String.format(NATURAL_ID_CQL, id));
   }
 
   default String buildIdsQuery(Set<UUID> ids) {
-    return AUTHORIZED_REF_TYPE + AND + ids.stream()
-      .map(id -> String.format(ID, id))
+    return buildQuery(ids, id -> String.format(ID_CQL, id));
+  }
+
+  private static <T> String buildQuery(Set<T> params, Function<T, String> queryFunction) {
+    return AUTHORIZED_REF_TYPE_CQL + AND + params.stream()
+      .map(queryFunction)
       .collect(Collectors.joining(OR, "(", ")"));
   }
 }

--- a/src/main/java/org/folio/entlinks/domain/entity/AuthorityData.java
+++ b/src/main/java/org/folio/entlinks/domain/entity/AuthorityData.java
@@ -34,7 +34,7 @@ public class AuthorityData extends AuditableEntity {
   private String naturalId;
 
   @Column(name = "state")
-  private boolean deleted = false;
+  private boolean deleted;
 
   @Override
   public int hashCode() {

--- a/src/main/java/org/folio/entlinks/integration/internal/SearchService.java
+++ b/src/main/java/org/folio/entlinks/integration/internal/SearchService.java
@@ -1,0 +1,66 @@
+package org.folio.entlinks.integration.internal;
+
+import com.google.common.collect.Lists;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.UUID;
+import java.util.function.Function;
+import lombok.RequiredArgsConstructor;
+import lombok.Setter;
+import org.folio.entlinks.client.SearchClient;
+import org.folio.entlinks.controller.converter.DataMapper;
+import org.folio.entlinks.domain.dto.Authority;
+import org.folio.entlinks.domain.dto.AuthoritySearchResult;
+import org.folio.entlinks.domain.entity.AuthorityData;
+import org.folio.entlinks.exception.FolioIntegrationException;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class SearchService {
+
+  private static final int REQUEST_PARAM_MAX_SIZE_DEFAULT = 10;
+
+  private final SearchClient searchClient;
+  private final DataMapper dataMapper;
+
+  private @Setter int requestParamMaxSize = REQUEST_PARAM_MAX_SIZE_DEFAULT;
+
+  public List<AuthorityData> searchAuthoritiesByIds(Collection<UUID> ids) {
+    return getAuthorityData(ids, params -> searchClient.buildIdsQuery(new HashSet<>(params)));
+  }
+
+  public List<AuthorityData> searchAuthoritiesByNaturalIds(Collection<String> naturalIds) {
+    return getAuthorityData(naturalIds, params -> searchClient.buildNaturalIdsQuery(new HashSet<>(params)));
+  }
+
+  private <T> List<AuthorityData> getAuthorityData(Collection<T> params, Function<List<T>, String> paramsMapper) {
+    if (params == null || params.isEmpty()) {
+      return Collections.emptyList();
+    }
+
+    return Lists.partition(new ArrayList<>(params), requestParamMaxSize).stream()
+      .map(paramsMapper)
+      .map(this::doRequest)
+      .flatMap(authoritySearchResult -> authoritySearchResult.getAuthorities().stream())
+      .map(this::toAuthorityData)
+      .toList();
+  }
+
+  private AuthoritySearchResult doRequest(String query) {
+    try {
+      return searchClient.searchAuthorities(query, false);
+    } catch (Exception e) {
+      throw new FolioIntegrationException("Failed to fetch authorities", e);
+    }
+  }
+
+  private AuthorityData toAuthorityData(Authority authority) {
+    var authorityData = dataMapper.convertToData(authority);
+    authorityData.setDeleted(false);
+    return authorityData;
+  }
+}

--- a/src/main/java/org/folio/entlinks/service/links/InstanceAuthorityLinkingService.java
+++ b/src/main/java/org/folio/entlinks/service/links/InstanceAuthorityLinkingService.java
@@ -21,9 +21,7 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
-import org.folio.entlinks.client.SearchClient;
 import org.folio.entlinks.client.SourceStorageClient;
-import org.folio.entlinks.domain.dto.Authority;
 import org.folio.entlinks.domain.dto.LinkStatus;
 import org.folio.entlinks.domain.dto.LinksChangeEvent;
 import org.folio.entlinks.domain.dto.StrippedParsedRecord;
@@ -34,6 +32,7 @@ import org.folio.entlinks.domain.entity.InstanceAuthorityLinkingRule;
 import org.folio.entlinks.domain.entity.projection.LinkCountView;
 import org.folio.entlinks.domain.repository.InstanceLinkRepository;
 import org.folio.entlinks.exception.DeletedLinkingAuthorityException;
+import org.folio.entlinks.integration.internal.SearchService;
 import org.folio.entlinks.integration.kafka.EventProducer;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
@@ -55,7 +54,7 @@ public class InstanceAuthorityLinkingService {
   private final AuthorityRuleValidationService authorityRuleValidationService;
   private final AuthorityDataService authorityDataService;
   private final RenovateLinksService renovateService;
-  private final SearchClient searchClient;
+  private final SearchService searchService;
   private final SourceStorageClient sourceStorageClient;
   private final EventProducer<LinksChangeEvent> eventProducer;
 
@@ -169,7 +168,7 @@ public class InstanceAuthorityLinkingService {
     InstanceAuthorityLinkStatus status, Timestamp from, Timestamp to) {
 
     return (root, query, builder) -> {
-      var predicates = new LinkedList<>();
+      var predicates = new LinkedList<Predicate>();
 
       if (status != null) {
         predicates.add(builder.equal(root.get("status"), status));
@@ -209,10 +208,8 @@ public class InstanceAuthorityLinkingService {
     if (authorityIds.isEmpty()) {
       return emptyMap();
     }
-    var searchQuery = searchClient.buildIdsQuery(authorityIds);
-    return searchClient.searchAuthorities(searchQuery, false)
-      .getAuthorities().stream()
-      .collect(Collectors.toMap(Authority::getId, Authority::getNaturalId));
+    return searchService.searchAuthoritiesByIds(authorityIds).stream()
+      .collect(Collectors.toMap(AuthorityData::getId, AuthorityData::getNaturalId));
   }
 
   private List<StrippedParsedRecord> fetchAuthoritySources(Set<UUID> authorityIds) {

--- a/src/test/java/org/folio/entlinks/integration/internal/SearchServiceTest.java
+++ b/src/test/java/org/folio/entlinks/integration/internal/SearchServiceTest.java
@@ -1,0 +1,155 @@
+package org.folio.entlinks.integration.internal;
+
+import static java.util.UUID.randomUUID;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anySet;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.UUID;
+import org.folio.entlinks.client.SearchClient;
+import org.folio.entlinks.controller.converter.DataMapper;
+import org.folio.entlinks.domain.dto.Authority;
+import org.folio.entlinks.domain.dto.AuthoritySearchResult;
+import org.folio.entlinks.domain.entity.AuthorityData;
+import org.folio.spring.test.type.UnitTest;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@UnitTest
+@ExtendWith(MockitoExtension.class)
+class SearchServiceTest {
+
+  private @Mock SearchClient searchClient;
+  private @Mock DataMapper dataMapper;
+  private @InjectMocks SearchService searchService;
+
+  @Test
+  void testSearchAuthoritiesByIds_withNullNaturalIds_shouldReturnEmptyList() {
+    // Arrange
+    List<UUID> naturalIds = null;
+
+    // Act
+    List<AuthorityData> result = searchService.searchAuthoritiesByIds(naturalIds);
+
+    // Assert
+    assertThat(result).isEmpty();
+    verifyNoInteractions(searchClient);
+    verifyNoInteractions(dataMapper);
+  }
+
+  @Test
+  void testSearchAuthoritiesByIds_withEmptyNaturalIds_shouldReturnEmptyList() {
+    // Arrange
+    List<UUID> naturalIds = Collections.emptyList();
+
+    // Act
+    List<AuthorityData> result = searchService.searchAuthoritiesByIds(naturalIds);
+
+    // Assert
+    assertThat(result).isEmpty();
+    verifyNoInteractions(searchClient);
+    verifyNoInteractions(dataMapper);
+  }
+
+  @Test
+  void testSearchAuthoritiesByIds_withNonEmptyNaturalIds_shouldReturnListOfAuthorityData() {
+    // Arrange
+    final var ids = Arrays.asList(randomUUID(), randomUUID(), randomUUID());
+
+    AuthoritySearchResult searchResult1 = new AuthoritySearchResult();
+    searchResult1.setAuthorities(Arrays.asList(new Authority(), new Authority()));
+
+    AuthoritySearchResult searchResult2 = new AuthoritySearchResult();
+    searchResult2.setAuthorities(Collections.singletonList(new Authority()));
+
+    AuthorityData authorityData1 = new AuthorityData();
+    AuthorityData authorityData2 = new AuthorityData();
+    AuthorityData authorityData3 = new AuthorityData();
+
+    when(searchClient.buildIdsQuery(anySet())).thenReturn("query1", "query2");
+    when(searchClient.searchAuthorities(anyString(), eq(false))).thenReturn(searchResult1, searchResult2);
+    when(dataMapper.convertToData(any(Authority.class))).thenReturn(authorityData1, authorityData2, authorityData3);
+    searchService.setRequestParamMaxSize(2);
+
+    // Act
+    List<AuthorityData> result = searchService.searchAuthoritiesByIds(ids);
+
+    // Assert
+    assertThat(result).hasSize(3)
+      .containsAll(List.of(authorityData1, authorityData2, authorityData3))
+      .allMatch(authorityData -> !authorityData.isDeleted());
+    verify(searchClient, times(2)).searchAuthorities(anyString(), eq(false));
+    verify(dataMapper, times(3)).convertToData(any(Authority.class));
+  }
+
+  @Test
+  void testSearchAuthoritiesByNaturalIds_withNullNaturalIds_shouldReturnEmptyList() {
+    // Arrange
+    List<String> naturalIds = null;
+
+    // Act
+    List<AuthorityData> result = searchService.searchAuthoritiesByNaturalIds(naturalIds);
+
+    // Assert
+    assertThat(result).isEmpty();
+    verifyNoInteractions(searchClient);
+    verifyNoInteractions(dataMapper);
+  }
+
+  @Test
+  void testSearchAuthoritiesByNaturalIds_withEmptyNaturalIds_shouldReturnEmptyList() {
+    // Arrange
+    List<String> naturalIds = Collections.emptyList();
+
+    // Act
+    List<AuthorityData> result = searchService.searchAuthoritiesByNaturalIds(naturalIds);
+
+    // Assert
+    assertThat(result).isEmpty();
+    verifyNoInteractions(searchClient);
+    verifyNoInteractions(dataMapper);
+  }
+
+  @Test
+  void testSearchAuthoritiesByNaturalIds_withNonEmptyNaturalIds_shouldReturnListOfAuthorityData() {
+    // Arrange
+    final var naturalIds = Arrays.asList("id1", "id2", "id3");
+
+    AuthoritySearchResult searchResult1 = new AuthoritySearchResult();
+    searchResult1.setAuthorities(Arrays.asList(new Authority(), new Authority()));
+
+    AuthoritySearchResult searchResult2 = new AuthoritySearchResult();
+    searchResult2.setAuthorities(Collections.singletonList(new Authority()));
+
+    AuthorityData authorityData1 = new AuthorityData();
+    AuthorityData authorityData2 = new AuthorityData();
+    AuthorityData authorityData3 = new AuthorityData();
+
+    when(searchClient.buildNaturalIdsQuery(anySet())).thenReturn("query1", "query2");
+    when(searchClient.searchAuthorities(anyString(), eq(false))).thenReturn(searchResult1, searchResult2);
+    when(dataMapper.convertToData(any(Authority.class))).thenReturn(authorityData1, authorityData2, authorityData3);
+    searchService.setRequestParamMaxSize(2);
+
+    // Act
+    List<AuthorityData> result = searchService.searchAuthoritiesByNaturalIds(naturalIds);
+
+    // Assert
+    assertThat(result).hasSize(3)
+      .containsAll(List.of(authorityData1, authorityData2, authorityData3))
+      .allMatch(authorityData -> !authorityData.isDeleted());
+    verify(searchClient, times(2)).searchAuthorities(anyString(), eq(false));
+    verify(dataMapper, times(3)).convertToData(any(Authority.class));
+  }
+}

--- a/src/test/resources/application-test.yaml
+++ b/src/test/resources/application-test.yaml
@@ -10,7 +10,7 @@ spring:
       hibernate:
         dialect: org.hibernate.dialect.PostgreSQLDialect
         format_sql: true
-        generate_statistics: true
+#        generate_statistics: true
         jdbc:
           batch_size: 20
         order_inserts: true


### PR DESCRIPTION
## Purpose
Fix too-long url exception in search requests while automate linking

## Approach
- create a service to work with SearchClient
- do chunkable requests

### Changes checklist
- [ ] API paths, methods, request or response bodies changed, added, or removed
- [ ] Database schema changes
- [ ] Interface versions changes
- [ ] Interface dependencies added, or removed
- [ ] Permissions changed, added, or removed
- [ ] Check logging.

### Learning
https://issues.folio.org/browse/MODELINKS-111