### PR TITLE
MODELINKS-132: Fix Optimistic Locking and Make authority version always increase in update

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
 
     <folio-spring-base.version>7.2.0</folio-spring-base.version>
     <hypersistence-utils-hibernate.version>3.5.1</hypersistence-utils-hibernate.version>
-    <folio-service-tools.version>3.1.0-SNAPSHOT</folio-service-tools.version>
+    <folio-service-tools.version>3.1.0</folio-service-tools.version>
     <mapstruct.version>1.5.5.Final</mapstruct.version>
     <lombok.mapstruct-binding.version>0.2.0</lombok.mapstruct-binding.version>
     <marc4j.version>2.9.5</marc4j.version>

--- a/src/main/java/org/folio/entlinks/controller/ApiErrorHandler.java
+++ b/src/main/java/org/folio/entlinks/controller/ApiErrorHandler.java
@@ -22,6 +22,7 @@ import java.util.Optional;
 import lombok.extern.log4j.Log4j2;
 import org.apache.logging.log4j.Level;
 import org.folio.entlinks.config.constants.ErrorCode;
+import org.folio.entlinks.exception.OptimisticLockingException;
 import org.folio.entlinks.exception.RequestBodyValidationException;
 import org.folio.entlinks.exception.ResourceNotFoundException;
 import org.folio.entlinks.exception.type.ErrorType;
@@ -61,6 +62,11 @@ public class ApiErrorHandler {
   @ExceptionHandler(ResourceNotFoundException.class)
   public ResponseEntity<Errors> handleNotFoundException(ResourceNotFoundException e) {
     return buildResponseEntity(e, NOT_FOUND, ErrorType.NOT_FOUND_ERROR);
+  }
+
+  @ExceptionHandler(OptimisticLockingException.class)
+  public ResponseEntity<Errors> handleOptimisticLockingException(OptimisticLockingException e) {
+    return buildResponseEntity(e, HttpStatus.CONFLICT, ErrorType.OPTIMISTIC_LOCKING_ERROR);
   }
 
   @ExceptionHandler(RequestBodyValidationException.class)

--- a/src/main/java/org/folio/entlinks/exception/OptimisticLockingException.java
+++ b/src/main/java/org/folio/entlinks/exception/OptimisticLockingException.java
@@ -1,0 +1,19 @@
+package org.folio.entlinks.exception;
+
+import java.util.UUID;
+
+public final class OptimisticLockingException extends RuntimeException {
+
+  private OptimisticLockingException(String errorMessage) {
+    super(errorMessage);
+  }
+
+  public static OptimisticLockingException optimisticLockingOnUpdate(UUID recordId,
+                                                                     int existingVersion,
+                                                                     int requestVersion) {
+    var errorMessage = String.format("Cannot update record %s because it has been changed (optimistic locking): "
+        + "Stored _version is %d, _version of request is %d",
+        recordId.toString(), existingVersion, requestVersion);
+    return new OptimisticLockingException(errorMessage);
+  }
+}

--- a/src/main/java/org/folio/entlinks/exception/type/ErrorType.java
+++ b/src/main/java/org/folio/entlinks/exception/type/ErrorType.java
@@ -10,6 +10,7 @@ public enum ErrorType {
   VALIDATION_ERROR("validation"),
   NOT_FOUND_ERROR("not-found"),
   INTEGRATION_ERROR("intregration-error"),
+  OPTIMISTIC_LOCKING_ERROR("optimistic locking"),
   UNKNOWN_ERROR("unknown");
 
   private final String value;

--- a/src/test/java/org/folio/entlinks/controller/AuthorityControllerIT.java
+++ b/src/test/java/org/folio/entlinks/controller/AuthorityControllerIT.java
@@ -15,12 +15,9 @@ import static org.folio.support.base.TestConstants.USER_ID;
 import static org.folio.support.base.TestConstants.authorityEndpoint;
 import static org.folio.support.base.TestConstants.authoritySourceFilesEndpoint;
 import static org.folio.support.base.TestConstants.authorityTopic;
-import static org.hamcrest.CoreMatchers.anyOf;
 import static org.hamcrest.CoreMatchers.containsString;
-import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.lessThan;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
@@ -30,8 +27,6 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.BlockingQueue;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.TimeUnit;
 import javax.annotation.Nullable;
@@ -42,6 +37,7 @@ import org.folio.entlinks.domain.dto.AuthorityDtoCollection;
 import org.folio.entlinks.domain.entity.Authority;
 import org.folio.entlinks.exception.AuthorityNotFoundException;
 import org.folio.entlinks.exception.AuthoritySourceFileNotFoundException;
+import org.folio.entlinks.exception.OptimisticLockingException;
 import org.folio.entlinks.service.reindex.event.DomainEvent;
 import org.folio.spring.integration.XOkapiHeaders;
 import org.folio.spring.test.extension.DatabaseCleanup;
@@ -52,7 +48,6 @@ import org.hamcrest.Matcher;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -368,42 +363,6 @@ class AuthorityControllerIT extends IntegrationTestBase {
   }
 
   @Test
-  @Disabled("behaves un-deterministically and thus disable for now")
-  @DisplayName("PUT: repeated update of Authority without modification")
-  void updateConcurrently_positive_notAllShouldSucceedAndAtLeastOneShouldFail() throws Exception {
-    var dto = authorityDto(0, 0);
-    createSourceFile(0);
-
-    doPost(authorityEndpoint(), dto);
-    getReceivedEvent();
-    var existingAsString = doGet(authorityEndpoint()).andReturn().getResponse().getContentAsString();
-    var collection = objectMapper.readValue(existingAsString, AuthorityDtoCollection.class);
-    var expected = collection.getAuthorities().get(0);
-    var sources = List.of("source a", "source b", "source c", "source d");
-
-    int concurrency = 4;
-    ExecutorService executor = Executors.newFixedThreadPool(concurrency);
-    for (var source : sources) {
-      executor.execute(() -> {
-        expected.setSource(source);
-        doPut(authorityEndpoint(expected.getId()), expected);
-      });
-    }
-    executor.shutdown();
-    assertTrue(executor.awaitTermination(2, TimeUnit.MINUTES));
-
-    doGet(authorityEndpoint(expected.getId()))
-      .andExpect(jsonPath("_version", lessThan(concurrency)))
-      .andExpect(jsonPath("source",
-        anyOf(equalTo("source a"), equalTo("source b"),
-          equalTo("source c"), equalTo("source d"))))
-      .andExpect(jsonPath("metadata.createdDate", notNullValue()))
-      .andExpect(jsonPath("metadata.updatedDate", notNullValue()))
-      .andExpect(jsonPath("metadata.updatedByUserId", is(USER_ID)))
-      .andExpect(jsonPath("metadata.createdByUserId", is(USER_ID)));
-  }
-
-  @Test
   @DisplayName("PUT: update Authority with non-existing source file id")
   void updateAuthority_negative_notUpdatedWithNonExistingSourceFile() throws Exception {
     var dto = authorityDto(0, 0);
@@ -421,6 +380,30 @@ class AuthorityControllerIT extends IntegrationTestBase {
       .andExpect(status().isNotFound())
       .andExpect(errorMessageMatch(is("Authority Source File with ID [" + sourceFileId + "] was not found")))
       .andExpect(exceptionMatch(AuthoritySourceFileNotFoundException.class));
+  }
+
+  @Test
+  @DisplayName("PUT: repeated update of Authority with old version")
+  void repeatedUpdateWithOldVersion_negative_shouldReturnOptimisticLockingError() throws Exception {
+    getReceivedEvent();
+    var dto = authorityDto(0, 0);
+    createSourceFile(0);
+
+    doPost(authorityEndpoint(), dto);
+    getReceivedEvent();
+    var existingAsString = doGet(authorityEndpoint())
+        .andExpect(jsonPath("authorities[0]._version", is(0)))
+        .andReturn().getResponse().getContentAsString();
+    var collection = objectMapper.readValue(existingAsString, AuthorityDtoCollection.class);
+    var putDto = collection.getAuthorities().get(0);
+    var expectedError = String.format("Cannot update record %s because it has been changed (optimistic locking): "
+            + "Stored _version is %d, _version of request is %d", putDto.getId().toString(), 1, 0);
+
+    tryPut(authorityEndpoint(putDto.getId()), putDto).andExpect(status().isNoContent());
+    tryPut(authorityEndpoint(putDto.getId()), putDto)
+        .andExpect(status().isConflict())
+        .andExpect(errorMessageMatch(is(expectedError)))
+        .andExpect(exceptionMatch(OptimisticLockingException.class));
   }
 
   @Test

--- a/src/test/java/org/folio/entlinks/service/authority/AuthorityServiceTest.java
+++ b/src/test/java/org/folio/entlinks/service/authority/AuthorityServiceTest.java
@@ -19,6 +19,7 @@ import org.folio.entlinks.domain.repository.AuthorityRepository;
 import org.folio.entlinks.domain.repository.AuthoritySourceFileRepository;
 import org.folio.entlinks.exception.AuthorityNotFoundException;
 import org.folio.entlinks.exception.AuthoritySourceFileNotFoundException;
+import org.folio.entlinks.exception.OptimisticLockingException;
 import org.folio.entlinks.exception.RequestBodyValidationException;
 import org.folio.spring.test.type.UnitTest;
 import org.junit.jupiter.api.Test;
@@ -27,7 +28,6 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.dao.OptimisticLockingFailureException;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
 
@@ -171,10 +171,11 @@ class AuthorityServiceTest {
 
     when(repository.findByIdAndDeletedFalse(id)).thenReturn(Optional.of(existing));
 
-    var thrown = assertThrows(OptimisticLockingFailureException.class, () -> service.update(id, modified));
+    var thrown = assertThrows(OptimisticLockingException.class, () -> service.update(id, modified));
 
     assertThat(thrown.getMessage())
-        .isEqualTo("Authority was already modified. Existing version: 1, Version with changes: 0");
+        .isEqualTo("Cannot update record " + id + " because it has been changed (optimistic locking): "
+            + "Stored _version is 1, _version of request is 0");
     verifyNoMoreInteractions(repository);
   }
 


### PR DESCRIPTION
## Purpose
_The version of Authority is not increased if there are no any changes in update operation. This contradicts with what we had before migrating Authority to mod-entities-links. Make the version of Authority change in every update operation._

## Approach
_Indicate an authority entity as modified so that it gets updated by entity manager_

### Changes checklist
- [ ] API paths, methods, request or response bodies changed, added, or removed
- [ ] Database schema changes
- [ ] Interface versions changes
- [ ] Interface dependencies added, or removed
- [ ] Permissions changed, added, or removed
- [ ] Check logging.

### Learning
[_MODELINKS-132_](https://issues.folio.org/browse/MODELINKS-132)
