### PR TITLE
fix(automate-linking): incorrect order of resulting fields

### DIFF
--- a/src/main/java/org/folio/entlinks/controller/delegate/LinksSuggestionsServiceDelegate.java
+++ b/src/main/java/org/folio/entlinks/controller/delegate/LinksSuggestionsServiceDelegate.java
@@ -108,17 +108,10 @@ public class LinksSuggestionsServiceDelegate {
   private Set<String> extractNaturalIdsOfLinkableFields(List<SourceParsedContent> contentCollection,
                                                         Map<String, List<InstanceAuthorityLinkingRule>> rules) {
     return contentCollection.stream()
-      .flatMap(bibRecord -> bibRecord.getFields().entrySet().stream())
-      .filter(fields -> isAutoLinkingEnabled(rules.get(fields.getKey())))
-      .map(fields -> extractNaturalIds(fields.getValue()))
-      .filter(CollectionUtils::isNotEmpty)
-      .flatMap(Set::stream)
-      .collect(Collectors.toSet());
-  }
-
-  private Set<String> extractNaturalIds(List<FieldParsedContent> fields) {
-    return fields.stream()
+      .flatMap(bibRecord -> bibRecord.getFields().stream())
+      .filter(field -> isAutoLinkingEnabled(rules.get(field.getTag())))
       .map(this::extractNaturalIds)
+      .filter(CollectionUtils::isNotEmpty)
       .flatMap(Set::stream)
       .collect(Collectors.toSet());
   }

--- a/src/main/java/org/folio/entlinks/integration/dto/AuthorityParsedContent.java
+++ b/src/main/java/org/folio/entlinks/integration/dto/AuthorityParsedContent.java
@@ -1,7 +1,6 @@
 package org.folio.entlinks.integration.dto;
 
 import java.util.List;
-import java.util.Map;
 import java.util.UUID;
 import lombok.Getter;
 
@@ -10,7 +9,7 @@ public class AuthorityParsedContent extends SourceParsedContent {
   private final String naturalId;
 
   public AuthorityParsedContent(UUID id, String naturalId, String leader,
-                                Map<String, List<FieldParsedContent>> fields) {
+                                List<FieldParsedContent> fields) {
     super(id, leader, fields);
     this.naturalId = naturalId;
   }

--- a/src/main/java/org/folio/entlinks/integration/dto/FieldParsedContent.java
+++ b/src/main/java/org/folio/entlinks/integration/dto/FieldParsedContent.java
@@ -11,6 +11,7 @@ import org.folio.entlinks.domain.dto.LinkDetails;
 @Setter
 @AllArgsConstructor
 public class FieldParsedContent {
+  private String tag;
   private String ind1;
   private String ind2;
   private Map<String, List<String>> subfields;

--- a/src/main/java/org/folio/entlinks/integration/dto/SourceParsedContent.java
+++ b/src/main/java/org/folio/entlinks/integration/dto/SourceParsedContent.java
@@ -1,7 +1,6 @@
 package org.folio.entlinks.integration.dto;
 
 import java.util.List;
-import java.util.Map;
 import java.util.UUID;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -11,5 +10,5 @@ import lombok.Getter;
 public class SourceParsedContent {
   private final UUID id;
   private final String leader;
-  private final Map<String, List<FieldParsedContent>> fields;
+  private final List<FieldParsedContent> fields;
 }

--- a/src/main/java/org/folio/entlinks/service/links/AuthorityRuleValidationService.java
+++ b/src/main/java/org/folio/entlinks/service/links/AuthorityRuleValidationService.java
@@ -64,7 +64,8 @@ public class AuthorityRuleValidationService {
 
   public boolean validateAuthorityFields(AuthorityParsedContent authorityContent, InstanceAuthorityLinkingRule rule) {
     log.info("Starting validation for authority {}", authorityContent.getId());
-    var authorityFields = authorityContent.getFields().get(rule.getAuthorityField());
+    var authorityFields = authorityContent.getFields().stream().filter(fieldParsedContent ->
+      fieldParsedContent.getTag().equals(rule.getAuthorityField())).toList();
 
     if (validateAuthorityFields(authorityFields)) {
       var authorityField = authorityFields.get(0);

--- a/src/test/java/org/folio/entlinks/service/links/LinksSuggestionsServiceTest.java
+++ b/src/test/java/org/folio/entlinks/service/links/LinksSuggestionsServiceTest.java
@@ -57,7 +57,7 @@ class LinksSuggestionsServiceTest {
     linksSuggestionService
       .fillLinkDetailsWithSuggestedAuthorities(List.of(bib), List.of(authority), rules);
 
-    var bibField = bib.getFields().get("100").get(0);
+    var bibField = bib.getFields().get(0);
     var linkDetails = bibField.getLinkDetails();
     assertEquals(LinkStatus.NEW, linkDetails.getStatus());
     assertEquals(AUTHORITY_ID, linkDetails.getAuthorityId());
@@ -84,7 +84,7 @@ class LinksSuggestionsServiceTest {
     linksSuggestionService
       .fillLinkDetailsWithSuggestedAuthorities(List.of(bib), List.of(authority), rules);
 
-    var bibField = bib.getFields().get("100").get(0);
+    var bibField = bib.getFields().get(0);
     var linkDetails = bibField.getLinkDetails();
     assertEquals(LinkStatus.ACTUAL, linkDetails.getStatus());
     assertEquals(AUTHORITY_ID, linkDetails.getAuthorityId());
@@ -108,7 +108,7 @@ class LinksSuggestionsServiceTest {
     linksSuggestionService
       .fillLinkDetailsWithSuggestedAuthorities(List.of(bib), List.of(authority), rules);
 
-    var linkDetails = bib.getFields().get("100").get(0).getLinkDetails();
+    var linkDetails = bib.getFields().get(0).getLinkDetails();
     assertEquals(LinkStatus.ERROR, linkDetails.getStatus());
     assertEquals(NO_SUGGESTIONS.getErrorCode(), linkDetails.getErrorCause());
   }
@@ -123,7 +123,7 @@ class LinksSuggestionsServiceTest {
     linksSuggestionService
       .fillLinkDetailsWithSuggestedAuthorities(List.of(bib), List.of(authority, secondAuthority), rules);
 
-    var linkDetails = bib.getFields().get("100").get(0).getLinkDetails();
+    var linkDetails = bib.getFields().get(0).getLinkDetails();
     assertEquals(LinkStatus.ERROR, linkDetails.getStatus());
     assertEquals(MORE_THAN_ONE_SUGGESTIONS.getErrorCode(), linkDetails.getErrorCause());
     assertNull(linkDetails.getAuthorityId());
@@ -140,7 +140,7 @@ class LinksSuggestionsServiceTest {
     linksSuggestionService
       .fillLinkDetailsWithSuggestedAuthorities(List.of(bib), List.of(authority), rules);
 
-    var linkDetails = bib.getFields().get("100").get(0).getLinkDetails();
+    var linkDetails = bib.getFields().get(0).getLinkDetails();
     assertEquals(LinkStatus.ERROR, linkDetails.getStatus());
     assertEquals(NO_SUGGESTIONS.getErrorCode(), linkDetails.getErrorCause());
   }
@@ -156,7 +156,7 @@ class LinksSuggestionsServiceTest {
     linksSuggestionService
       .fillLinkDetailsWithSuggestedAuthorities(List.of(bib), List.of(authority), rules);
 
-    var linkDetails = bib.getFields().get("600").get(0).getLinkDetails();
+    var linkDetails = bib.getFields().get(0).getLinkDetails();
     assertEquals(LinkStatus.ERROR, linkDetails.getStatus());
     assertEquals(DISABLED_AUTO_LINKING.getErrorCode(), linkDetails.getErrorCause());
   }
@@ -167,17 +167,15 @@ class LinksSuggestionsServiceTest {
 
   private AuthorityParsedContent getAuthorityParsedRecordContent(String authorityField,
                                                                  Map<String, List<String>> subfields) {
-    var field = new FieldParsedContent("//", "//", subfields, null);
-    var fields = Map.of(authorityField, List.of(field));
-    return new AuthorityParsedContent(AUTHORITY_ID, NATURAL_ID, "", fields);
+    var field = new FieldParsedContent(authorityField, "//", "//", subfields, null);
+    return new AuthorityParsedContent(AUTHORITY_ID, NATURAL_ID, "", List.of(field));
   }
 
   private SourceParsedContent getBibParsedRecordContent(String bibField, LinkDetails linkDetails) {
     var subfields = new HashMap<String, List<String>>();
     subfields.put("0", List.of(NATURAL_ID));
-    var field = new FieldParsedContent("//", "//", subfields, linkDetails);
-    var fields = Map.of(bibField, List.of(field));
-    return new SourceParsedContent(UUID.randomUUID(), "", fields);
+    var field = new FieldParsedContent(bibField, "//", "//", subfields, linkDetails);
+    return new SourceParsedContent(UUID.randomUUID(), "", List.of(field));
   }
 
   private LinkDetails getActualLinksDetails() {


### PR DESCRIPTION
## Purpose
Fix bug when not linked field replaced by a linked one when auto-linking fields with same tag and field with another tag between them

### Changes checklist
- [ ] API paths, methods, request or response bodies changed, added, or removed
- [ ] Database schema changes
- [ ] Interface versions changes
- [ ] Interface dependencies added, or removed
- [ ] Permissions changed, added, or removed
- [ ] Check logging.

### Learning
https://issues.folio.org/browse/MODELINKS-110
