### PR TITLE
fix(links-suggestions): Fix 'ignoreAutoLinkingEnabled' flag handling

### DIFF
--- a/src/main/java/org/folio/entlinks/service/links/LinksSuggestionService.java
+++ b/src/main/java/org/folio/entlinks/service/links/LinksSuggestionService.java
@@ -3,6 +3,7 @@ package org.folio.entlinks.service.links;
 import static java.util.Objects.isNull;
 import static org.apache.commons.collections4.CollectionUtils.isNotEmpty;
 import static org.apache.commons.lang3.BooleanUtils.isFalse;
+import static org.apache.commons.lang3.StringUtils.isEmpty;
 import static org.folio.entlinks.domain.dto.LinkStatus.ERROR;
 import static org.folio.entlinks.domain.dto.LinkStatus.NEW;
 import static org.folio.entlinks.service.links.model.LinksSuggestionErrorCode.DISABLED_AUTO_LINKING;
@@ -64,9 +65,24 @@ public class LinksSuggestionService {
   public void fillErrorDetailsWithNoSuggestions(List<SourceParsedContent> marcBibsContent,
                                                 String linkingMatchSubfield) {
     marcBibsContent.stream()
-      .flatMap(bibContent -> bibContent.getFields().stream())
-      .filter(fieldContent -> containsSubfield(fieldContent, linkingMatchSubfield))
-      .forEach(bibField -> bibField.setLinkDetails(getErrorDetails(NO_SUGGESTIONS)));
+        .flatMap(bibContent -> bibContent.getFields().stream())
+        .filter(fieldContent -> containsSubfield(fieldContent, linkingMatchSubfield))
+        .filter(fieldContent -> Optional.ofNullable(fieldContent.getLinkDetails())
+            .map(linkDetails -> isEmpty(linkDetails.getErrorCause()))
+            .orElse(true))
+        .forEach(bibField -> bibField.setLinkDetails(getErrorDetails(NO_SUGGESTIONS)));
+  }
+
+  /**
+   * Fill bib fields with no suggestions error detail, if it contains subfields.
+   *
+   * @param field list of bib records {@link FieldParsedContent}
+   */
+  public void fillErrorDetailsWithDisabledAutoLinking(FieldParsedContent field,
+                                                      String linkingMatchSubfield) {
+    if (containsSubfield(field, linkingMatchSubfield)) {
+      field.setLinkDetails(getErrorDetails(DISABLED_AUTO_LINKING));
+    }
   }
 
   private void suggestAuthorityForBibFields(List<FieldParsedContent> bibFields,

--- a/src/test/java/org/folio/entlinks/controller/delegate/suggestion/LinksSuggestionsServiceDelegateTest.java
+++ b/src/test/java/org/folio/entlinks/controller/delegate/suggestion/LinksSuggestionsServiceDelegateTest.java
@@ -6,6 +6,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 import java.util.ArrayList;
@@ -174,6 +175,23 @@ class LinksSuggestionsServiceDelegateTest {
     verify(sourceStorageClient, times(0)).fetchParsedRecordsInBatch(any());
   }
 
+  @Test
+  void suggestLinksForMarcRecords_shouldFillError_ifAutoLinkingDisabled() {
+    var record = getRecord("100", Map.of("0", "test"));
+    var rules = List.of(getRule("100", false));
+
+    when(linkingRulesService.getLinkingRules()).thenReturn(rules);
+    when(dataRepository.findByNaturalIds(emptySet())).thenReturn(emptyList());
+
+    var parsedContentCollection = new ParsedRecordContentCollection().records(List.of(record));
+    serviceDelegate.suggestLinksForMarcRecords(parsedContentCollection, false);
+
+    verify(dataRepository).findByNaturalIds(emptySet());
+    verifyNoInteractions(searchService);
+    verifyNoInteractions(sourceStorageClient);
+    verify(suggestionService).fillErrorDetailsWithDisabledAutoLinking(any(), any());
+  }
+
   private ParsedRecordContent getRecord(String bibField) {
     return getRecord(bibField, Map.of("a", "test"));
   }
@@ -188,6 +206,10 @@ class LinksSuggestionsServiceDelegateTest {
   }
 
   private InstanceAuthorityLinkingRule getRule(String bibField) {
+    return getRule(bibField, true);
+  }
+
+  private InstanceAuthorityLinkingRule getRule(String bibField, Boolean autoLinkingEnabled) {
     var modification = new SubfieldModification().source("a").target("b");
     var existence = Map.of("a", true);
 
@@ -195,7 +217,7 @@ class LinksSuggestionsServiceDelegateTest {
     rule.setId(1);
     rule.setBibField(bibField);
     rule.setAuthorityField("100");
-    rule.setAutoLinkingEnabled(true);
+    rule.setAutoLinkingEnabled(autoLinkingEnabled);
     rule.setAuthoritySubfields(new char[] {'a', 'b'});
     rule.setSubfieldModifications(List.of(modification));
     rule.setSubfieldsExistenceValidations(existence);

--- a/src/test/java/org/folio/entlinks/service/links/LinksSuggestionsServiceTest.java
+++ b/src/test/java/org/folio/entlinks/service/links/LinksSuggestionsServiceTest.java
@@ -24,6 +24,7 @@ import org.folio.entlinks.integration.dto.FieldParsedContent;
 import org.folio.entlinks.integration.dto.SourceParsedContent;
 import org.folio.entlinks.integration.internal.AuthoritySourceFilesService;
 import org.folio.spring.test.type.UnitTest;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
@@ -203,6 +204,36 @@ class LinksSuggestionsServiceTest {
     assertEquals(BASE_URL + NATURAL_ID, bibSubfields.get("0").get(0));
     assertFalse(bibSubfields.containsKey("a"));
     assertTrue(bibSubfields.containsKey("b"));
+  }
+
+  @Test
+  void shouldFillErrorDetailsWithNoSuggestions_onlyForFieldWithNoError() {
+    var bibs = List.of(getBibParsedRecordContent("100", getActualLinksDetails()),
+        getBibParsedRecordContent("101", getActualLinksDetails().errorCause("test")));
+
+    linksSuggestionService.fillErrorDetailsWithNoSuggestions(bibs, "0");
+
+    assertEquals("101", bibs.get(0).getFields().get(0).getLinkDetails().getErrorCause());
+    assertEquals("test", bibs.get(1).getFields().get(0).getLinkDetails().getErrorCause());
+  }
+
+  @Test
+  void shouldFillErrorDetailsWithDisabledAutoLinking() {
+    var field = new FieldParsedContent("100", "//", "//",
+        Map.of(NATURAL_ID_SUBFIELD, List.of(NATURAL_ID)), null);
+
+    linksSuggestionService.fillErrorDetailsWithDisabledAutoLinking(field, "0");
+
+    assertEquals("103", field.getLinkDetails().getErrorCause());
+  }
+
+  @Test
+  void shouldNotFillErrorDetailsWithDisabledAutoLinking_whenNoSubfield() {
+    var field = new FieldParsedContent("100", "//", "//", Map.of(), null);
+
+    linksSuggestionService.fillErrorDetailsWithDisabledAutoLinking(field, "0");
+
+    assertNull(field.getLinkDetails());
   }
 
   private AuthorityParsedContent getAuthorityParsedRecordContent(String authorityField) {


### PR DESCRIPTION
## Purpose
Fix 'ignoreAutoLinkingEnabled' flag handling

## Approach
- Check flag in delegate also
- Fill appropriate error when only autolinking error field

### Changes checklist
- [ ] API paths, methods, request or response bodies changed, added, or removed
- [ ] Database schema changes
- [ ] Interface versions changes
- [ ] Interface dependencies added, or removed
- [ ] Permissions changed, added, or removed
- [ ] Check logging.
