### PR TITLE
fix(instance-authority-linking): Add missing permissions to save links api

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -55,7 +55,10 @@
           ],
           "modulePermissions": [
             "source-storage.records.fetch",
-            "search.authorities.collection.get"
+            "search.authorities.collection.get",
+            "mapping-metadata.get",
+            "inventory-storage.instances.item.get",
+            "inventory-storage.instances.item.put"
           ]
         },
         {


### PR DESCRIPTION
## Purpose
Links saved with error because inventory can't retrieve mapping metadata
[MODELINKS-112](https://issues.folio.org/browse/MODELINKS-112)

## Approach
Add permissions for mapping metadata and instance storage

### Changes checklist
- [ ] API paths, methods, request or response bodies changed, added, or removed
- [ ] Database schema changes
- [ ] Interface versions changes
- [ ] Interface dependencies added, or removed
- [x] Permissions changed, added, or removed
- [ ] Check logging.
