### PR TITLE
MODELINKS-124: Add missing permission for user-tenants

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -156,7 +156,8 @@
           ],
           "modulePermissions": [
             "source-storage.records.fetch",
-            "search.authorities.collection.get"
+            "search.authorities.collection.get",
+            "user-tenants.collection.get"
           ]
         }
       ]


### PR DESCRIPTION
## Purpose
_Add permission for getting user tenants for links suggestions API._

## Approach
_Add missing permission_

### Learning
[_MODELINKS-124_](https://issues.folio.org/browse/MODELINKS-124)
