### PR TITLE
fix(deps): Upgrade spring-boot to 3.2.2 and not upgrade version of Hibernate

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.springframework.boot</groupId>
     <artifactId>spring-boot-starter-parent</artifactId>
-    <version>3.2.0</version>
+    <version>3.2.2</version>
     <relativePath /> <!-- lookup parent from repository -->
   </parent>
 
@@ -135,6 +135,18 @@
       <version>${mapstruct.version}</version>
       <scope>provided</scope>
     </dependency>
+
+    <!-- Hibernate 6.4.1.Final has issue with saving or persisting JsonType fields and this was observed for authorities
+    when they are persisted hibernate increased version property twice (one for insert and one for update).
+    There is similar to this one issue in their issue tracker: https://hibernate.atlassian.net/browse/HHH-17660, we can
+    track its status and once it fixed we can try to upgrade version of hibernate which is enough to remove this dependency
+    and use the one from parent spring-boot -->
+    <dependency>
+      <groupId>org.hibernate.orm</groupId>
+      <artifactId>hibernate-core</artifactId>
+      <version>6.3.1.Final</version>
+    </dependency>
+
 
     <dependency>
       <groupId>org.hibernate.validator</groupId>


### PR DESCRIPTION
### Purpose
_Hibernate 6.4.1.Final has issue with saving or persisting JsonType fields and this was observed for authorities when they are persisted hibernate increases version property twice (one for insert and one for update)_

### Approach
_Upgrade version of Spring-Boot without upgrading Hibernate._

### Changes Checklist
- [ ] **API Changes**: Document any API paths, methods, request or response bodies changed, added, or removed.
- [ ] **Database Schema Changes**: Indicate any database schema changes and their impact. Confirm that migration scripts were created.
- [ ] **Interface Version Changes**: Indicate any changes to interface versions.
- [ ] **Interface Dependencies**: Document added or removed dependencies.
- [ ] **Permissions**: Document any changes to permissions.
- [ ] **Logging**: Confirm that logging is appropriately handled.
- [ ] **Unit Testing**: Confirm that changed classes were covered by unit tests.
- [ ] **Integration Testing**: Confirm that changed logic was covered by integration tests.
- [ ] **Manual Testing**: Confirm that changes were tested on local or dev environment.
- [ ] **NEWS**: Confirm that the NEWS file is updated with relevant information about the changes made in this pull request.

### Related Issues
[MODELINKS-206](https://folio-org.atlassian.net/browse/MODELINKS-206)