### PR TITLE
fix: remove foreign key for authority_data_stat

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -7,12 +7,13 @@
 * Requires `API_NAME vX.Y`
 
 ### Features
-* Implement Authority Archiving for deleted authoritites ([MODELINKS-138](https://issues.folio.org/browse/MODELINKS-138))
+* Implement Authority Archiving for deleted authorities ([MODELINKS-138](https://issues.folio.org/browse/MODELINKS-138))
 
 ### Bug fixes
 * Fix secure setup of system users by default ([MODELINKS-135](https://issues.folio.org/browse/MODELINKS-135))
 * Updating authority's source file field to null is failed ([MODELINKS-143](https://issues.folio.org/browse/MODELINKS-143))
 * Failed to send update event if sourceFile is null ([MODELINKS-144](https://issues.folio.org/browse/MODELINKS-144))
+* Remove foreign key for authority_data_stat ([MODELINKS-155](https://issues.folio.org/browse/MODELINKS-155))
 
 ### Tech Dept
 * Description ([ISSUE_NUMBER](https://issues.folio.org/browse/ISSUE_NUMBER))

--- a/src/main/resources/db/changelog/changes/v2.0/replace_authority_data.xml
+++ b/src/main/resources/db/changelog/changes/v2.0/replace_authority_data.xml
@@ -84,26 +84,4 @@
                              onDelete="CASCADE"/>
   </changeSet>
 
-  <changeSet id="MODELINKS-2@@add-authority_data_stat-authority_id-foreign-key" author="Mukhiddin_Yusupov">
-    <preConditions onFail="MARK_RAN">
-      <and>
-        <tableExists tableName="authority"/>
-        <tableExists tableName="authority_data_stat"/>
-        <not>
-          <foreignKeyConstraintExists foreignKeyName="fk_authority_data_stat_authority_id"
-                                      schemaName="${database.defaultSchemaName}"
-                                      foreignKeyTableName="authority_data_stat"/>
-        </not>
-      </and>
-    </preConditions>
-
-    <comment>Add FK for authority_id in authority_data_stat referenced to authority.id</comment>
-
-    <addForeignKeyConstraint baseTableName="authority_data_stat"
-                             baseColumnNames="authority_id"
-                             referencedTableName="authority"
-                             referencedColumnNames="id"
-                             constraintName="fk_authority_data_stat_authority_id"/>
-  </changeSet>
-
 </databaseChangeLog>


### PR DESCRIPTION
### Purpose
Fix migration issue

### Approach
Remove foreign key for authority_data_stat.
Decided to remove the FK because we will not be able to handle it due to moving deleted authorities to the archive table. We can't just remove rows from the stats table as this data still could be needed for the user.

### Changes Checklist
- [ ] **API Changes**: List any API paths, methods, request or response bodies changed, added, or removed.
- [ ] **Database Schema Changes**: Specify any database schema changes and their impact.
- [ ] **Interface Version Changes**: Indicate any changes to interface versions.
- [ ] **Interface Dependencies**: Note added or removed dependencies.
- [ ] **Permissions**: Document any changes to permissions.
- [ ] **Logging**: Confirm that logging is appropriately handled.
- [ ] **NEWS**: Ensure that the `NEWS` file is updated with relevant information about the changes made in this pull request.

### Related Issues
_List any Jira issues related to this pull request._

### Learning and Resources (if applicable)
_Discuss any research conducted during the development of this pull request. Include links to relevant blog posts, patterns, libraries, or addons that were used to solve the problem._

### Screenshots (if applicable)
_If this pull request involves any visual changes or new features, consider including screenshots or GIFs to illustrate the changes._
