### PR TITLE
MODELINKS-214: Add possibility to filter authority records by (un)defined fields with Cql query

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -23,6 +23,7 @@
 * Propagate authority archives deletion to member tenants ([MODELINKS-195](https://issues.folio.org/browse/MODELINKS-195))
 * Implement endpoint for bulk authorities upsert from external file ([MODELINKS-173](https://issues.folio.org/browse/MODELINKS-173))
 * Create custom Mockito verifies for Hibernate entities ([MODELINKS-209](https://issues.folio.org/browse/MODELINKS-209))
+* Add possibility to filter Authority records by (un)defined fields in Cql query ([MODELINKS-214](https://issues.folio.org/browse/MODELINKS-214))
 
 ### Bug fixes
 * Fix secure setup of system users by default ([MODELINKS-135](https://issues.folio.org/browse/MODELINKS-135))

--- a/doc/documentation.md
+++ b/doc/documentation.md
@@ -624,13 +624,15 @@ Endpoint `GET /authority-storage/authorities` support CQL queries.
 
 **CQL queries examples**
 
-| Example                                           | Description                                                              |
-|:--------------------------------------------------|:-------------------------------------------------------------------------|
-| `headingType = personalName`                      | Matches authorities with `Personal Name` heading type                    |
-| `authoritySourceFile.id = 12345`                  | Matches authorities with `12345` source file id                          |
-| `authoritySourceFile.name = LC Genre/Form Terms`  | Matches authorities with source file name `LC Genre/Form Terms`          |
-| `createdDate > 2021-10-25T12:00:00.0"`            | Matches authorities that were created after `2021-10-25 12:00:00`        |
-| `updatedDate <= 2021-10-28T12:00:00.0`            | Matches authorities that were updated before or at `2021-10-28 12:00:00` |
+| Example                                                    | Description                                                                                                                                                                                                                                                   |
+|:-----------------------------------------------------------|:--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `headingType = personalName`                               | Matches authorities with `Personal Name` heading type                                                                                                                                                                                                         |
+| `authoritySourceFile.id = 12345`                           | Matches authorities with `12345` source file id                                                                                                                                                                                                               |
+| `authoritySourceFile.name = LC Genre/Form Terms`           | Matches authorities with source file name `LC Genre/Form Terms`                                                                                                                                                                                               |
+| `authoritySourceFile = ""`                                 | Matches authorities with any defined authority source file, queries `authoritySourceFile.id = ""` and `authoritySourceFile.name = ""` gives the identical result as `id` and `name` are required attributes of source file                                    |
+| `headingType = corporateName NOT authoritySourceFile = ""` | Matches authorities with `Corporate Name` heading type and without any defined authority source file, same like in a previous query `NOT authoritySourceFile = ""` can be replaced by `NOT authoritySourceFile.id = ""` or `NOT authoritySourceFile.name = ""` |
+| `createdDate > 2021-10-25T12:00:00.0`                      | Matches authorities that were created after `2021-10-25 12:00:00`                                                                                                                                                                                             |
+| `updatedDate <= 2021-10-28T12:00:00.0`                     | Matches authorities that were updated before or at `2021-10-28 12:00:00`                                                                                                                                                                                      |
 
 #### Retention policy for archived authorities
 In order to provide an ability for a tenant to have specific retention period of authority archives, we need to add the below configuration in mod-settings.

--- a/src/test/java/org/folio/entlinks/controller/AuthorityControllerIT.java
+++ b/src/test/java/org/folio/entlinks/controller/AuthorityControllerIT.java
@@ -262,7 +262,11 @@ class AuthorityControllerIT extends IntegrationTestBase {
     "authoritySourceFile.id=51243be4-27cb-4d78-9206-c956299483b1, personalName, 2",
     "authoritySourceFile.id=51243be4-27cb-4d78-9206-c956299483b1 and headingType=corporateName, corporateName, 1",
     "authoritySourceFile.name=name2, genreTerm, 1",
-    "createdDate>2021-10-25T12:00:00.0 and createdDate<=2021-10-30T12:00:00.0, genreTerm, 2",
+    "cql.allRecords=1 NOT authoritySourceFile=\"\", genreTerm, 1",
+    "subjectHeadingCode=d NOT authoritySourceFile=\"\", genreTerm, 1",
+    "subjectHeadingCode=d NOT authoritySourceFile.id=\"\", genreTerm, 1",
+    "subjectHeadingCode=d NOT authoritySourceFile.name=\"\", genreTerm, 1",
+    "createdDate>2021-10-25T12:00:00.0 and createdDate<=2021-10-30T12:00:00.0, genreTerm, 3",
     "updatedDate>=2021-10-24T12:00:00.0 and updatedDate<=2021-10-28T12:00:00.0, corporateName, 1",
     "authoritySourceFile.name=name1 and createdDate>2021-10-28T12:00:00.0, corporateName, 1",
   })
@@ -281,7 +285,18 @@ class AuthorityControllerIT extends IntegrationTestBase {
     databaseHelper.saveAuthority(TENANT_ID, authority1);
     databaseHelper.saveAuthority(TENANT_ID, authority2);
     databaseHelper.saveAuthority(TENANT_ID, authority3);
+    var authority4 = authority(3, 0);
+    authority4.setAuthoritySourceFile(null);
+    authority4.setUpdatedDate(Timestamp.from(Instant.parse(UPDATED_DATE).minus(2, ChronoUnit.DAYS)));
+    databaseHelper.saveAuthority(TENANT_ID, authority4);
 
+    // query and filter authorities
+    var cqlQuery = "(" + query + ")sortby createdDate";
+    doGet(authorityEndpoint() + "?query={cql}", cqlQuery)
+      .andExpect(jsonPath("authorities[0]." + heading, notNullValue()))
+      .andExpect(jsonPath("totalRecords").value(numberOfRecords));
+
+    // query and filter authority archives
     var archive1 = authorityArchive(0, 0);
     archive1.setCreatedDate(authority1.getCreatedDate());
     archive1.setUpdatedDate(authority1.getUpdatedDate());
@@ -292,14 +307,11 @@ class AuthorityControllerIT extends IntegrationTestBase {
     databaseHelper.saveAuthorityArchive(TENANT_ID, archive1);
     databaseHelper.saveAuthorityArchive(TENANT_ID, archive2);
     databaseHelper.saveAuthorityArchive(TENANT_ID, archive3);
+    var archive4 = authorityArchive(3, 0);
+    archive4.setAuthoritySourceFile(null);
+    archive4.setUpdatedDate(Timestamp.from(Instant.parse(UPDATED_DATE).minus(2, ChronoUnit.DAYS)));
+    databaseHelper.saveAuthorityArchive(TENANT_ID, archive4);
 
-    // query and filter authorities
-    var cqlQuery = "(cql.allRecords=1 and " + query + ")sortby createdDate";
-    doGet(authorityEndpoint() + "?query={cql}", cqlQuery)
-      .andExpect(jsonPath("authorities[0]." + heading, notNullValue()))
-      .andExpect(jsonPath("totalRecords").value(numberOfRecords));
-
-    // query and filter authority archives
     doGet(authorityEndpoint() + "?query={cql}&deleted=true", cqlQuery)
       .andExpect(jsonPath("authorities[0]." + heading, notNullValue()))
       .andExpect(jsonPath("totalRecords").value(numberOfRecords));
@@ -352,7 +364,7 @@ class AuthorityControllerIT extends IntegrationTestBase {
       .andExpect(jsonPath("source", is(dto.getSource())))
       .andExpect(jsonPath("naturalId", is(dto.getNaturalId())))
       .andExpect(jsonPath("personalName", is(dto.getPersonalName())))
-      .andExpect(jsonPath("sourceFileId", is(dto.getSourceFileId().toString())))
+      //.andExpect(jsonPath("sourceFileId", is(dto.getSourceFileId().toString())))
       .andExpect(jsonPath("_version", is(0)))
       .andExpect(jsonPath("metadata.createdDate", notNullValue()))
       .andExpect(jsonPath("metadata.updatedDate", notNullValue()))

--- a/src/test/java/org/folio/entlinks/controller/AuthorityControllerIT.java
+++ b/src/test/java/org/folio/entlinks/controller/AuthorityControllerIT.java
@@ -364,7 +364,7 @@ class AuthorityControllerIT extends IntegrationTestBase {
       .andExpect(jsonPath("source", is(dto.getSource())))
       .andExpect(jsonPath("naturalId", is(dto.getNaturalId())))
       .andExpect(jsonPath("personalName", is(dto.getPersonalName())))
-      //.andExpect(jsonPath("sourceFileId", is(dto.getSourceFileId().toString())))
+      .andExpect(jsonPath("sourceFileId", is(dto.getSourceFileId().toString())))
       .andExpect(jsonPath("_version", is(0)))
       .andExpect(jsonPath("metadata.createdDate", notNullValue()))
       .andExpect(jsonPath("metadata.updatedDate", notNullValue()))


### PR DESCRIPTION
### Purpose
_Add possibility to filter authority records by (un)defined fields with cql query_

### Approach
_Specifically handle Cql terms representing (un)defined fields of the DB table record._

### Changes Checklist
- [ ] **API Changes**: Document any API paths, methods, request or response bodies changed, added, or removed.
- [ ] **Database Schema Changes**: Indicate any database schema changes and their impact. Confirm that migration scripts were created.
- [ ] **Interface Version Changes**: Indicate any changes to interface versions.
- [ ] **Interface Dependencies**: Document added or removed dependencies.
- [ ] **Permissions**: Document any changes to permissions.
- [ ] **Logging**: Confirm that logging is appropriately handled.
- [ ] **Unit Testing**: Confirm that changed classes were covered by unit tests.
- [ ] **Integration Testing**: Confirm that changed logic was covered by integration tests.
- [x] **Manual Testing**: Confirm that changes were tested on local or dev environment.
- [x] **NEWS**: Confirm that the NEWS file is updated with relevant information about the changes made in this pull request.

### Related Issues
[FOLSPRINGS-144](https://folio-org.atlassian.net/browse/FOLSPRINGS-144)
[MODELINKS-214](https://folio-org.atlassian.net/browse/MODELINKS-214)
