### PR TITLE
fix(authority): updating authority's source file field to null

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -10,7 +10,7 @@
 * Description ([ISSUE_NUMBER](https://issues.folio.org/browse/ISSUE_NUMBER))
 
 ### Bug fixes
-* Description ([ISSUE_NUMBER](https://issues.folio.org/browse/ISSUE_NUMBER))
+* Updating authority's source file field to null is failed ([MODELINKS-143](https://issues.folio.org/browse/MODELINKS-143))
 
 ### Tech Dept
 * Description ([ISSUE_NUMBER](https://issues.folio.org/browse/ISSUE_NUMBER))

--- a/src/main/java/org/folio/entlinks/service/authority/AuthorityService.java
+++ b/src/main/java/org/folio/entlinks/service/authority/AuthorityService.java
@@ -117,11 +117,11 @@ public class AuthorityService {
 
     Optional.ofNullable(modified.getAuthoritySourceFile())
       .map(AuthoritySourceFile::getId)
-      .ifPresent(sourceFileId -> {
+      .ifPresentOrElse(sourceFileId -> {
         var sourceFile = new AuthoritySourceFile();
         sourceFile.setId(sourceFileId);
         existing.setAuthoritySourceFile(sourceFile);
-      });
+      }, () -> existing.setAuthoritySourceFile(null));
   }
 
   private void validateSourceFile(Authority authority) {


### PR DESCRIPTION
## Purpose
Fix updating authority's source file field to null failed

## Approach
Set null when incoming records has null in source file field

### Changes checklist
- [ ] API paths, methods, request or response bodies changed, added, or removed
- [ ] Database schema changes
- [ ] Interface versions changes
- [ ] Interface dependencies added, or removed
- [ ] Permissions changed, added, or removed
- [ ] Check logging.

### Learning
https://issues.folio.org/browse/MODELINKS-143
