### PR TITLE
fix(instance-authority-linking): Propagate central tenant authority links update to member tenants

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
 
     <folio-spring-base.version>7.2.0</folio-spring-base.version>
     <hypersistence-utils-hibernate.version>3.5.1</hypersistence-utils-hibernate.version>
-    <folio-service-tools.version>3.1.0-SNAPSHOT</folio-service-tools.version>
+    <folio-service-tools.version>3.1.0</folio-service-tools.version>
     <mapstruct.version>1.5.5.Final</mapstruct.version>
     <lombok.mapstruct-binding.version>0.2.0</lombok.mapstruct-binding.version>
     <marc4j.version>2.9.5</marc4j.version>

--- a/src/main/java/org/folio/entlinks/controller/delegate/AuthorityServiceDelegate.java
+++ b/src/main/java/org/folio/entlinks/controller/delegate/AuthorityServiceDelegate.java
@@ -1,8 +1,8 @@
 package org.folio.entlinks.controller.delegate;
 
-import static org.folio.entlinks.service.consortium.propagation.ConsortiumAuthorityPropagationService.PropagationType.CREATE;
-import static org.folio.entlinks.service.consortium.propagation.ConsortiumAuthorityPropagationService.PropagationType.DELETE;
-import static org.folio.entlinks.service.consortium.propagation.ConsortiumAuthorityPropagationService.PropagationType.UPDATE;
+import static org.folio.entlinks.service.consortium.propagation.ConsortiumPropagationService.PropagationType.CREATE;
+import static org.folio.entlinks.service.consortium.propagation.ConsortiumPropagationService.PropagationType.DELETE;
+import static org.folio.entlinks.service.consortium.propagation.ConsortiumPropagationService.PropagationType.UPDATE;
 
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/org/folio/entlinks/controller/delegate/LinkingServiceDelegate.java
+++ b/src/main/java/org/folio/entlinks/controller/delegate/LinkingServiceDelegate.java
@@ -23,8 +23,8 @@ import org.folio.entlinks.domain.dto.LinksCountDtoCollection;
 import org.folio.entlinks.domain.dto.UuidCollection;
 import org.folio.entlinks.exception.RequestBodyValidationException;
 import org.folio.entlinks.integration.internal.InstanceStorageService;
-import org.folio.entlinks.service.consortium.propagation.ConsortiumAuthorityPropagationService;
 import org.folio.entlinks.service.consortium.propagation.ConsortiumLinksPropagationService;
+import org.folio.entlinks.service.consortium.propagation.ConsortiumPropagationService;
 import org.folio.entlinks.service.links.InstanceAuthorityLinkingService;
 import org.folio.spring.FolioExecutionContext;
 import org.folio.tenant.domain.dto.Parameter;
@@ -73,7 +73,7 @@ public class LinkingServiceDelegate {
     validateLinks(instanceId, links);
     var incomingLinks = mapper.convertDto(links);
     linkingService.updateLinks(instanceId, incomingLinks);
-    propagationService.propagate(incomingLinks, ConsortiumAuthorityPropagationService.PropagationType.UPDATE,
+    propagationService.propagate(incomingLinks, ConsortiumPropagationService.PropagationType.UPDATE,
       context.getTenantId());
   }
 

--- a/src/main/java/org/folio/entlinks/service/consortium/propagation/ConsortiumAuthorityDataStatsPropagationService.java
+++ b/src/main/java/org/folio/entlinks/service/consortium/propagation/ConsortiumAuthorityDataStatsPropagationService.java
@@ -24,7 +24,7 @@ public class ConsortiumAuthorityDataStatsPropagationService
 
   @Override
   protected void doPropagation(List<AuthorityDataStat> authorityDataStats,
-                               ConsortiumAuthorityPropagationService.PropagationType propagationType) {
+                               PropagationType propagationType) {
     switch (propagationType) {
       case CREATE -> authorityDataStatService.createInBatch(authorityDataStats);
       case UPDATE, DELETE -> throw new IllegalArgumentException(ILLEGAL_PROPAGATION_MSG.formatted(propagationType));

--- a/src/main/java/org/folio/entlinks/service/consortium/propagation/ConsortiumAuthorityPropagationService.java
+++ b/src/main/java/org/folio/entlinks/service/consortium/propagation/ConsortiumAuthorityPropagationService.java
@@ -30,7 +30,4 @@ public class ConsortiumAuthorityPropagationService extends ConsortiumPropagation
     }
   }
 
-  public enum PropagationType {
-    CREATE, UPDATE, DELETE
-  }
 }

--- a/src/main/java/org/folio/entlinks/service/consortium/propagation/ConsortiumLinksPropagationService.java
+++ b/src/main/java/org/folio/entlinks/service/consortium/propagation/ConsortiumLinksPropagationService.java
@@ -23,7 +23,7 @@ public class ConsortiumLinksPropagationService extends ConsortiumPropagationServ
 
   @Override
   protected void doPropagation(List<InstanceAuthorityLink> links,
-                               ConsortiumAuthorityPropagationService.PropagationType propagationType) {
+                               PropagationType propagationType) {
     switch (propagationType) {
       case CREATE, DELETE -> throw new IllegalArgumentException(ILLEGAL_PROPAGATION_MSG.formatted(propagationType));
       case UPDATE -> instanceAuthorityLinkingService.updateLinks(links.get(0).getInstanceId(), links);

--- a/src/main/java/org/folio/entlinks/service/consortium/propagation/ConsortiumPropagationService.java
+++ b/src/main/java/org/folio/entlinks/service/consortium/propagation/ConsortiumPropagationService.java
@@ -19,7 +19,7 @@ public abstract class ConsortiumPropagationService<T> {
   }
 
   @Async
-  public void propagate(T entity, ConsortiumAuthorityPropagationService.PropagationType propagationType,
+  public void propagate(T entity, PropagationType propagationType,
                         String tenantId) {
     log.info("Try to propagate [entity: {}, propagationType: {}, context: {}]", entity.getClass().getSimpleName(),
       propagationType, tenantId);
@@ -38,5 +38,9 @@ public abstract class ConsortiumPropagationService<T> {
   }
 
   protected abstract void doPropagation(T entity,
-                                        ConsortiumAuthorityPropagationService.PropagationType propagationType);
+                                        PropagationType propagationType);
+
+  public enum PropagationType {
+    CREATE, UPDATE, DELETE
+  }
 }

--- a/src/main/java/org/folio/entlinks/service/messaging/authority/model/AuthorityChangeHolder.java
+++ b/src/main/java/org/folio/entlinks/service/messaging/authority/model/AuthorityChangeHolder.java
@@ -13,6 +13,7 @@ import org.folio.entlinks.domain.entity.Authority;
 import org.folio.entlinks.domain.entity.AuthorityDataStat;
 import org.folio.entlinks.domain.entity.AuthorityDataStatAction;
 import org.folio.entlinks.integration.dto.AuthorityDomainEvent;
+import org.folio.entlinks.integration.dto.AuthoritySourceRecord;
 import org.folio.entlinks.service.reindex.event.DomainEventType;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -24,12 +25,25 @@ public class AuthorityChangeHolder {
   private final @NotNull AuthorityDomainEvent event;
   private final @NotNull Map<AuthorityChangeField, AuthorityChange> changes;
   private final @NotNull Map<AuthorityChangeField, String> fieldTagRelation;
-  @Getter
-  private final int numberOfLinks;
 
   @Getter
   @Setter
+  private int numberOfLinks;
+  @Getter
+  @Setter
   private UUID authorityDataStatId;
+  @Getter
+  @Setter
+  private AuthoritySourceRecord sourceRecord;
+
+  public AuthorityChangeHolder(@NotNull AuthorityDomainEvent event,
+                               @NotNull Map<AuthorityChangeField, AuthorityChange> changes,
+                               @NotNull Map<AuthorityChangeField, String> fieldTagRelation, int numberOfLinks) {
+    this.event = event;
+    this.changes = changes;
+    this.fieldTagRelation = fieldTagRelation;
+    this.numberOfLinks = numberOfLinks;
+  }
 
   public UUID getAuthorityId() {
     return event.getId();
@@ -160,6 +174,12 @@ public class AuthorityChangeHolder {
 
   private boolean isHeadingTypeChanged() {
     return changes.size() > 2 || changes.size() == 2 && !changes.containsKey(AuthorityChangeField.NATURAL_ID);
+  }
+
+  public AuthorityChangeHolder copy() {
+    var copy = new AuthorityChangeHolder(event, changes, fieldTagRelation);
+    copy.setSourceRecord(sourceRecord);
+    return copy;
   }
 
 }

--- a/src/test/java/org/folio/entlinks/controller/delegate/AuthorityServiceDelegateTest.java
+++ b/src/test/java/org/folio/entlinks/controller/delegate/AuthorityServiceDelegateTest.java
@@ -1,8 +1,8 @@
 package org.folio.entlinks.controller.delegate;
 
-import static org.folio.entlinks.service.consortium.propagation.ConsortiumAuthorityPropagationService.PropagationType.CREATE;
-import static org.folio.entlinks.service.consortium.propagation.ConsortiumAuthorityPropagationService.PropagationType.DELETE;
-import static org.folio.entlinks.service.consortium.propagation.ConsortiumAuthorityPropagationService.PropagationType.UPDATE;
+import static org.folio.entlinks.service.consortium.propagation.ConsortiumPropagationService.PropagationType.CREATE;
+import static org.folio.entlinks.service.consortium.propagation.ConsortiumPropagationService.PropagationType.DELETE;
+import static org.folio.entlinks.service.consortium.propagation.ConsortiumPropagationService.PropagationType.UPDATE;
 import static org.folio.support.base.TestConstants.TENANT_ID;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;

--- a/src/test/java/org/folio/entlinks/service/consortium/propagation/ConsortiumAuthorityDataStatsPropagationServiceTest.java
+++ b/src/test/java/org/folio/entlinks/service/consortium/propagation/ConsortiumAuthorityDataStatsPropagationServiceTest.java
@@ -1,7 +1,7 @@
 package org.folio.entlinks.service.consortium.propagation;
 
-import static org.folio.entlinks.service.consortium.propagation.ConsortiumAuthorityPropagationService.PropagationType.CREATE;
-import static org.folio.entlinks.service.consortium.propagation.ConsortiumAuthorityPropagationService.PropagationType.UPDATE;
+import static org.folio.entlinks.service.consortium.propagation.ConsortiumPropagationService.PropagationType.CREATE;
+import static org.folio.entlinks.service.consortium.propagation.ConsortiumPropagationService.PropagationType.UPDATE;
 import static org.folio.support.base.TestConstants.TENANT_ID;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;

--- a/src/test/java/org/folio/entlinks/service/messaging/authority/InstanceAuthorityLinkUpdateServiceTest.java
+++ b/src/test/java/org/folio/entlinks/service/messaging/authority/InstanceAuthorityLinkUpdateServiceTest.java
@@ -4,25 +4,37 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.folio.support.base.TestConstants.TENANT_ID;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
+import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
+import java.util.concurrent.Callable;
 import org.folio.entlinks.domain.dto.AuthorityDto;
 import org.folio.entlinks.domain.dto.LinksChangeEvent;
 import org.folio.entlinks.integration.dto.AuthorityDomainEvent;
+import org.folio.entlinks.integration.dto.AuthoritySourceRecord;
+import org.folio.entlinks.integration.internal.AuthoritySourceRecordService;
 import org.folio.entlinks.integration.kafka.EventProducer;
+import org.folio.entlinks.service.consortium.ConsortiumTenantsService;
 import org.folio.entlinks.service.links.AuthorityDataStatService;
 import org.folio.entlinks.service.links.InstanceAuthorityLinkingService;
 import org.folio.entlinks.service.messaging.authority.handler.AuthorityChangeHandler;
+import org.folio.entlinks.service.messaging.authority.model.AuthorityChangeHolder;
 import org.folio.entlinks.service.messaging.authority.model.AuthorityChangeType;
 import org.folio.entlinks.service.reindex.event.DomainEventType;
+import org.folio.spring.FolioExecutionContext;
+import org.folio.spring.service.SystemUserScopedExecutionService;
 import org.folio.spring.test.type.UnitTest;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -36,7 +48,8 @@ import org.mockito.junit.jupiter.MockitoExtension;
 @ExtendWith(MockitoExtension.class)
 class InstanceAuthorityLinkUpdateServiceTest {
 
-  private @Captor ArgumentCaptor<List<LinksChangeEvent>> argumentCaptor;
+  private @Captor ArgumentCaptor<List<LinksChangeEvent>> eventCaptor;
+  private @Captor ArgumentCaptor<List<AuthorityChangeHolder>> changeHolderCaptor;
 
   private @Mock EventProducer<LinksChangeEvent> eventProducer;
   private @Mock AuthorityDataStatService authorityDataStatService;
@@ -45,6 +58,10 @@ class InstanceAuthorityLinkUpdateServiceTest {
   private @Mock AuthorityChangeHandler deleteHandler;
   private @Mock AuthorityMappingRulesProcessingService mappingRulesProcessingService;
   private @Mock InstanceAuthorityLinkingService linkingService;
+  private @Mock AuthoritySourceRecordService sourceRecordService;
+  private @Mock ConsortiumTenantsService consortiumTenantsService;
+  private @Mock FolioExecutionContext folioExecutionContext;
+  private @Mock SystemUserScopedExecutionService executionService;
 
   private InstanceAuthorityLinkUpdateService service;
 
@@ -54,32 +71,42 @@ class InstanceAuthorityLinkUpdateServiceTest {
     when(deleteHandler.supportedAuthorityChangeType()).thenReturn(AuthorityChangeType.DELETE);
 
     service = new InstanceAuthorityLinkUpdateService(authorityDataStatService,
-      mappingRulesProcessingService, linkingService, eventProducer, List.of(updateHandler, deleteHandler));
+      mappingRulesProcessingService, linkingService, eventProducer, List.of(updateHandler, deleteHandler),
+      sourceRecordService, consortiumTenantsService, folioExecutionContext, executionService);
   }
 
   @Test
   void handleAuthoritiesChanges_positive_updateEvent() {
     final var id = UUID.randomUUID();
     final var authorityEvents = List.of(
-      new AuthorityDomainEvent(id, null, new AuthorityDto().naturalId("new"), DomainEventType.UPDATE, TENANT_ID));
+      new AuthorityDomainEvent(id, null, new AuthorityDto().naturalId("new").personalName("test"),
+          DomainEventType.UPDATE, TENANT_ID));
+    final var sourceRecord = new AuthoritySourceRecord(null, null, null);
 
     var expected = new LinksChangeEvent().type(LinksChangeEvent.TypeEnum.UPDATE);
     when(linkingService.countLinksByAuthorityIds(Set.of(id))).thenReturn(Map.of(id, 1));
-    when(updateHandler.handle(anyList())).thenReturn(List.of(expected));
+    when(sourceRecordService.getAuthoritySourceRecordById(any())).thenReturn(sourceRecord);
+    when(updateHandler.handle(changeHolderCaptor.capture())).thenReturn(List.of(expected));
 
     service.handleAuthoritiesChanges(authorityEvents);
 
-    verify(eventProducer).sendMessages(argumentCaptor.capture());
+    verify(eventProducer).sendMessages(eventCaptor.capture());
     verify(authorityDataStatService).createInBatch(anyList());
     verifyNoMoreInteractions(authorityDataStatService);
 
-    var messages = argumentCaptor.getValue();
+    var changeHolders = changeHolderCaptor.getValue();
+
+    assertThat(changeHolders)
+        .isNotEmpty()
+        .allMatch(changeHolder -> changeHolder.getSourceRecord() == sourceRecord);
+
+    var messages = eventCaptor.getValue();
     assertThat(messages).hasSize(1);
     assertThat(messages.get(0).getType()).isEqualTo(LinksChangeEvent.TypeEnum.UPDATE);
   }
 
   @Test
-  void handleAuthoritiesChanges_positive_updateEventWhenNoLinksExist() {
+  void handleAuthoritiesChanges_positive_updateEventWhenNoLinksExistAndOnlyNaturalIdChanged() {
     final var id = UUID.randomUUID();
     final var authorityEvents = List.of(
       new AuthorityDomainEvent(id, null, new AuthorityDto().naturalId("new"), DomainEventType.UPDATE, TENANT_ID));
@@ -88,9 +115,10 @@ class InstanceAuthorityLinkUpdateServiceTest {
 
     service.handleAuthoritiesChanges(authorityEvents);
 
-    verify(eventProducer, never()).sendMessages(argumentCaptor.capture());
+    verify(eventProducer, never()).sendMessages(eventCaptor.capture());
     verify(authorityDataStatService).createInBatch(anyList());
     verifyNoMoreInteractions(authorityDataStatService);
+    verifyNoInteractions(sourceRecordService);
   }
 
   @Test
@@ -106,11 +134,58 @@ class InstanceAuthorityLinkUpdateServiceTest {
 
     service.handleAuthoritiesChanges(authorityEvents);
 
-    verify(eventProducer).sendMessages(argumentCaptor.capture());
+    verify(eventProducer).sendMessages(eventCaptor.capture());
     verify(authorityDataStatService).createInBatch(anyList());
+    verifyNoInteractions(sourceRecordService);
 
-    var messages = argumentCaptor.getValue();
+    var messages = eventCaptor.getValue();
     assertThat(messages).hasSize(1);
     assertThat(messages.get(0).getType()).isEqualTo(LinksChangeEvent.TypeEnum.DELETE);
+  }
+
+  @Test
+  void handleAuthoritiesChanges_positive_updateEventOnConsortiumCentralTenant() {
+    final var id = UUID.randomUUID();
+    final var authorityEvents = List.of(
+        new AuthorityDomainEvent(id, null, new AuthorityDto().naturalId("new").personalName("test"),
+            DomainEventType.UPDATE, TENANT_ID));
+    final var sourceRecord = new AuthoritySourceRecord(null, null, null);
+    final var memberTenants = List.of("tenant1", "tenant2");
+
+    var expected = new LinksChangeEvent().type(LinksChangeEvent.TypeEnum.UPDATE);
+    when(linkingService.countLinksByAuthorityIds(Set.of(id)))
+        .thenReturn(Map.of(id, 1))
+        .thenReturn(Map.of(id, 2))
+        .thenReturn(Map.of(id, 3));
+    when(sourceRecordService.getAuthoritySourceRecordById(any())).thenReturn(sourceRecord);
+    when(updateHandler.handle(changeHolderCaptor.capture())).thenReturn(List.of(expected));
+    when(folioExecutionContext.getTenantId()).thenReturn(TENANT_ID);
+    when(consortiumTenantsService.getConsortiumTenants(TENANT_ID)).thenReturn(memberTenants);
+    mockExecutionService();
+
+    service.handleAuthoritiesChanges(authorityEvents);
+
+    verify(eventProducer, times(3)).sendMessages(eventCaptor.capture());
+    verify(executionService).executeSystemUserScoped(eq(memberTenants.get(0)), any());
+    verify(executionService).executeSystemUserScoped(eq(memberTenants.get(1)), any());
+
+    var messages = eventCaptor.getAllValues().stream().flatMap(Collection::stream).toList();
+    assertThat(messages).hasSize(3);
+    assertThat(messages.get(0).getType()).isEqualTo(LinksChangeEvent.TypeEnum.UPDATE);
+
+    var changeHolders = changeHolderCaptor.getAllValues().stream().flatMap(Collection::stream).toList();
+    assertThat(changeHolders)
+        .hasSize(3)
+        .allMatch(changeHolder -> changeHolder.getSourceRecord() == sourceRecord)
+        .extracting(AuthorityChangeHolder::getNumberOfLinks)
+        .containsExactlyInAnyOrder(1, 2, 3);
+
+    verify(authorityDataStatService, times(3)).createInBatch(anyList());
+  }
+
+  @SuppressWarnings("unchecked")
+  private void mockExecutionService() {
+    doAnswer(invocationOnMock -> ((Callable<Object>) invocationOnMock.getArgument(1)).call())
+        .when(executionService).executeSystemUserScoped(any(), any());
   }
 }

--- a/src/test/java/org/folio/entlinks/service/messaging/authority/handler/UpdateAuthorityChangeHandlerTest.java
+++ b/src/test/java/org/folio/entlinks/service/messaging/authority/handler/UpdateAuthorityChangeHandlerTest.java
@@ -76,13 +76,12 @@ class UpdateAuthorityChangeHandlerTest {
     expected.setStatus(LinkUpdateReport.StatusEnum.FAIL);
 
     when(mappingRulesProcessingService.getTagByAuthorityChangeField(any())).thenReturn("notExistingTag");
-    when(sourceRecordService.getAuthoritySourceRecordById(any()))
-      .thenReturn(new AuthoritySourceRecord(id, UUID.randomUUID(), new RecordImpl()));
 
     var changes = Map.of(
       AuthorityChangeField.PERSONAL_NAME, new AuthorityChange(AuthorityChangeField.PERSONAL_NAME, "new", "old")
     );
     var event = new AuthorityChangeHolder(new AuthorityDomainEvent(id), changes, emptyMap(), 0);
+    event.setSourceRecord(new AuthoritySourceRecord(id, UUID.randomUUID(), new RecordImpl()));
     handler.handle(List.of(event));
 
     verify(linksUpdateKafkaTemplate).sendMessages(producerRecord.capture());


### PR DESCRIPTION
## Purpose
We should update shared links/bibs on member tenants when authority is updated/deleted on central tenant

## Approach
- Retrieve source record only for central tenant
- Handle authority update for each of member tenants

### Changes checklist
- [ ] API paths, methods, request or response bodies changed, added, or removed
- [ ] Database schema changes
- [ ] Interface versions changes
- [ ] Interface dependencies added, or removed
- [ ] Permissions changed, added, or removed
- [ ] Check logging.

### TODOS and Open Questions
- [ ] Do we need ConsortiumAuthorityDataStatsPropagationService? It's not used and separate authority data stats are created for shadow authorities during authority change handling so maybe it can be removed
