### PR TITLE
MODELINKS-120: Don't add "mapping-metadata.get" and "mapping-rules.get"

### DIFF
--- a/src/main/resources/permissions/mod-entities-links-permissions.csv
+++ b/src/main/resources/permissions/mod-entities-links-permissions.csv
@@ -32,7 +32,5 @@ inventory-storage.modes-of-issuance.collection.get
 inventory-storage.nature-of-content-terms.collection.get
 inventory-storage.statistical-code-types.collection.get
 inventory-storage.statistical-codes.collection.get
-mapping-metadata.get
-mapping-rules.get
 source-storage.sourceRecords.get
 users.collection.get


### PR DESCRIPTION
https://issues.folio.org/browse/MODELINKS-120

Don't add "mapping-metadata.get" and "mapping-rules.get" permissions to the system user because they belong to mod-source-record-manager that hasn't been enabled at this time.