### PR TITLE
MODELINKS-197: Fix Authority Source File Copy Constructor

### DIFF
--- a/src/main/java/org/folio/entlinks/domain/entity/AuthoritySourceFile.java
+++ b/src/main/java/org/folio/entlinks/domain/entity/AuthoritySourceFile.java
@@ -99,8 +99,9 @@ public class AuthoritySourceFile extends MetadataEntity implements Persistable<U
       .stream()
       .map(AuthoritySourceFileCode::new)
       .collect(java.util.stream.Collectors.toSet());
-    Optional.ofNullable(other.authorities).orElse(Set.of())
-        .forEach(authority -> authority.setAuthoritySourceFile(this));
+    this.authorities = Optional.ofNullable(other.authorities)
+        .map(LinkedHashSet::new)
+        .orElse(new LinkedHashSet<>());
     this.sequenceName = other.sequenceName;
     this.selectable = other.selectable;
     this.hridStartNumber = other.hridStartNumber;

--- a/src/main/java/org/folio/entlinks/domain/entity/AuthoritySourceFile.java
+++ b/src/main/java/org/folio/entlinks/domain/entity/AuthoritySourceFile.java
@@ -19,7 +19,6 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
-import java.util.stream.Collectors;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -100,12 +99,13 @@ public class AuthoritySourceFile extends MetadataEntity implements Persistable<U
       .stream()
       .map(AuthoritySourceFileCode::new)
       .collect(java.util.stream.Collectors.toSet());
-    this.authorities = Optional.ofNullable(other.authorities).orElse(Set.of()).stream()
-        .map(Authority::new)
-        .collect(Collectors.toSet());
+    Optional.ofNullable(other.authorities).orElse(Set.of())
+        .forEach(authority -> authority.setAuthoritySourceFile(this));
     this.sequenceName = other.sequenceName;
     this.selectable = other.selectable;
     this.hridStartNumber = other.hridStartNumber;
+    this.version = other.version;
+    this.baseUrlProtocol = other.baseUrlProtocol;
   }
 
   public void addCode(AuthoritySourceFileCode code) {

--- a/src/test/java/org/folio/entlinks/controller/AuthoritySourceFilesControllerIT.java
+++ b/src/test/java/org/folio/entlinks/controller/AuthoritySourceFilesControllerIT.java
@@ -55,7 +55,11 @@ import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
 
 @IntegrationTest
-@DatabaseCleanup(tables = {DatabaseHelper.AUTHORITY_SOURCE_FILE_CODE_TABLE, DatabaseHelper.AUTHORITY_SOURCE_FILE_TABLE})
+@DatabaseCleanup(tables = {
+  DatabaseHelper.AUTHORITY_TABLE,
+  DatabaseHelper.AUTHORITY_SOURCE_FILE_CODE_TABLE,
+  DatabaseHelper.AUTHORITY_SOURCE_FILE_TABLE}
+)
 class AuthoritySourceFilesControllerIT extends IntegrationTestBase {
 
   private static final String CREATED_DATE = "2021-10-28T06:31:31+05:00";
@@ -335,8 +339,7 @@ class AuthoritySourceFilesControllerIT extends IntegrationTestBase {
   @Test
   @DisplayName("PATCH: partially update Authority Source File with reference in Authority")
   void updateAuthoritySourceFilePartially_positive_whenAuthorityReferenced() throws Exception {
-    var createDto = new AuthoritySourceFilePostDto("name", "code").type("type").baseUrl("http://url");
-    var hridStartNumber = 125;
+    var createDto = new AuthoritySourceFilePostDto("name", "codeXXX").type("type").baseUrl("http://url");
     var partiallyModified = new AuthoritySourceFilePatchDto()
         .version(1)
         .baseUrl("http://url.upd");
@@ -352,9 +355,8 @@ class AuthoritySourceFilesControllerIT extends IntegrationTestBase {
 
     var content = doGet(authoritySourceFilesEndpoint(created.getId()))
       .andExpect(jsonPath("source", is(SourceEnum.LOCAL.getValue())))
-      .andExpect(jsonPath("codes", hasSize(2)))
+      .andExpect(jsonPath("codes", hasSize(1)))
       .andExpect(jsonPath("_version", is(1)))
-      .andExpect(jsonPath("hridManagement.startNumber", is(hridStartNumber)))
       .andExpect(jsonPath("metadata.createdDate", notNullValue()))
       .andExpect(jsonPath("metadata.updatedDate", notNullValue()))
       .andExpect(jsonPath("metadata.updatedByUserId", is(USER_ID)))
@@ -362,7 +364,7 @@ class AuthoritySourceFilesControllerIT extends IntegrationTestBase {
       .andReturn().getResponse().getContentAsString();
     var resultDto = objectMapper.readValue(content, AuthoritySourceFileDto.class);
 
-    assertThat(new HashSet<>(resultDto.getCodes()), equalTo(new HashSet<>(partiallyModified.getCodes())));
+    assertThat(new HashSet<>(resultDto.getCodes()), equalTo(new HashSet<>(created.getCodes())));
   }
 
   @Test


### PR DESCRIPTION
### Purpose
_Stackoverflow was detected when authority source file and authority copy instances in copy constructors were created with circular dependency._

### Approach
_Modify Authority Source File Copy constructor by removing dependency for authority copy constructor._

### Changes Checklist
- [ ] **API Changes**: Document any API paths, methods, request or response bodies changed, added, or removed.
- [ ] **Database Schema Changes**: Indicate any database schema changes and their impact. Confirm that migration scripts were created.
- [ ] **Interface Version Changes**: Indicate any changes to interface versions.
- [ ] **Interface Dependencies**: Document added or removed dependencies.
- [ ] **Permissions**: Document any changes to permissions.
- [ ] **Logging**: Confirm that logging is appropriately handled.
- [ ] **Unit Testing**: Confirm that changed classes were covered by unit tests.
- [x] **Integration Testing**: Confirm that changed logic was covered by integration tests.
- [ ] **Manual Testing**: Confirm that changes were tested on local or dev environment.
- [ ] **NEWS**: Confirm that the NEWS file is updated with relevant information about the changes made in this pull request.

### Learning and Resources (if applicable)
[MODELINKS-197](https://issues.folio.org/browse/MODELINKS-197)