### PR TITLE
fix: change reference data behaviour

### DIFF
--- a/src/main/java/org/folio/entlinks/config/JpaConfig.java
+++ b/src/main/java/org/folio/entlinks/config/JpaConfig.java
@@ -2,6 +2,8 @@ package org.folio.entlinks.config;
 
 import java.util.Optional;
 import java.util.UUID;
+import java.util.function.Supplier;
+import lombok.extern.log4j.Log4j2;
 import org.folio.spring.FolioExecutionContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -9,13 +11,24 @@ import org.springframework.data.domain.AuditorAware;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 import org.springframework.retry.annotation.EnableRetry;
 
+@Log4j2
 @Configuration
 @EnableJpaAuditing(auditorAwareRef = "auditorProvider")
 @EnableRetry
 public class JpaConfig {
 
+  private static final UUID DEFAULT_USER_ID = UUID.fromString("00000000-0000-0000-0000-000000000000");
+
   @Bean
   public AuditorAware<UUID> auditorProvider(FolioExecutionContext folioExecutionContext) {
-    return () -> Optional.ofNullable(folioExecutionContext.getUserId());
+    return () -> Optional.ofNullable(folioExecutionContext.getUserId()).or(useDefault());
+  }
+
+  private Supplier<Optional<UUID>> useDefault() {
+    return () -> {
+      log.warn("Current auditor cannot be determined from execution context. userId is NULL");
+
+      return Optional.of(DEFAULT_USER_ID);
+    };
   }
 }

--- a/src/main/java/org/folio/entlinks/service/tenant/ExtendedTenantService.java
+++ b/src/main/java/org/folio/entlinks/service/tenant/ExtendedTenantService.java
@@ -5,7 +5,6 @@ import org.folio.entlinks.service.dataloader.ReferenceDataLoader;
 import org.folio.spring.FolioExecutionContext;
 import org.folio.spring.liquibase.FolioSpringLiquibase;
 import org.folio.spring.service.PrepareSystemUserService;
-import org.folio.spring.service.SystemUserScopedExecutionService;
 import org.folio.spring.service.TenantService;
 import org.folio.spring.tools.kafka.KafkaAdminService;
 import org.folio.tenant.domain.dto.TenantAttributes;
@@ -19,7 +18,6 @@ import org.springframework.stereotype.Service;
 public class ExtendedTenantService extends TenantService {
 
   private final PrepareSystemUserService folioPrepareSystemUserService;
-  private final SystemUserScopedExecutionService systemUserScopedExecutionService;
   private final FolioExecutionContext folioExecutionContext;
   private final KafkaAdminService kafkaAdminService;
   private final ReferenceDataLoader referenceDataLoader;
@@ -30,13 +28,11 @@ public class ExtendedTenantService extends TenantService {
                                FolioSpringLiquibase folioSpringLiquibase,
                                FolioExecutionContext folioExecutionContext,
                                PrepareSystemUserService folioPrepareSystemUserService,
-                               SystemUserScopedExecutionService systemUserScopedExecutionService,
                                ReferenceDataLoader referenceDataLoader) {
     super(jdbcTemplate, context, folioSpringLiquibase);
     this.folioPrepareSystemUserService = folioPrepareSystemUserService;
     this.folioExecutionContext = folioExecutionContext;
     this.kafkaAdminService = kafkaAdminService;
-    this.systemUserScopedExecutionService = systemUserScopedExecutionService;
     this.referenceDataLoader = referenceDataLoader;
   }
 
@@ -56,10 +52,6 @@ public class ExtendedTenantService extends TenantService {
 
   @Override
   public void loadReferenceData() {
-    systemUserScopedExecutionService.executeSystemUserScoped(context.getTenantId(),
-      () -> {
-        referenceDataLoader.loadRefData();
-        return null;
-      });
+    referenceDataLoader.loadRefData();
   }
 }


### PR DESCRIPTION
## Approach
We can't build system-user context on POST _/tenant because dependant modules like mod-login and mod-authtoken are not ready to handle requests even if dependency is set in module descriptor

