### PR TITLE
feat(consortium): Propagate authority source files to member tenants

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -14,6 +14,7 @@
 * Change the AuthoritySourceType field type from String to Enum([MODELINKS-170](https://issues.folio.org/browse/MODELINKS-170))
 * Prohibit update/delete of authority consortium shadow copy([MODELINKS-174](https://issues.folio.org/browse/MODELINKS-174))
 * Prohibit authority source files creation from consortium member tenant([MODELINKS-174](https://issues.folio.org/browse/MODELINKS-174))
+* Propagate authority source files to member tenants([MODELINKS-175](https://issues.folio.org/browse/MODELINKS-175))
 
 ### Bug fixes
 * Fix secure setup of system users by default ([MODELINKS-135](https://issues.folio.org/browse/MODELINKS-135))

--- a/src/main/java/org/folio/entlinks/domain/entity/AuthoritySourceFile.java
+++ b/src/main/java/org/folio/entlinks/domain/entity/AuthoritySourceFile.java
@@ -127,4 +127,12 @@ public class AuthoritySourceFile extends MetadataEntity implements Persistable<U
   void markNotNew() {
     this.isNew = false;
   }
+
+  public void markAsConsortiumShadowCopy() {
+    this.setSource(AuthoritySourceFileSource.CONSORTIUM);
+  }
+
+  public boolean isConsortiumShadowCopy() {
+    return AuthoritySourceFileSource.CONSORTIUM.equals(this.getSource());
+  }
 }

--- a/src/main/java/org/folio/entlinks/service/authority/AuthoritySourceFileService.java
+++ b/src/main/java/org/folio/entlinks/service/authority/AuthoritySourceFileService.java
@@ -7,7 +7,6 @@ import java.util.List;
 import java.util.Objects;
 import java.util.UUID;
 import java.util.stream.Collectors;
-import javax.annotation.Nonnull;
 import lombok.AllArgsConstructor;
 import lombok.extern.log4j.Log4j2;
 import org.apache.commons.lang3.StringUtils;
@@ -77,7 +76,7 @@ public class AuthoritySourceFileService {
     return repository.save(entity);
   }
 
-  public AuthoritySourceFile update(@Nonnull UUID id, AuthoritySourceFile modified) {
+  public AuthoritySourceFile update(UUID id, AuthoritySourceFile modified) {
     log.debug("update:: Attempting to update AuthoritySourceFile [id: {}]", id);
 
     if (!Objects.equals(id, modified.getId())) {

--- a/src/main/java/org/folio/entlinks/service/consortium/propagation/ConsortiumAuthoritySourceFilePropagationService.java
+++ b/src/main/java/org/folio/entlinks/service/consortium/propagation/ConsortiumAuthoritySourceFilePropagationService.java
@@ -1,0 +1,33 @@
+package org.folio.entlinks.service.consortium.propagation;
+
+import lombok.extern.log4j.Log4j2;
+import org.folio.entlinks.domain.entity.AuthoritySourceFile;
+import org.folio.entlinks.service.authority.AuthoritySourceFileService;
+import org.folio.entlinks.service.consortium.ConsortiumTenantsService;
+import org.folio.spring.service.SystemUserScopedExecutionService;
+import org.springframework.stereotype.Service;
+
+@Log4j2
+@Service
+public class ConsortiumAuthoritySourceFilePropagationService extends ConsortiumPropagationService<AuthoritySourceFile> {
+
+  private final AuthoritySourceFileService sourceFileService;
+
+  public ConsortiumAuthoritySourceFilePropagationService(AuthoritySourceFileService sourceFileService,
+                                                         ConsortiumTenantsService tenantsService,
+                                                         SystemUserScopedExecutionService executionService) {
+    super(tenantsService, executionService);
+    this.sourceFileService = sourceFileService;
+  }
+
+  protected void doPropagation(AuthoritySourceFile sourceFile, PropagationType propagationType) {
+    sourceFile.markAsConsortiumShadowCopy();
+    switch (propagationType) {
+      case CREATE -> sourceFileService.create(sourceFile);
+      case UPDATE -> sourceFileService.update(sourceFile.getId(), sourceFile);
+      case DELETE -> sourceFileService.deleteById(sourceFile.getId());
+      default -> throw new IllegalStateException("Unexpected value: " + propagationType);
+    }
+  }
+
+}

--- a/src/test/java/org/folio/entlinks/service/consortium/ConsortiumAuthoritySourceFilePropagationServiceTest.java
+++ b/src/test/java/org/folio/entlinks/service/consortium/ConsortiumAuthoritySourceFilePropagationServiceTest.java
@@ -1,8 +1,7 @@
 package org.folio.entlinks.service.consortium;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.folio.support.base.TestConstants.AUTHORITY_CONSORTIUM_SOURCE;
-import static org.folio.support.base.TestConstants.AUTHORITY_SOURCE;
+import static org.folio.entlinks.domain.entity.AuthoritySourceFileSource.CONSORTIUM;
 import static org.folio.support.base.TestConstants.TENANT_ID;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doAnswer;
@@ -12,10 +11,11 @@ import static org.mockito.Mockito.when;
 
 import java.util.List;
 import java.util.UUID;
-import org.folio.entlinks.domain.entity.Authority;
+import org.folio.entlinks.domain.entity.AuthoritySourceFile;
 import org.folio.entlinks.exception.FolioIntegrationException;
-import org.folio.entlinks.service.authority.AuthorityService;
+import org.folio.entlinks.service.authority.AuthoritySourceFileService;
 import org.folio.entlinks.service.consortium.propagation.ConsortiumAuthorityPropagationService;
+import org.folio.entlinks.service.consortium.propagation.ConsortiumAuthoritySourceFilePropagationService;
 import org.folio.spring.service.SystemUserScopedExecutionService;
 import org.folio.spring.test.type.UnitTest;
 import org.junit.jupiter.api.Test;
@@ -27,68 +27,61 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 @UnitTest
 @ExtendWith(MockitoExtension.class)
-class ConsortiumAuthorityPropagationServiceTest {
+class ConsortiumAuthoritySourceFilePropagationServiceTest {
 
-  private @Mock AuthorityService authorityService;
+  private @Mock AuthoritySourceFileService authorityService;
   private @Mock ConsortiumTenantsService tenantsService;
   private @Mock SystemUserScopedExecutionService executionService;
-  private @InjectMocks ConsortiumAuthorityPropagationService propagationService;
+  private @InjectMocks ConsortiumAuthoritySourceFilePropagationService propagationService;
 
   @Test
   void testPropagateCreate() throws FolioIntegrationException {
-    var authority = authority();
-
+    var sourceFile = new AuthoritySourceFile();
     doMocks();
-    propagationService.propagate(authority, ConsortiumAuthorityPropagationService.PropagationType.CREATE, TENANT_ID);
+    propagationService.propagate(sourceFile, ConsortiumAuthorityPropagationService.PropagationType.CREATE, TENANT_ID);
 
-    assertThat(authority.getSource()).isEqualTo(AUTHORITY_CONSORTIUM_SOURCE);
+    assertThat(sourceFile.getSource()).isEqualTo(CONSORTIUM);
     verify(tenantsService).getConsortiumTenants(TENANT_ID);
     verify(executionService, times(3)).executeAsyncSystemUserScoped(any(), any());
-    verify(authorityService, times(3)).create(authority);
+    verify(authorityService, times(3)).create(sourceFile);
   }
 
   @Test
   void testPropagateUpdate() throws FolioIntegrationException {
-    var authority = authority();
-    authority.setId(UUID.randomUUID());
+    var sourceFile = new AuthoritySourceFile();
+    sourceFile.setId(UUID.randomUUID());
     doMocks();
-    propagationService.propagate(authority, ConsortiumAuthorityPropagationService.PropagationType.UPDATE, TENANT_ID);
+    propagationService.propagate(sourceFile, ConsortiumAuthorityPropagationService.PropagationType.UPDATE, TENANT_ID);
 
-    assertThat(authority.getSource()).isEqualTo(AUTHORITY_CONSORTIUM_SOURCE);
+    assertThat(sourceFile.getSource()).isEqualTo(CONSORTIUM);
     verify(tenantsService, times(1)).getConsortiumTenants(any());
     verify(executionService, times(3)).executeAsyncSystemUserScoped(any(), any());
-    verify(authorityService, times(3)).update(authority.getId(), authority);
+    verify(authorityService, times(3)).update(sourceFile.getId(), sourceFile);
   }
 
   @Test
   void testPropagateDelete() throws FolioIntegrationException {
-    var authority = authority();
-    authority.setId(UUID.randomUUID());
+    var sourceFile = new AuthoritySourceFile();
+    sourceFile.setId(UUID.randomUUID());
     doMocks();
-    propagationService.propagate(authority, ConsortiumAuthorityPropagationService.PropagationType.DELETE, TENANT_ID);
+    propagationService.propagate(sourceFile, ConsortiumAuthorityPropagationService.PropagationType.DELETE, TENANT_ID);
 
-    assertThat(authority.getSource()).isEqualTo(AUTHORITY_CONSORTIUM_SOURCE);
+    assertThat(sourceFile.getSource()).isEqualTo(CONSORTIUM);
     verify(tenantsService, times(1)).getConsortiumTenants(any());
     verify(executionService, times(3)).executeAsyncSystemUserScoped(any(), any());
-    verify(authorityService, times(3)).deleteById(authority.getId());
+    verify(authorityService, times(3)).deleteById(sourceFile.getId());
   }
 
   @Test
   void testPropagateException() throws FolioIntegrationException {
     Mockito.doThrow(FolioIntegrationException.class).when(tenantsService).getConsortiumTenants(any());
 
-    var authority = authority();
-    propagationService.propagate(authority, ConsortiumAuthorityPropagationService.PropagationType.CREATE, TENANT_ID);
+    var sourceFile = new AuthoritySourceFile();
+    propagationService.propagate(sourceFile, ConsortiumAuthorityPropagationService.PropagationType.CREATE, TENANT_ID);
 
     verify(tenantsService, times(1)).getConsortiumTenants(any());
     verify(executionService, times(0)).executeAsyncSystemUserScoped(any(), any());
     verify(authorityService, times(0)).create(any());
-  }
-
-  private Authority authority() {
-    var authority = new Authority();
-    authority.setSource(AUTHORITY_SOURCE);
-    return authority;
   }
 
   private void doMocks() {

--- a/src/test/java/org/folio/support/base/TestConstants.java
+++ b/src/test/java/org/folio/support/base/TestConstants.java
@@ -15,12 +15,15 @@ public class TestConstants {
 
   public static final String TENANT_ID = "test";
   public static final String CENTRAL_TENANT_ID = "consortium";
+  public static final String CONSORTIUM_SOURCE_PREFIX = "CONSORTIUM-";
   public static final String USER_ID = "38d3a441-c100-5e8d-bd12-71bde492b723";
   public static final String SOURCE_FILE_NAME = "sourceFileName";
   public static final String SOURCE_FILE_TYPE = "sourceFileType";
   public static final String SOURCE_FILE_CODE = "sourceFileType";
   public static final String SOURCE_FILE_NATURAL_ID = "sourceFileNaturalId";
   public static final String SOURCE_FILE_SOURCE = "sourceFileSource";
+  public static final String AUTHORITY_SOURCE = "SOURCE";
+  public static final String AUTHORITY_CONSORTIUM_SOURCE = CONSORTIUM_SOURCE_PREFIX + AUTHORITY_SOURCE;
   public static final String TEST_PROPERTY_VALUE = "value";
   public static final UUID TEST_ID = UUID.randomUUID();
   public static final int TEST_VERSION = 2;


### PR DESCRIPTION
### Purpose
Propagate authority source files to member tenants

### Approach
- Propagate local authority source files on create/update/delete
- Set "consortium" source for shadow copies
- Prevent update/delete of shadow copies through API

### Changes Checklist
- [ ] **API Changes**: List any API paths, methods, request or response bodies changed, added, or removed.
- [ ] **Database Schema Changes**: Specify any database schema changes and their impact.
- [ ] **Interface Version Changes**: Indicate any changes to interface versions.
- [ ] **Interface Dependencies**: Note added or removed dependencies.
- [ ] **Permissions**: Document any changes to permissions.
- [ ] **Logging**: Confirm that logging is appropriately handled.
- [x] **NEWS**: Ensure that the `NEWS` file is updated with relevant information about the changes made in this pull request.

### Related Issues
[MODELINKS-175](https://issues.folio.org/browse/MODELINKS-175)

### Learning and Resources (if applicable)
[central->member tenant migration script](https://wiki.folio.org/display/FOLIJET/Adding+a+new+member+tenant+to+consortium.+mod-entities-links+scope)
