### PR TITLE
fix(instance-authority-linking): Add missing permissions to save links api

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -52,6 +52,10 @@
           "pathPattern": "/links/instances/{instanceId}",
           "permissionsRequired": [
             "instance-authority-links.instances.collection.put"
+          ],
+          "modulePermissions": [
+            "source-storage.records.fetch",
+            "search.authorities.collection.get"
           ]
         },
         {


### PR DESCRIPTION
## Purpose
Fix saving links for user with limited permissions
[MODELINKS-112](https://issues.folio.org/browse/MODELINKS-112)

## Approach
Add permissions for source records and search authorities

### Changes checklist
- [ ] API paths, methods, request or response bodies changed, added, or removed
- [ ] Database schema changes
- [ ] Interface versions changes
- [ ] Interface dependencies added, or removed
- [x] Permissions changed, added, or removed
- [ ] Check logging.
