### PR TITLE
fix(instance-authority-linking): Revert renovation logic and extend suggestions endpoint

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,7 +1,7 @@
 ## v2.0.0 In progress
 ### APIs versions
 * Provides `instance-authority-links-statistics v2.0`
-* Provides `instance-authority-links-suggestions v1.0`
+* Provides `instance-authority-links-suggestions v1.1`
 * Provides `instance-authority-links v2.1`
 * Provides `instance-authority-linking-rules v1.1`
 * Removes `linked-bib-update-statistics v1.0`
@@ -11,6 +11,7 @@
 * Add PATCH and GET instance-authority linking rule endpoints ([MODELINKS-80](https://issues.folio.org/browse/MODELINKS-80))
 * Extend GET /links/instances/{id} with link status, errorCause ([MODELINKS-68](https://issues.folio.org/browse/MODELINKS-68))
 * Implement endpoint to suggest links for MARC-bibliographic record ([MODELINKS-82](https://issues.folio.org/browse/MODELINKS-82))
+* Add possibility of matching by Authority id for links suggestions ([MODELINKS-113](https://issues.folio.org/browse/MODELINKS-113))
 
 ### Tech Dept
 * Upgrade folio-spring-base to v7.1.0 ([MODELINKS-99](https://issues.folio.org/browse/MODELINKS-99))

--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -137,7 +137,7 @@
     },
     {
       "id": "instance-authority-links-suggestions",
-      "version": "1.0",
+      "version": "1.1",
       "handlers": [
         {
           "methods": [

--- a/src/main/java/org/folio/entlinks/controller/LinksSuggestionsController.java
+++ b/src/main/java/org/folio/entlinks/controller/LinksSuggestionsController.java
@@ -1,7 +1,8 @@
 package org.folio.entlinks.controller;
 
 import lombok.RequiredArgsConstructor;
-import org.folio.entlinks.controller.delegate.LinksSuggestionsServiceDelegate;
+import org.folio.entlinks.controller.delegate.suggestion.LinksSuggestionServiceDelegateHelper;
+import org.folio.entlinks.domain.dto.AuthoritySearchParameter;
 import org.folio.entlinks.domain.dto.ParsedRecordContentCollection;
 import org.folio.entlinks.rest.resource.LinksSuggestionsApi;
 import org.springframework.http.ResponseEntity;
@@ -11,13 +12,14 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 public class LinksSuggestionsController implements LinksSuggestionsApi {
 
-  private final LinksSuggestionsServiceDelegate serviceDelegate;
+  private final LinksSuggestionServiceDelegateHelper delegateServiceHelper;
 
   @Override
   public ResponseEntity<ParsedRecordContentCollection> suggestLinksForMarcRecord(
-    ParsedRecordContentCollection parsedRecordContentCollection) {
+    ParsedRecordContentCollection parsedRecordContentCollection, AuthoritySearchParameter authoritySearchParameter) {
     return ResponseEntity.ok(
-      serviceDelegate.suggestLinksForMarcRecords(parsedRecordContentCollection)
+      delegateServiceHelper.getDelegate(authoritySearchParameter)
+        .suggestLinksForMarcRecords(parsedRecordContentCollection)
     );
   }
 }

--- a/src/main/java/org/folio/entlinks/controller/delegate/suggestion/LinksSuggestionServiceDelegate.java
+++ b/src/main/java/org/folio/entlinks/controller/delegate/suggestion/LinksSuggestionServiceDelegate.java
@@ -1,0 +1,7 @@
+package org.folio.entlinks.controller.delegate.suggestion;
+
+import org.folio.entlinks.domain.dto.ParsedRecordContentCollection;
+
+public interface LinksSuggestionServiceDelegate {
+  ParsedRecordContentCollection suggestLinksForMarcRecords(ParsedRecordContentCollection contentCollection);
+}

--- a/src/main/java/org/folio/entlinks/controller/delegate/suggestion/LinksSuggestionServiceDelegateHelper.java
+++ b/src/main/java/org/folio/entlinks/controller/delegate/suggestion/LinksSuggestionServiceDelegateHelper.java
@@ -1,5 +1,7 @@
 package org.folio.entlinks.controller.delegate.suggestion;
 
+import static java.util.Objects.isNull;
+
 import java.util.Map;
 import org.folio.entlinks.domain.dto.AuthoritySearchParameter;
 import org.springframework.stereotype.Service;
@@ -20,6 +22,10 @@ public class LinksSuggestionServiceDelegateHelper {
   }
 
   public LinksSuggestionServiceDelegate getDelegate(AuthoritySearchParameter authoritySearchParameter) {
+    if (isNull(authoritySearchParameter)) {
+      throw new IllegalArgumentException("AuthoritySearchParameter must not be null.");
+    }
+
     return searchParameterToServiceDelegateMap.get(authoritySearchParameter);
   }
 

--- a/src/main/java/org/folio/entlinks/controller/delegate/suggestion/LinksSuggestionServiceDelegateHelper.java
+++ b/src/main/java/org/folio/entlinks/controller/delegate/suggestion/LinksSuggestionServiceDelegateHelper.java
@@ -1,0 +1,26 @@
+package org.folio.entlinks.controller.delegate.suggestion;
+
+import java.util.Map;
+import org.folio.entlinks.domain.dto.AuthoritySearchParameter;
+import org.springframework.stereotype.Service;
+
+@Service
+public class LinksSuggestionServiceDelegateHelper {
+
+  private final Map<AuthoritySearchParameter, LinksSuggestionServiceDelegate> searchParameterToServiceDelegateMap;
+
+  public LinksSuggestionServiceDelegateHelper(
+    LinksSuggestionsByAuthorityNaturalId linksSuggestionsByAuthorityNaturalId,
+    LinksSuggestionsByAuthorityId linksSuggestionsByAuthorityId) {
+
+    searchParameterToServiceDelegateMap = Map.of(
+      AuthoritySearchParameter.NATURAL_ID, linksSuggestionsByAuthorityNaturalId,
+      AuthoritySearchParameter.ID, linksSuggestionsByAuthorityId
+    );
+  }
+
+  public LinksSuggestionServiceDelegate getDelegate(AuthoritySearchParameter authoritySearchParameter) {
+    return searchParameterToServiceDelegateMap.get(authoritySearchParameter);
+  }
+
+}

--- a/src/main/java/org/folio/entlinks/controller/delegate/suggestion/LinksSuggestionsByAuthorityId.java
+++ b/src/main/java/org/folio/entlinks/controller/delegate/suggestion/LinksSuggestionsByAuthorityId.java
@@ -1,0 +1,79 @@
+package org.folio.entlinks.controller.delegate.suggestion;
+
+import static java.util.Objects.nonNull;
+import static org.apache.commons.collections4.CollectionUtils.isNotEmpty;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+import lombok.extern.log4j.Log4j2;
+import org.folio.entlinks.client.SourceStorageClient;
+import org.folio.entlinks.controller.converter.SourceContentMapper;
+import org.folio.entlinks.domain.entity.AuthorityData;
+import org.folio.entlinks.domain.repository.AuthorityDataRepository;
+import org.folio.entlinks.integration.dto.FieldParsedContent;
+import org.folio.entlinks.integration.internal.SearchService;
+import org.folio.entlinks.service.links.InstanceAuthorityLinkingRulesService;
+import org.folio.entlinks.service.links.LinksSuggestionService;
+import org.springframework.stereotype.Service;
+
+@Log4j2
+@Service
+public class LinksSuggestionsByAuthorityId extends LinksSuggestionsServiceDelegateBase<UUID> {
+
+  private static final Pattern UUID_REGEX =
+    Pattern.compile("^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$");
+  private final AuthorityDataRepository dataRepository;
+  private final SearchService searchService;
+
+  public LinksSuggestionsByAuthorityId(InstanceAuthorityLinkingRulesService linkingRulesService,
+                                       LinksSuggestionService suggestionService,
+                                       AuthorityDataRepository dataRepository,
+                                       SourceStorageClient sourceStorageClient,
+                                       SourceContentMapper contentMapper,
+                                       SearchService searchService) {
+    super(linkingRulesService, suggestionService, dataRepository, sourceStorageClient, contentMapper);
+    this.dataRepository = dataRepository;
+    this.searchService = searchService;
+  }
+
+  @Override
+  protected String getSearchSubfield() {
+    return "9";
+  }
+
+  @Override
+  protected Set<UUID> extractIds(FieldParsedContent field) {
+    var ids = new HashSet<UUID>();
+    var subfieldValues = field.getSubfields().get("9");
+    if (isNotEmpty(subfieldValues)) {
+      ids.addAll(subfieldValues.stream()
+        .filter(id -> UUID_REGEX.matcher(id).matches())
+        .map(UUID::fromString)
+        .collect(Collectors.toSet()));
+    }
+    if (nonNull(field.getLinkDetails()) && nonNull(field.getLinkDetails().getAuthorityId())) {
+      ids.add(field.getLinkDetails().getAuthorityId());
+    }
+    return ids;
+  }
+
+  @Override
+  protected List<AuthorityData> findExistingAuthorities(Set<UUID> ids) {
+    return dataRepository.findAllById(ids);
+  }
+
+  @Override
+  protected UUID extractId(AuthorityData authorityData) {
+    return authorityData.getId();
+  }
+
+  @Override
+  protected List<AuthorityData> searchAuthorities(Set<UUID> ids) {
+    return searchService.searchAuthoritiesByIds(new ArrayList<>(ids));
+  }
+}

--- a/src/main/java/org/folio/entlinks/controller/delegate/suggestion/LinksSuggestionsByAuthorityNaturalId.java
+++ b/src/main/java/org/folio/entlinks/controller/delegate/suggestion/LinksSuggestionsByAuthorityNaturalId.java
@@ -1,0 +1,75 @@
+package org.folio.entlinks.controller.delegate.suggestion;
+
+import static java.util.Objects.nonNull;
+import static org.apache.commons.collections4.CollectionUtils.isNotEmpty;
+import static org.apache.commons.lang3.StringUtils.isEmpty;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+import lombok.extern.log4j.Log4j2;
+import org.folio.entlinks.client.SourceStorageClient;
+import org.folio.entlinks.controller.converter.SourceContentMapper;
+import org.folio.entlinks.domain.entity.AuthorityData;
+import org.folio.entlinks.domain.repository.AuthorityDataRepository;
+import org.folio.entlinks.integration.dto.FieldParsedContent;
+import org.folio.entlinks.integration.internal.SearchService;
+import org.folio.entlinks.service.links.InstanceAuthorityLinkingRulesService;
+import org.folio.entlinks.service.links.LinksSuggestionService;
+import org.folio.entlinks.utils.FieldUtils;
+import org.springframework.stereotype.Service;
+
+@Log4j2
+@Service
+public class LinksSuggestionsByAuthorityNaturalId extends LinksSuggestionsServiceDelegateBase<String> {
+  private final AuthorityDataRepository dataRepository;
+  private final SearchService searchService;
+
+  public LinksSuggestionsByAuthorityNaturalId(InstanceAuthorityLinkingRulesService linkingRulesService,
+                                              LinksSuggestionService suggestionService,
+                                              AuthorityDataRepository dataRepository,
+                                              SourceStorageClient sourceStorageClient,
+                                              SourceContentMapper contentMapper,
+                                              SearchService searchService) {
+    super(linkingRulesService, suggestionService, dataRepository, sourceStorageClient, contentMapper);
+    this.dataRepository = dataRepository;
+    this.searchService = searchService;
+  }
+
+  @Override
+  protected String getSearchSubfield() {
+    return "0";
+  }
+
+  @Override
+  protected Set<String> extractIds(FieldParsedContent field) {
+    var naturalIds = new HashSet<String>();
+    var zeroValues = field.getSubfields().get("0");
+    if (isNotEmpty(zeroValues)) {
+      naturalIds.addAll(zeroValues.stream()
+        .map(FieldUtils::trimSubfield0Value)
+        .collect(Collectors.toSet()));
+    }
+    if (nonNull(field.getLinkDetails()) && !isEmpty(field.getLinkDetails().getAuthorityNaturalId())) {
+      naturalIds.add(field.getLinkDetails().getAuthorityNaturalId());
+    }
+    return naturalIds;
+  }
+
+  @Override
+  protected List<AuthorityData> findExistingAuthorities(Set<String> ids) {
+    return dataRepository.findByNaturalIds(ids);
+  }
+
+  @Override
+  protected String extractId(AuthorityData authorityData) {
+    return authorityData.getNaturalId();
+  }
+
+  @Override
+  protected List<AuthorityData> searchAuthorities(Set<String> ids) {
+    return searchService.searchAuthoritiesByNaturalIds(new ArrayList<>(ids));
+  }
+}

--- a/src/main/resources/swagger.api/mod-entities-links.yaml
+++ b/src/main/resources/swagger.api/mod-entities-links.yaml
@@ -163,6 +163,13 @@ paths:
       operationId: suggestLinksForMarcRecord
       tags:
         - links-suggestions
+      parameters:
+        - name: authoritySearchParameter
+          in: query
+          required: false
+          description: Authority field to search by
+          schema:
+            $ref: "#/components/schemas/AuthoritySearchParameter"
       requestBody:
         content:
           application/json:
@@ -625,6 +632,11 @@ components:
         ts:
           description: Timestamp
           type: string
+    AuthoritySearchParameter:
+      description: Authority search parameter for link suggestions
+      type: string
+      enum: [ID, NATURAL_ID]
+      default: NATURAL_ID
 
   responses:
     badRequestResponse:

--- a/src/test/java/org/folio/entlinks/controller/LinksSuggestionsIT.java
+++ b/src/test/java/org/folio/entlinks/controller/LinksSuggestionsIT.java
@@ -15,6 +15,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import lombok.SneakyThrows;
+import org.folio.entlinks.domain.dto.AuthoritySearchParameter;
 import org.folio.entlinks.domain.dto.FieldContent;
 import org.folio.entlinks.domain.dto.LinkDetails;
 import org.folio.entlinks.domain.dto.LinkStatus;
@@ -60,6 +61,23 @@ class LinksSuggestionsIT extends IntegrationTestBase {
 
     var requestBody = new ParsedRecordContentCollection().records(List.of(givenRecord));
     doPost(linksSuggestionsEndpoint(), requestBody)
+      .andExpect(status().isOk())
+      .andExpect(content().json(asJson(new ParsedRecordContentCollection()
+        .records(List.of(expectedRecord)), objectMapper)));
+  }
+
+  @Test
+  @SneakyThrows
+  void getAuthDataStat_shouldSuggestNewLinkByAuthorityId() {
+    var givenSubfields = Map.of("9", LINKABLE_AUTHORITY_ID);
+    var givenRecord = getRecord("100", null, givenSubfields);
+
+    var expectedLinkDetails = getLinkDetails(NEW, "oneAuthority");
+    var expectedSubfields = Map.of("a", "new $a value", "0", BASE_URL + "oneAuthority", "9", LINKABLE_AUTHORITY_ID);
+    var expectedRecord = getRecord("100", expectedLinkDetails, expectedSubfields);
+
+    var requestBody = new ParsedRecordContentCollection().records(List.of(givenRecord));
+    doPost(linksSuggestionsEndpoint(AuthoritySearchParameter.ID), requestBody)
       .andExpect(status().isOk())
       .andExpect(content().json(asJson(new ParsedRecordContentCollection()
         .records(List.of(expectedRecord)), objectMapper)));

--- a/src/test/java/org/folio/entlinks/controller/delegate/suggestion/LinksSuggestionServiceDelegateHelperTest.java
+++ b/src/test/java/org/folio/entlinks/controller/delegate/suggestion/LinksSuggestionServiceDelegateHelperTest.java
@@ -1,0 +1,37 @@
+package org.folio.entlinks.controller.delegate.suggestion;
+
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.folio.entlinks.domain.dto.AuthoritySearchParameter;
+import org.folio.spring.test.type.UnitTest;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@UnitTest
+@ExtendWith(MockitoExtension.class)
+class LinksSuggestionServiceDelegateHelperTest {
+
+  @Mock
+  private LinksSuggestionsByAuthorityNaturalId linksSuggestionsByAuthorityNaturalId;
+  @Mock
+  private LinksSuggestionsByAuthorityId linksSuggestionsByAuthorityId;
+
+  @InjectMocks
+  private LinksSuggestionServiceDelegateHelper delegateHelper;
+
+  @Test
+  void getDelegate_positive_id() {
+    var actual = delegateHelper.getDelegate(AuthoritySearchParameter.ID);
+    assertThat(actual).isInstanceOf(LinksSuggestionsByAuthorityId.class);
+  }
+
+  @Test
+  void getDelegate_positive_naturalId() {
+    var actual = delegateHelper.getDelegate(AuthoritySearchParameter.NATURAL_ID);
+    assertThat(actual).isInstanceOf(LinksSuggestionsByAuthorityNaturalId.class);
+  }
+}

--- a/src/test/java/org/folio/entlinks/controller/delegate/suggestion/LinksSuggestionServiceDelegateHelperTest.java
+++ b/src/test/java/org/folio/entlinks/controller/delegate/suggestion/LinksSuggestionServiceDelegateHelperTest.java
@@ -8,6 +8,8 @@ import org.folio.entlinks.domain.dto.AuthoritySearchParameter;
 import org.folio.spring.test.type.UnitTest;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -34,6 +36,13 @@ class LinksSuggestionServiceDelegateHelperTest {
   void getDelegate_positive_naturalId() {
     var actual = delegateHelper.getDelegate(AuthoritySearchParameter.NATURAL_ID);
     assertThat(actual).isInstanceOf(LinksSuggestionsByAuthorityNaturalId.class);
+  }
+
+  @ParameterizedTest
+  @EnumSource(AuthoritySearchParameter.class)
+  void getDelegate_positive_naturalId(AuthoritySearchParameter searchParam) {
+    var actual = delegateHelper.getDelegate(searchParam);
+    assertThat(actual).isNotNull();
   }
 
   @Test

--- a/src/test/java/org/folio/entlinks/controller/delegate/suggestion/LinksSuggestionServiceDelegateHelperTest.java
+++ b/src/test/java/org/folio/entlinks/controller/delegate/suggestion/LinksSuggestionServiceDelegateHelperTest.java
@@ -2,6 +2,7 @@ package org.folio.entlinks.controller.delegate.suggestion;
 
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import org.folio.entlinks.domain.dto.AuthoritySearchParameter;
 import org.folio.spring.test.type.UnitTest;
@@ -33,5 +34,12 @@ class LinksSuggestionServiceDelegateHelperTest {
   void getDelegate_positive_naturalId() {
     var actual = delegateHelper.getDelegate(AuthoritySearchParameter.NATURAL_ID);
     assertThat(actual).isInstanceOf(LinksSuggestionsByAuthorityNaturalId.class);
+  }
+
+  @Test
+  void getDelegate_negative_null() {
+    assertThatThrownBy(() -> delegateHelper.getDelegate(null))
+      .isInstanceOf(IllegalArgumentException.class)
+      .hasMessage("AuthoritySearchParameter must not be null.");
   }
 }

--- a/src/test/java/org/folio/entlinks/controller/delegate/suggestion/LinksSuggestionsByAuthorityIdTest.java
+++ b/src/test/java/org/folio/entlinks/controller/delegate/suggestion/LinksSuggestionsByAuthorityIdTest.java
@@ -1,0 +1,95 @@
+package org.folio.entlinks.controller.delegate.suggestion;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import org.folio.entlinks.client.SourceStorageClient;
+import org.folio.entlinks.controller.converter.SourceContentMapper;
+import org.folio.entlinks.domain.dto.LinkDetails;
+import org.folio.entlinks.domain.entity.AuthorityData;
+import org.folio.entlinks.domain.repository.AuthorityDataRepository;
+import org.folio.entlinks.integration.dto.FieldParsedContent;
+import org.folio.entlinks.integration.internal.SearchService;
+import org.folio.entlinks.service.links.InstanceAuthorityLinkingRulesService;
+import org.folio.entlinks.service.links.LinksSuggestionService;
+import org.folio.spring.test.type.UnitTest;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@UnitTest
+@ExtendWith(MockitoExtension.class)
+class LinksSuggestionsByAuthorityIdTest {
+  @Mock
+  private InstanceAuthorityLinkingRulesService linkingRulesService;
+  @Mock
+  private LinksSuggestionService suggestionService;
+  @Mock
+  private AuthorityDataRepository dataRepository;
+  @Mock
+  private SourceStorageClient sourceStorageClient;
+  @Mock
+  private SourceContentMapper contentMapper;
+  @Mock
+  private SearchService searchService;
+
+  @InjectMocks
+  private LinksSuggestionsByAuthorityId delegate;
+
+  @Test
+  void extractIds_positive() {
+    var authorityId = UUID.randomUUID();
+    var expectedIds = List.of(UUID.randomUUID(), authorityId);
+    var ids = List.of(expectedIds.get(0).toString(), "test", "");
+
+    var subfields = Map.of("9", ids);
+    var linkDetails = new LinkDetails().authorityId(authorityId);
+    var field = new FieldParsedContent("100", "/", "/", subfields, linkDetails);
+
+    var actual = delegate.extractIds(field);
+    assertThat(actual).isEqualTo(new HashSet<>(expectedIds));
+  }
+
+  @Test
+  void extractIds_negative_noSubfieldsAndNullLinkDetails() {
+    var field = new FieldParsedContent("100", "/", "/", new HashMap<>(), null);
+    var actual = delegate.extractIds(field);
+    assertThat(actual).isEmpty();
+  }
+
+  @Test
+  void extractIds_negative_noSubfieldsAndNullAuthorityId() {
+    var field = new FieldParsedContent("100", "/", "/", new HashMap<>(), new LinkDetails());
+    var actual = delegate.extractIds(field);
+    assertThat(actual).isEmpty();
+  }
+
+  @Test
+  void findExistingAuthorities_positive() {
+    var ids = new HashSet<UUID>();
+    delegate.findExistingAuthorities(ids);
+    verify(dataRepository).findAllById(ids);
+  }
+
+  @Test
+  void extractId_positive() {
+    var authorityData = AuthorityData.builder().id(UUID.randomUUID()).build();
+    var actual = delegate.extractId(authorityData);
+    assertThat(actual).isEqualTo(authorityData.getId());
+  }
+
+  @Test
+  void searchAuthorities_positive() {
+    var ids = new HashSet<UUID>();
+    delegate.searchAuthorities(ids);
+    verify(searchService).searchAuthoritiesByIds(new ArrayList<>(ids));
+  }
+}

--- a/src/test/java/org/folio/entlinks/controller/delegate/suggestion/LinksSuggestionsByAuthorityNaturalIdTest.java
+++ b/src/test/java/org/folio/entlinks/controller/delegate/suggestion/LinksSuggestionsByAuthorityNaturalIdTest.java
@@ -1,0 +1,92 @@
+package org.folio.entlinks.controller.delegate.suggestion;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import org.folio.entlinks.client.SourceStorageClient;
+import org.folio.entlinks.controller.converter.SourceContentMapper;
+import org.folio.entlinks.domain.dto.LinkDetails;
+import org.folio.entlinks.domain.entity.AuthorityData;
+import org.folio.entlinks.domain.repository.AuthorityDataRepository;
+import org.folio.entlinks.integration.dto.FieldParsedContent;
+import org.folio.entlinks.integration.internal.SearchService;
+import org.folio.entlinks.service.links.InstanceAuthorityLinkingRulesService;
+import org.folio.entlinks.service.links.LinksSuggestionService;
+import org.folio.spring.test.type.UnitTest;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@UnitTest
+@ExtendWith(MockitoExtension.class)
+class LinksSuggestionsByAuthorityNaturalIdTest {
+  @Mock
+  private InstanceAuthorityLinkingRulesService linkingRulesService;
+  @Mock
+  private LinksSuggestionService suggestionService;
+  @Mock
+  private AuthorityDataRepository dataRepository;
+  @Mock
+  private SourceStorageClient sourceStorageClient;
+  @Mock
+  private SourceContentMapper contentMapper;
+  @Mock
+  private SearchService searchService;
+
+  @InjectMocks
+  private LinksSuggestionsByAuthorityNaturalId delegate;
+
+  @Test
+  void extractIds_positive() {
+    var expectedNaturalIds = List.of("test0", "test1", "test2");
+
+    var subfields = Map.of("0", expectedNaturalIds.subList(0, 2));
+    var linkDetails = new LinkDetails().authorityNaturalId(expectedNaturalIds.get(2));
+    var field = new FieldParsedContent("100", "/", "/", subfields, linkDetails);
+
+    var actual = delegate.extractIds(field);
+    assertThat(actual).isEqualTo(new HashSet<>(expectedNaturalIds));
+  }
+
+  @Test
+  void extractIds_negative_noSubfieldsAndNullLinkDetails() {
+    var field = new FieldParsedContent("100", "/", "/", new HashMap<>(), null);
+    var actual = delegate.extractIds(field);
+    assertThat(actual).isEmpty();
+  }
+
+  @Test
+  void extractIds_negative_noSubfieldsAndNullNaturalId() {
+    var field = new FieldParsedContent("100", "/", "/", new HashMap<>(), new LinkDetails());
+    var actual = delegate.extractIds(field);
+    assertThat(actual).isEmpty();
+  }
+
+  @Test
+  void findExistingAuthorities_positive() {
+    var ids = new HashSet<String>();
+    delegate.findExistingAuthorities(ids);
+    verify(dataRepository).findByNaturalIds(ids);
+  }
+
+  @Test
+  void extractId_positive() {
+    var authorityData = AuthorityData.builder().naturalId("test").build();
+    var actual = delegate.extractId(authorityData);
+    assertThat(actual).isEqualTo(authorityData.getNaturalId());
+  }
+
+  @Test
+  void searchAuthorities_positive() {
+    var ids = new HashSet<String>();
+    delegate.searchAuthorities(ids);
+    verify(searchService).searchAuthoritiesByNaturalIds(new ArrayList<>(ids));
+  }
+}

--- a/src/test/java/org/folio/entlinks/controller/delegate/suggestion/LinksSuggestionsServiceDelegateTest.java
+++ b/src/test/java/org/folio/entlinks/controller/delegate/suggestion/LinksSuggestionsServiceDelegateTest.java
@@ -1,4 +1,4 @@
-package org.folio.entlinks.controller.delegate;
+package org.folio.entlinks.controller.delegate.suggestion;
 
 import static java.util.Collections.emptyList;
 import static java.util.Collections.emptySet;
@@ -57,7 +57,7 @@ class LinksSuggestionsServiceDelegateTest {
   private @Mock AuthorityDataRepository dataRepository;
   private @Mock SourceStorageClient sourceStorageClient;
   private @Mock SearchService searchService;
-  private @InjectMocks LinksSuggestionsServiceDelegate serviceDelegate;
+  private @InjectMocks LinksSuggestionsByAuthorityNaturalId serviceDelegate;
 
   @Test
   void suggestLinksForMarcRecords_shouldSaveAuthoritiesFromSearch() {

--- a/src/test/java/org/folio/entlinks/service/links/InstanceAuthorityLinkingServiceRenovateTest.java
+++ b/src/test/java/org/folio/entlinks/service/links/InstanceAuthorityLinkingServiceRenovateTest.java
@@ -1,0 +1,434 @@
+package org.folio.entlinks.service.links;
+
+import static java.util.Collections.emptyList;
+import static java.util.UUID.randomUUID;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.from;
+import static org.folio.entlinks.domain.dto.LinksChangeEvent.TypeEnum.DELETE;
+import static org.folio.entlinks.domain.dto.LinksChangeEvent.TypeEnum.UPDATE;
+import static org.folio.support.TestDataUtils.getAuthorityRecordsCollection;
+import static org.folio.support.TestDataUtils.links;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.UUID;
+import java.util.stream.Collectors;
+import org.folio.entlinks.client.SourceStorageClient;
+import org.folio.entlinks.domain.dto.LinksChangeEvent;
+import org.folio.entlinks.domain.dto.StrippedParsedRecordCollection;
+import org.folio.entlinks.domain.entity.AuthorityData;
+import org.folio.entlinks.domain.entity.InstanceAuthorityLink;
+import org.folio.entlinks.domain.repository.InstanceLinkRepository;
+import org.folio.entlinks.exception.DeletedLinkingAuthorityException;
+import org.folio.entlinks.exception.RequestBodyValidationException;
+import org.folio.entlinks.integration.internal.AuthoritySourceFilesService;
+import org.folio.entlinks.integration.internal.SearchService;
+import org.folio.entlinks.integration.kafka.EventProducer;
+import org.folio.spring.test.type.UnitTest;
+import org.folio.support.TestDataUtils.Link;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Spy;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+/**
+ * Created to test renovate logic separately from regular update.
+ * Merge with InstanceAuthorityLinkingServiceTest when renovate fixed / delete in case approach not needed.
+ * Problems with renovation described in MODELINKS-113.
+ * */
+@UnitTest
+@ExtendWith(MockitoExtension.class)
+class InstanceAuthorityLinkingServiceRenovateTest {
+
+  private final AuthoritySourceFilesService sourceFilesService = mock(AuthoritySourceFilesService.class);
+  private final RenovateLinksService renovateLinksService = spy(new RenovateLinksService(sourceFilesService));
+
+  @Mock
+  private InstanceLinkRepository instanceLinkRepository;
+  @Mock
+  private AuthorityDataService authorityDataService;
+  @Mock
+  private SearchService searchService;
+  @Mock
+  private SourceStorageClient sourceStorageClient;
+  @Mock
+  private InstanceAuthorityLinkingRulesService linkingRulesService;
+  @Spy
+  private AuthorityRuleValidationService authorityRuleValidationService;
+  @Mock
+  private EventProducer<LinksChangeEvent> eventProducer;
+
+  @InjectMocks
+  private InstanceAuthorityLinkingService service;
+
+  @Test
+  void updateLinksRenovate_positive_saveIncomingLinks_whenAnyExist() {
+    final var instanceId = randomUUID();
+    final var existedLinks = Collections.<InstanceAuthorityLink>emptyList();
+    final var incomingLinks = links(instanceId, Link.of(0, 0), Link.of(1, 1));
+
+    when(linkingRulesService.getLinkingRules()).thenReturn(incomingLinks.stream()
+      .map(InstanceAuthorityLink::getLinkingRule)
+      .toList());
+    mockAuthorities(incomingLinks);
+    when(instanceLinkRepository.findByInstanceId(any(UUID.class))).thenReturn(existedLinks);
+    doNothing().when(instanceLinkRepository).deleteAllInBatch(any());
+    when(instanceLinkRepository.saveAll(any())).thenReturn(emptyList());
+
+    service.updateLinksWithRenovation(instanceId, incomingLinks);
+
+    var saveCaptor = linksCaptor();
+    var deleteCaptor = linksCaptor();
+    var eventsCaptor = linksEventCaptor();
+    verify(instanceLinkRepository).saveAll(saveCaptor.capture());
+    verify(instanceLinkRepository).deleteAllInBatch(deleteCaptor.capture());
+    verify(eventProducer, times(1)).sendMessages(eventsCaptor.capture());
+
+    assertThat(saveCaptor.getValue()).hasSize(2)
+      .extracting(link -> link.getLinkingRule().getBibField())
+      .containsOnly(Link.TAGS[0], Link.TAGS[1]);
+
+    assertThat(deleteCaptor.getValue()).isEmpty();
+
+    var events = eventsCaptor.getValue();
+    assertThat(events).hasSize(2)
+      .extracting(LinksChangeEvent::getType)
+      .allMatch(UPDATE::equals);
+
+    events.forEach(event -> assertThat(event.getSubfieldsChanges().get(0).getSubfields())
+      .anyMatch(subfieldChange -> subfieldChange.getCode().equals("0")
+        && incomingLinks.stream()
+        .anyMatch(link -> event.getSubfieldsChanges().get(0).getField().equals(link.getLinkingRule().getBibField())
+          && subfieldChange.getValue().equals(link.getAuthorityData().getNaturalId())))
+      .anyMatch(subfieldChange -> subfieldChange.getCode().equals("a")
+        && subfieldChange.getValue().equals("test")));
+  }
+
+  @Test
+  void updateLinksRenovate_positive_deleteAllLinks_whenIncomingIsEmpty() {
+    final var instanceId = randomUUID();
+    final var existedLinks = links(instanceId, Link.of(0, 0), Link.of(1, 1));
+    final var incomingLinks = Collections.<InstanceAuthorityLink>emptyList();
+
+    when(instanceLinkRepository.findByInstanceId(any(UUID.class))).thenReturn(existedLinks);
+    doNothing().when(instanceLinkRepository).deleteAllInBatch(any());
+    when(instanceLinkRepository.saveAll(any())).thenReturn(emptyList());
+
+    service.updateLinksWithRenovation(instanceId, incomingLinks);
+
+    var saveCaptor = linksCaptor();
+    var deleteCaptor = linksCaptor();
+    verify(instanceLinkRepository).saveAll(saveCaptor.capture());
+    verify(instanceLinkRepository).deleteAllInBatch(deleteCaptor.capture());
+    verifyNoInteractions(eventProducer);
+
+    assertThat(saveCaptor.getValue()).isEmpty();
+
+    assertThat(deleteCaptor.getValue()).hasSize(2)
+      .extracting(link -> link.getLinkingRule().getBibField())
+      .containsOnly(Link.TAGS[0], Link.TAGS[1]);
+  }
+
+  @Test
+  void updateLinksRenovate_positive_deleteAllExistedAndSaveAllIncomingLinks() {
+    final var instanceId = randomUUID();
+    final var existedLinks = links(instanceId,
+      Link.of(0, 0),
+      Link.of(1, 1),
+      Link.of(2, 2),
+      Link.of(3, 3)
+    );
+    final var incomingLinks = links(instanceId,
+      Link.of(0, 1),
+      Link.of(1, 0),
+      Link.of(2, 3),
+      Link.of(3, 2)
+    );
+
+    when(linkingRulesService.getLinkingRules()).thenReturn(incomingLinks.stream()
+      .map(InstanceAuthorityLink::getLinkingRule)
+      .toList());
+    mockAuthorities(incomingLinks);
+    when(instanceLinkRepository.findByInstanceId(instanceId)).thenReturn(existedLinks);
+    doNothing().when(instanceLinkRepository).deleteAllInBatch(any());
+    when(instanceLinkRepository.saveAll(any())).thenReturn(emptyList());
+
+    service.updateLinksWithRenovation(instanceId, incomingLinks);
+
+    var saveCaptor = linksCaptor();
+    var deleteCaptor = linksCaptor();
+    var eventsCaptor = linksEventCaptor();
+    verify(instanceLinkRepository).saveAll(saveCaptor.capture());
+    verify(instanceLinkRepository).deleteAllInBatch(deleteCaptor.capture());
+    verify(eventProducer, times(1)).sendMessages(eventsCaptor.capture());
+
+    assertThat(saveCaptor.getValue()).hasSize(4)
+      .extracting(link -> link.getLinkingRule().getBibField())
+      .containsOnly(Link.TAGS[0], Link.TAGS[1], Link.TAGS[2], Link.TAGS[3]);
+
+    assertThat(deleteCaptor.getValue()).hasSize(4)
+      .extracting(link -> link.getLinkingRule().getBibField())
+      .containsOnly(Link.TAGS[0], Link.TAGS[1], Link.TAGS[2], Link.TAGS[3]);
+
+    assertThat(eventsCaptor.getValue()).hasSize(4)
+      .extracting(LinksChangeEvent::getType)
+      .allMatch(UPDATE::equals);
+  }
+
+  @Test
+  void updateLinksRenovate_positive_saveOnlyNewLinks() {
+    final var instanceId = randomUUID();
+    final var existedLinks = links(instanceId,
+      Link.of(0, 0),
+      Link.of(1, 1)
+    );
+    final var incomingLinks = links(instanceId,
+      Link.of(0, 0),
+      Link.of(1, 1),
+      Link.of(2, 2),
+      Link.of(3, 3)
+    );
+
+    when(linkingRulesService.getLinkingRules()).thenReturn(incomingLinks.stream()
+      .map(InstanceAuthorityLink::getLinkingRule)
+      .toList());
+    mockAuthorities(incomingLinks);
+    when(instanceLinkRepository.findByInstanceId(instanceId)).thenReturn(existedLinks);
+    doNothing().when(instanceLinkRepository).deleteAllInBatch(any());
+    when(instanceLinkRepository.saveAll(any())).thenReturn(emptyList());
+
+    service.updateLinksWithRenovation(instanceId, incomingLinks);
+
+    var saveCaptor = linksCaptor();
+    var deleteCaptor = linksCaptor();
+    var eventsCaptor = linksEventCaptor();
+    verify(instanceLinkRepository).saveAll(saveCaptor.capture());
+    verify(instanceLinkRepository).deleteAllInBatch(deleteCaptor.capture());
+    verify(eventProducer, times(1)).sendMessages(eventsCaptor.capture());
+
+    assertThat(saveCaptor.getValue()).hasSize(4)
+      .extracting(link -> link.getLinkingRule().getBibField())
+      .containsOnly(Link.TAGS[0], Link.TAGS[1], Link.TAGS[2], Link.TAGS[3]);
+
+    assertThat(deleteCaptor.getValue()).isEmpty();
+
+    assertThat(eventsCaptor.getValue()).hasSize(4)
+      .extracting(LinksChangeEvent::getType)
+      .allMatch(UPDATE::equals);
+  }
+
+  @Test
+  void updateLinksRenovate_positive_deleteAndSaveLinks_whenHaveDifference() {
+    final var instanceId = randomUUID();
+    final var existedLinks = links(instanceId,
+      Link.of(0, 0),
+      Link.of(1, 1),
+      Link.of(2, 2),
+      Link.of(3, 3)
+    );
+    final var incomingLinks = links(instanceId,
+      Link.of(0, 0),
+      Link.of(1, 1),
+      Link.of(2, 3),
+      Link.of(3, 2)
+    );
+
+    when(linkingRulesService.getLinkingRules()).thenReturn(incomingLinks.stream()
+      .map(InstanceAuthorityLink::getLinkingRule)
+      .toList());
+    mockAuthorities(incomingLinks);
+    when(instanceLinkRepository.findByInstanceId(instanceId)).thenReturn(existedLinks);
+    doNothing().when(instanceLinkRepository).deleteAllInBatch(any());
+    when(instanceLinkRepository.saveAll(any())).thenReturn(emptyList());
+
+    service.updateLinksWithRenovation(instanceId, incomingLinks);
+
+    var saveCaptor = linksCaptor();
+    var deleteCaptor = linksCaptor();
+    var eventsCaptor = linksEventCaptor();
+    verify(instanceLinkRepository).saveAll(saveCaptor.capture());
+    verify(instanceLinkRepository).deleteAllInBatch(deleteCaptor.capture());
+    verify(eventProducer, times(1)).sendMessages(eventsCaptor.capture());
+
+    assertThat(saveCaptor.getValue()).hasSize(4)
+      .extracting(link -> link.getLinkingRule().getBibField())
+      .containsOnly(Link.TAGS[0], Link.TAGS[1], Link.TAGS[2], Link.TAGS[3]);
+
+    assertThat(deleteCaptor.getValue()).hasSize(2)
+      .extracting(link -> link.getLinkingRule().getBibField())
+      .containsOnly(Link.TAGS[2], Link.TAGS[3]);
+
+    assertThat(eventsCaptor.getValue()).hasSize(4)
+      .extracting(LinksChangeEvent::getType)
+      .allMatch(UPDATE::equals);
+  }
+
+  @Test
+  void updateLinksRenovate_positive_deleteAndSaveLinks_whenSomeAuthorityDeleted() {
+    final var instanceId = randomUUID();
+    final var existedLinks = links(instanceId,
+      Link.of(0, 0),
+      Link.of(1, 1),
+      Link.of(2, 2),
+      Link.of(3, 3)
+    );
+    final var incomingLinks = links(instanceId,
+      Link.of(0, 0),
+      Link.of(1, 1),
+      Link.of(2, 3),
+      Link.of(3, 2)
+    );
+
+    when(linkingRulesService.getLinkingRules()).thenReturn(incomingLinks.stream()
+      .map(InstanceAuthorityLink::getLinkingRule)
+      .toList());
+    mockAuthorities(incomingLinks.subList(0, incomingLinks.size() - 1));
+    when(instanceLinkRepository.findByInstanceId(instanceId)).thenReturn(existedLinks);
+    doNothing().when(instanceLinkRepository).deleteAllInBatch(any());
+    when(instanceLinkRepository.saveAll(any())).thenReturn(emptyList());
+
+    service.updateLinksWithRenovation(instanceId, incomingLinks);
+
+    var saveCaptor = linksCaptor();
+    var deleteCaptor = linksCaptor();
+    var eventsCaptor = linksEventCaptor();
+    verify(instanceLinkRepository).saveAll(saveCaptor.capture());
+    verify(instanceLinkRepository).deleteAllInBatch(deleteCaptor.capture());
+    verify(eventProducer, times(1)).sendMessages(eventsCaptor.capture());
+
+    assertThat(saveCaptor.getValue()).hasSize(3)
+      .extracting(link -> link.getLinkingRule().getBibField())
+      .containsOnly(Link.TAGS[0], Link.TAGS[1], Link.TAGS[3]);
+
+    assertThat(deleteCaptor.getValue()).hasSize(2)
+      .extracting(link -> link.getLinkingRule().getBibField())
+      .containsOnly(Link.TAGS[2], Link.TAGS[3]);
+
+    var events = eventsCaptor.getAllValues();
+    assertThat(events.get(0)).hasSize(4)
+      .extracting(LinksChangeEvent::getType)
+      .containsExactlyInAnyOrder(UPDATE, UPDATE, UPDATE, DELETE);
+  }
+
+  @Test
+  void updateLinksRenovate_negative_whenAuthoritiesAreDeletedForIncomingLinks() {
+    final var instanceId = randomUUID();
+    var incomingLinks = links(instanceId,
+      Link.of(0, 0),
+      Link.of(1, 1),
+      Link.of(2, 3),
+      Link.of(3, 2)
+    );
+    var authorityIds = incomingLinks.stream()
+      .map(link -> link.getAuthorityData().getId())
+      .collect(Collectors.toSet());
+    var deletedAuthorityIds = incomingLinks.stream()
+      .map(link -> link.getAuthorityData().getId())
+      .limit(2)
+      .collect(Collectors.toSet());
+    var authorityDataMock = deletedAuthorityIds.stream()
+      .map(authorityId -> new AuthorityData(authorityId, "deleted", true))
+      .toList();
+
+    when(authorityDataService.getByIdAndDeleted(authorityIds, true)).thenReturn(authorityDataMock);
+
+    var exception = Assertions.assertThrows(DeletedLinkingAuthorityException.class,
+      () -> service.updateLinksWithRenovation(instanceId, incomingLinks));
+
+    assertThat(exception)
+      .hasMessage("Cannot save links to deleted authorities.")
+      .extracting(RequestBodyValidationException::getInvalidParameters)
+      .returns(2, from(List::size));
+  }
+
+  @Test
+  void updateLinksRenovate_positive_deleteAndSaveLinks_whenSomeAuthorityChangedToNotLinkable() {
+    final var instanceId = randomUUID();
+    final var existedLinks = links(instanceId,
+      Link.of(0, 0),
+      Link.of(1, 1),
+      Link.of(2, 2),
+      Link.of(3, 3)
+    );
+    final var incomingLinks = links(instanceId,
+      Link.of(0, 0),
+      Link.of(1, 1),
+      Link.of(2, 3),
+      Link.of(3, 2)
+    );
+    var linksForValidAuthorities = incomingLinks.subList(1, incomingLinks.size());
+    var linksForInvalidAuthorities = incomingLinks.subList(0, 1);
+    var authorityRecordsMock = getAuthorityRecordsCollection(linksForValidAuthorities, linksForInvalidAuthorities);
+
+    when(linkingRulesService.getLinkingRules()).thenReturn(incomingLinks.stream()
+      .map(InstanceAuthorityLink::getLinkingRule)
+      .toList());
+    mockAuthorities(incomingLinks, authorityRecordsMock);
+    when(instanceLinkRepository.findByInstanceId(instanceId)).thenReturn(existedLinks);
+    doNothing().when(instanceLinkRepository).deleteAllInBatch(any());
+    when(instanceLinkRepository.saveAll(any())).thenReturn(emptyList());
+
+    service.updateLinksWithRenovation(instanceId, incomingLinks);
+
+    var saveCaptor = linksCaptor();
+    var deleteCaptor = linksCaptor();
+    var eventsCaptor = linksEventCaptor();
+    verify(instanceLinkRepository).saveAll(saveCaptor.capture());
+    verify(instanceLinkRepository).deleteAllInBatch(deleteCaptor.capture());
+    verify(eventProducer, times(1)).sendMessages(eventsCaptor.capture());
+
+    assertThat(saveCaptor.getValue()).hasSize(3)
+      .extracting(link -> link.getLinkingRule().getBibField())
+      .containsOnly(Link.TAGS[1], Link.TAGS[2], Link.TAGS[3]);
+
+    assertThat(deleteCaptor.getValue()).hasSize(3)
+      .extracting(link -> link.getLinkingRule().getBibField())
+      .containsOnly(Link.TAGS[0], Link.TAGS[2], Link.TAGS[3]);
+
+    var events = eventsCaptor.getAllValues();
+    assertThat(events.get(0)).hasSize(4)
+      .extracting(LinksChangeEvent::getType)
+      .containsExactlyInAnyOrder(UPDATE, UPDATE, UPDATE, DELETE);
+  }
+
+  private void mockAuthorities(List<InstanceAuthorityLink> links) {
+    mockAuthorities(links, getAuthorityRecordsCollection(links));
+  }
+
+  @SuppressWarnings("unchecked")
+  private void mockAuthorities(List<InstanceAuthorityLink> links, StrippedParsedRecordCollection authorityRecords) {
+    final var authorityDataSet = links.stream()
+      .map(InstanceAuthorityLink::getAuthorityData)
+      .toList();
+
+    when(searchService.searchAuthoritiesByIds(any())).thenReturn(authorityDataSet);
+    when(sourceStorageClient.fetchParsedRecordsInBatch(any())).thenReturn(authorityRecords);
+    when(authorityDataService.saveAll(any(Collection.class)))
+      .thenAnswer(invocation -> ((Collection<AuthorityData>) invocation.getArgument(0)).stream()
+        .collect(Collectors.toMap(AuthorityData::getId, a -> a)));
+  }
+
+  private ArgumentCaptor<List<InstanceAuthorityLink>> linksCaptor() {
+    @SuppressWarnings("unchecked") var listClass = (Class<List<InstanceAuthorityLink>>) (Class<?>) List.class;
+    return ArgumentCaptor.forClass(listClass);
+  }
+
+  private ArgumentCaptor<List<LinksChangeEvent>> linksEventCaptor() {
+    @SuppressWarnings("unchecked") var listClass = (Class<List<LinksChangeEvent>>) (Class<?>) List.class;
+    return ArgumentCaptor.forClass(listClass);
+  }
+
+}

--- a/src/test/java/org/folio/support/base/TestConstants.java
+++ b/src/test/java/org/folio/support/base/TestConstants.java
@@ -4,6 +4,7 @@ import static org.folio.support.KafkaTestUtils.fullTopicName;
 
 import java.time.OffsetDateTime;
 import lombok.experimental.UtilityClass;
+import org.folio.entlinks.domain.dto.AuthoritySearchParameter;
 import org.folio.entlinks.domain.dto.LinkAction;
 import org.folio.entlinks.domain.dto.LinkStatus;
 
@@ -46,6 +47,10 @@ public class TestConstants {
 
   public static String linksSuggestionsEndpoint() {
     return LINKS_SUGGESTIONS_ENDPOINT;
+  }
+
+  public static String linksSuggestionsEndpoint(AuthoritySearchParameter authoritySearchParameter) {
+    return LINKS_SUGGESTIONS_ENDPOINT + "?authoritySearchParameter=" + authoritySearchParameter;
   }
 
   public static String linkingRulesEndpoint() {

--- a/src/test/resources/mappings/mod-search.json
+++ b/src/test/resources/mappings/mod-search.json
@@ -29,6 +29,19 @@
     {
       "request": {
         "method": "GET",
+        "url": "/search/authorities?query=authRefType%3DAuthorized%20and%20%28id%3D417f3355-081c-4aae-9209-ccb305f25f7e%29&includeNumberOfTitles=false"
+      },
+      "response": {
+        "status": 200,
+        "body": "{\"totalRecords\": 1, \"authorities\": [{\"id\": \"417f3355-081c-4aae-9209-ccb305f25f7e\",\n\"headingType\": \"Conference Name\",\n\"authRefType\": \"Authorized\",\n\"headingRef\": \"Western Region Agricultural Education Research Meeting Title value\",\n\"numberOfTitles\": 0,\n\"sourceFileId\": \"af045f2f-e851-4613-984c-4bc13430454a\",\n\"naturalId\": \"oneAuthority\"}]}",
+        "headers": {
+          "Content-Type": "application/json"
+        }
+      }
+    },
+    {
+      "request": {
+        "method": "GET",
         "url": "/search/authorities?query=authRefType%3DAuthorized%20and%20%28naturalId%3D%22noAuthority%22%29&includeNumberOfTitles=false"
       },
       "response": {


### PR DESCRIPTION
## Purpose
Extend "links suggestions" with some flag so it can search authorities by authorityId or naturalId based on provided flag value (for our case we need to search by authorityId)
Move "renovation" logic to a separate method so PUT endoint behave like before and renovation logic preserved for later purposes
[MODELINKS-113](https://issues.folio.org/browse/MODELINKS-113)

## Approach
- Remove links renovation from 'PUT' links endpoint
- Extend links suggestions endpoint with 'authoritySearchField' to support suggestions by authorityId

### Changes checklist
- [x] API paths, methods, request or response bodies changed, added, or removed
- [ ] Database schema changes
- [x] Interface versions changes
- [ ] Interface dependencies added, or removed
- [ ] Permissions changed, added, or removed
- [x] Check logging.

### TODOS and Open Questions
- [ ] Should we implement automatic definition of linking match point (remove new api parameter, check both $0 and $9 fields and find authorities by both, exclusive) later in the future?
