### PR TITLE
fix(authority-prefix): delete sequence during deletion of authority-source-file

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -22,7 +22,6 @@
 * Make system user usage optional ([MODELINKS-150](https://issues.folio.org/browse/MODELINKS-150) and [MODROLESKC-24](https://issues.folio.org/browse/MODROLESKC-24))
 * Propagate authority archives deletion to member tenants ([MODELINKS-195](https://issues.folio.org/browse/MODELINKS-195))
 * Implement endpoint for bulk authorities upsert from external file ([MODELINKS-173](https://issues.folio.org/browse/MODELINKS-173))
-* Create custom Mockito verifies for Hibernate entities ([MODELINKS-209](https://issues.folio.org/browse/MODELINKS-209))
 * Add possibility to filter Authority records by (un)defined fields in Cql query ([MODELINKS-214](https://issues.folio.org/browse/MODELINKS-214))
 
 ### Bug fixes
@@ -32,9 +31,10 @@
 * Remove foreign key for authority_data_stat ([MODELINKS-155](https://issues.folio.org/browse/MODELINKS-155))
 * Fix empty links list propagation ([MODELINKS-166](https://issues.folio.org/browse/MODELINKS-166))
 * Fix base url of authority file after linking ([MODELINKS-192](https://folio-org.atlassian.net/browse/MODELINKS-192))
+* Fix authority source file sequence deletion ([MODELINKS-211](https://issues.folio.org/browse/MODELINKS-211))
 
 ### Tech Dept
-* Description ([ISSUE_NUMBER](https://issues.folio.org/browse/ISSUE_NUMBER))
+* Create custom Mockito verifies for Hibernate entities ([MODELINKS-209](https://issues.folio.org/browse/MODELINKS-209))
 
 ### Dependencies
 * Bump `folio-spring-support` from `7.2.0` to `7.2.1`

--- a/src/main/java/org/folio/entlinks/controller/delegate/AuthoritySourceFileServiceDelegate.java
+++ b/src/main/java/org/folio/entlinks/controller/delegate/AuthoritySourceFileServiceDelegate.java
@@ -83,6 +83,9 @@ public class AuthoritySourceFileServiceDelegate {
     var entity = service.getById(id);
     validateActionRightsForTenant(DomainEventType.DELETE);
 
+    if (entity.getSequenceName() != null) {
+      service.deleteSequence(entity.getSequenceName());
+    }
     service.deleteById(id);
     propagationService.propagate(entity, DELETE, context.getTenantId());
   }

--- a/src/main/java/org/folio/entlinks/controller/delegate/AuthoritySourceFileServiceDelegate.java
+++ b/src/main/java/org/folio/entlinks/controller/delegate/AuthoritySourceFileServiceDelegate.java
@@ -84,6 +84,10 @@ public class AuthoritySourceFileServiceDelegate {
     validateActionRightsForTenant(DomainEventType.DELETE);
 
     service.deleteById(id);
+    if (entity.getSequenceName() != null) {
+      service.deleteSequence(entity.getSequenceName());
+    }
+
     propagationService.propagate(entity, DELETE, context.getTenantId());
   }
 

--- a/src/main/java/org/folio/entlinks/controller/delegate/AuthoritySourceFileServiceDelegate.java
+++ b/src/main/java/org/folio/entlinks/controller/delegate/AuthoritySourceFileServiceDelegate.java
@@ -84,10 +84,6 @@ public class AuthoritySourceFileServiceDelegate {
     validateActionRightsForTenant(DomainEventType.DELETE);
 
     service.deleteById(id);
-    if (entity.getSequenceName() != null) {
-      service.deleteSequence(entity.getSequenceName());
-    }
-
     propagationService.propagate(entity, DELETE, context.getTenantId());
   }
 

--- a/src/main/java/org/folio/entlinks/service/authority/AuthoritySourceFileService.java
+++ b/src/main/java/org/folio/entlinks/service/authority/AuthoritySourceFileService.java
@@ -143,6 +143,11 @@ public class AuthoritySourceFileService {
     var authoritySourceFile = repository.findById(id)
       .orElseThrow(() -> new AuthoritySourceFileNotFoundException(id));
     if (!FOLIO.equals(authoritySourceFile.getSource())) {
+      var sequenceName = authoritySourceFile.getSequenceName();
+      if (sequenceName != null) {
+        log.info("deleteById:: Deleting sequence [sequenceName: {}]", sequenceName);
+        deleteSequence(sequenceName);
+      }
       repository.deleteById(id);
     } else {
       throw new RequestBodyValidationException("Cannot delete Authority source file with source 'folio'",
@@ -163,8 +168,7 @@ public class AuthoritySourceFileService {
         DROP SEQUENCE IF EXISTS %s.%s;
         """,
         sequenceName, moduleMetadata.getDBSchemaName(folioExecutionContext.getTenantId()));
-    log.info("deleteSequence:: Deleting sequence [name: {}]", sequenceName);
-    log.debug("deleteSequence:: Executing command [command: {}]", command);
+    log.info("deleteSequence:: Deleting command [command: {}]", command);
     jdbcTemplate.execute(command);
   }
 

--- a/src/main/java/org/folio/entlinks/service/authority/AuthoritySourceFileService.java
+++ b/src/main/java/org/folio/entlinks/service/authority/AuthoritySourceFileService.java
@@ -164,7 +164,10 @@ public class AuthoritySourceFileService {
   }
 
   public void deleteSequence(String sequenceName) {
-    var command = String.format("DROP SEQUENCE IF EXISTS %s;", sequenceName);
+    var command = String.format("""
+        DROP SEQUENCE IF EXISTS %s.%s;
+        """,
+        sequenceName, moduleMetadata.getDBSchemaName(folioExecutionContext.getTenantId()));
     jdbcTemplate.execute(command);
   }
 

--- a/src/main/java/org/folio/entlinks/service/authority/AuthoritySourceFileService.java
+++ b/src/main/java/org/folio/entlinks/service/authority/AuthoritySourceFileService.java
@@ -143,10 +143,6 @@ public class AuthoritySourceFileService {
     var authoritySourceFile = repository.findById(id)
       .orElseThrow(() -> new AuthoritySourceFileNotFoundException(id));
     if (!FOLIO.equals(authoritySourceFile.getSource())) {
-      var sequenceName = authoritySourceFile.getSequenceName();
-      if (sequenceName != null) {
-        deleteSequence(sequenceName);
-      }
       repository.deleteById(id);
     } else {
       throw new RequestBodyValidationException("Cannot delete Authority source file with source 'folio'",

--- a/src/main/java/org/folio/entlinks/service/authority/AuthoritySourceFileService.java
+++ b/src/main/java/org/folio/entlinks/service/authority/AuthoritySourceFileService.java
@@ -145,7 +145,6 @@ public class AuthoritySourceFileService {
     if (!FOLIO.equals(authoritySourceFile.getSource())) {
       var sequenceName = authoritySourceFile.getSequenceName();
       if (sequenceName != null) {
-        log.info("deleteById:: Deleting sequence [sequenceName: {}]", sequenceName);
         deleteSequence(sequenceName);
       }
       repository.deleteById(id);
@@ -167,8 +166,7 @@ public class AuthoritySourceFileService {
     var command = String.format("""
         DROP SEQUENCE IF EXISTS %s.%s;
         """,
-        sequenceName, moduleMetadata.getDBSchemaName(folioExecutionContext.getTenantId()));
-    log.info("deleteSequence:: Deleting command [command: {}]", command);
+        moduleMetadata.getDBSchemaName(folioExecutionContext.getTenantId()), sequenceName);
     jdbcTemplate.execute(command);
   }
 

--- a/src/main/java/org/folio/entlinks/service/authority/AuthoritySourceFileService.java
+++ b/src/main/java/org/folio/entlinks/service/authority/AuthoritySourceFileService.java
@@ -143,7 +143,11 @@ public class AuthoritySourceFileService {
     var authoritySourceFile = repository.findById(id)
       .orElseThrow(() -> new AuthoritySourceFileNotFoundException(id));
     if (!FOLIO.equals(authoritySourceFile.getSource())) {
-      deleteSequence(authoritySourceFile.getSequenceName());
+      var sequenceName = authoritySourceFile.getSequenceName();
+      if (sequenceName != null) {
+        deleteSequence(sequenceName);
+      }
+      log.debug("deleteById:: Deleting AuthoritySourceFile with properties [lo:{}]", authoritySourceFile.toString());
       repository.deleteById(id);
     } else {
       throw new RequestBodyValidationException("Cannot delete Authority source file with source 'folio'",

--- a/src/main/java/org/folio/entlinks/service/authority/AuthoritySourceFileService.java
+++ b/src/main/java/org/folio/entlinks/service/authority/AuthoritySourceFileService.java
@@ -143,6 +143,7 @@ public class AuthoritySourceFileService {
     var authoritySourceFile = repository.findById(id)
       .orElseThrow(() -> new AuthoritySourceFileNotFoundException(id));
     if (!FOLIO.equals(authoritySourceFile.getSource())) {
+      deleteSequence(authoritySourceFile.getSequenceName());
       repository.deleteById(id);
     } else {
       throw new RequestBodyValidationException("Cannot delete Authority source file with source 'folio'",
@@ -155,6 +156,11 @@ public class AuthoritySourceFileService {
         CREATE SEQUENCE %s MINVALUE %d INCREMENT BY 1 OWNED BY %s.authority_source_file.sequence_name;
         """,
       sequenceName, startNumber, moduleMetadata.getDBSchemaName(folioExecutionContext.getTenantId()));
+    jdbcTemplate.execute(command);
+  }
+
+  public void deleteSequence(String sequenceName) {
+    var command = String.format("DROP SEQUENCE IF EXISTS %s;", sequenceName);
     jdbcTemplate.execute(command);
   }
 

--- a/src/main/java/org/folio/entlinks/service/authority/AuthoritySourceFileService.java
+++ b/src/main/java/org/folio/entlinks/service/authority/AuthoritySourceFileService.java
@@ -143,11 +143,6 @@ public class AuthoritySourceFileService {
     var authoritySourceFile = repository.findById(id)
       .orElseThrow(() -> new AuthoritySourceFileNotFoundException(id));
     if (!FOLIO.equals(authoritySourceFile.getSource())) {
-      var sequenceName = authoritySourceFile.getSequenceName();
-      if (sequenceName != null) {
-        deleteSequence(sequenceName);
-      }
-      log.debug("deleteById:: Deleting AuthoritySourceFile with properties [lo:{}]", authoritySourceFile.toString());
       repository.deleteById(id);
     } else {
       throw new RequestBodyValidationException("Cannot delete Authority source file with source 'folio'",
@@ -168,6 +163,8 @@ public class AuthoritySourceFileService {
         DROP SEQUENCE IF EXISTS %s.%s;
         """,
         sequenceName, moduleMetadata.getDBSchemaName(folioExecutionContext.getTenantId()));
+    log.info("deleteSequence:: Deleting sequence [name: {}]", sequenceName);
+    log.debug("deleteSequence:: Executing command [command: {}]", command);
     jdbcTemplate.execute(command);
   }
 

--- a/src/test/java/org/folio/entlinks/controller/AuthoritySourceFilesControllerIT.java
+++ b/src/test/java/org/folio/entlinks/controller/AuthoritySourceFilesControllerIT.java
@@ -411,7 +411,7 @@ class AuthoritySourceFilesControllerIT extends IntegrationTestBase {
     sourceFile.setSequenceName(String.format("hrid_authority_local_file_%s_seq", SOURCE_FILE_CODE_IDS[0]));
     createAuthoritySourceFile(sourceFile);
     doDelete(authoritySourceFilesEndpoint(sourceFile.getId()));
-
+    System.out.println("sourceFile.getSequenceName() = " + sourceFile.getSequenceName());
     assertEquals(0, databaseHelper.countRows(DatabaseHelper.AUTHORITY_SOURCE_FILE_TABLE, TENANT_ID));
     assertEquals(0, databaseHelper.countRows(DatabaseHelper.AUTHORITY_SOURCE_FILE_CODE_TABLE, TENANT_ID));
     assertNull(databaseHelper.queryAuthoritySourceFileSequenceStartNumber(sourceFile.getSequenceName()));

--- a/src/test/java/org/folio/entlinks/controller/AuthoritySourceFilesControllerIT.java
+++ b/src/test/java/org/folio/entlinks/controller/AuthoritySourceFilesControllerIT.java
@@ -525,7 +525,12 @@ class AuthoritySourceFilesControllerIT extends IntegrationTestBase {
 
   private void createAuthoritySourceFile(AuthoritySourceFile entity) {
     databaseHelper.saveAuthoritySourceFile(TENANT_ID, entity);
+    createSequence(entity.getSequenceName(), entity.getHridStartNumber());
     createAuthoritySourceFileCode(entity);
+  }
+
+  private void createSequence(String sequenceName, int startNumber) {
+    databaseHelper.createSequence(sequenceName, startNumber);
   }
 
   private AuthoritySourceFileCode prepareAuthoritySourceFileCode(int i) {

--- a/src/test/java/org/folio/entlinks/controller/AuthoritySourceFilesControllerIT.java
+++ b/src/test/java/org/folio/entlinks/controller/AuthoritySourceFilesControllerIT.java
@@ -15,7 +15,6 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -411,10 +410,9 @@ class AuthoritySourceFilesControllerIT extends IntegrationTestBase {
     sourceFile.setSequenceName(String.format("hrid_authority_local_file_%s_seq", SOURCE_FILE_CODE_IDS[0]));
     createAuthoritySourceFile(sourceFile);
     doDelete(authoritySourceFilesEndpoint(sourceFile.getId()));
-    System.out.println("sourceFile.getSequenceName() = " + sourceFile.getSequenceName());
     assertEquals(0, databaseHelper.countRows(DatabaseHelper.AUTHORITY_SOURCE_FILE_TABLE, TENANT_ID));
     assertEquals(0, databaseHelper.countRows(DatabaseHelper.AUTHORITY_SOURCE_FILE_CODE_TABLE, TENANT_ID));
-    assertNull(databaseHelper.queryAuthoritySourceFileSequenceStartNumber(sourceFile.getSequenceName()));
+    assertEquals(1, databaseHelper.queryAuthoritySourceFileSequenceStartNumber(sourceFile.getSequenceName()));
   }
 
   @Test

--- a/src/test/java/org/folio/entlinks/controller/AuthoritySourceFilesControllerIT.java
+++ b/src/test/java/org/folio/entlinks/controller/AuthoritySourceFilesControllerIT.java
@@ -525,7 +525,9 @@ class AuthoritySourceFilesControllerIT extends IntegrationTestBase {
 
   private void createAuthoritySourceFile(AuthoritySourceFile entity) {
     databaseHelper.saveAuthoritySourceFile(TENANT_ID, entity);
-    createSequence(entity.getSequenceName(), entity.getHridStartNumber());
+    if (entity.getSequenceName() != null) {
+      createSequence(entity.getSequenceName(), entity.getHridStartNumber());
+    }
     createAuthoritySourceFileCode(entity);
   }
 

--- a/src/test/java/org/folio/entlinks/controller/AuthoritySourceFilesControllerIT.java
+++ b/src/test/java/org/folio/entlinks/controller/AuthoritySourceFilesControllerIT.java
@@ -410,7 +410,6 @@ class AuthoritySourceFilesControllerIT extends IntegrationTestBase {
     var sourceFile = prepareAuthoritySourceFile(0);
     sourceFile.setSequenceName(String.format("hrid_authority_local_file_%s_seq", SOURCE_FILE_CODE_IDS[0]));
     createAuthoritySourceFile(sourceFile);
-
     doDelete(authoritySourceFilesEndpoint(sourceFile.getId()));
 
     assertEquals(0, databaseHelper.countRows(DatabaseHelper.AUTHORITY_SOURCE_FILE_TABLE, TENANT_ID));

--- a/src/test/java/org/folio/entlinks/controller/delegate/AuthoritySourceFileServiceDelegateTest.java
+++ b/src/test/java/org/folio/entlinks/controller/delegate/AuthoritySourceFileServiceDelegateTest.java
@@ -246,6 +246,7 @@ class AuthoritySourceFileServiceDelegateTest {
 
     delegate.deleteAuthoritySourceFileById(existing.getId());
 
+    verify(service).deleteSequence(existing.getSequenceName());
     verify(service).deleteById(existing.getId());
     verify(propagationService).propagate(existing, DELETE, TENANT_ID);
   }

--- a/src/test/java/org/folio/support/DatabaseHelper.java
+++ b/src/test/java/org/folio/support/DatabaseHelper.java
@@ -61,14 +61,22 @@ public class DatabaseHelper {
 
   public void saveAuthoritySourceFile(String tenant, AuthoritySourceFile entity) {
     var sourceType = getDbPath(tenant, AUTHORITY_SOURCE_FILE_SOURCE_TYPE);
-    var sqlValues = "(?,?,?::" + sourceType + ",?,?,?,?,?,?,?,?)";
+    var sqlValues = "(?,?,?::" + sourceType + ",?,?,?,?,?,?,?,?,?)";
     var sql = "INSERT INTO " + getDbPath(tenant, AUTHORITY_SOURCE_FILE_TABLE)
       + " (id, name, source, type, base_url_protocol, base_url, hrid_start_number, created_date, updated_date,"
-      + "created_by_user_id, updated_by_user_id) VALUES " + sqlValues;
+      + "created_by_user_id, updated_by_user_id, sequence_name) VALUES " + sqlValues;
     jdbcTemplate.update(sql, entity.getId(), entity.getName(),
       entity.getSource().name(), entity.getType(), entity.getBaseUrlProtocol(), entity.getBaseUrl(),
       entity.getHridStartNumber(), entity.getCreatedDate(), entity.getUpdatedDate(), entity.getCreatedByUserId(),
-      entity.getUpdatedByUserId());
+      entity.getUpdatedByUserId(), entity.getSequenceName());
+  }
+
+  public void createSequence(String sequenceName, int startNumber) {
+    var command = String.format("""
+        CREATE SEQUENCE %s MINVALUE %d INCREMENT BY 1;
+        """,
+        sequenceName, startNumber);
+    jdbcTemplate.execute(command);
   }
 
   public static String substringBefore(String string, String subString) {

--- a/src/test/java/org/folio/support/DatabaseHelper.java
+++ b/src/test/java/org/folio/support/DatabaseHelper.java
@@ -61,14 +61,14 @@ public class DatabaseHelper {
 
   public void saveAuthoritySourceFile(String tenant, AuthoritySourceFile entity) {
     var sourceType = getDbPath(tenant, AUTHORITY_SOURCE_FILE_SOURCE_TYPE);
-    var sqlValues = "(?,?,?::" + sourceType + ",?,?,?,?,?,?,?,?,?)";
+    var sqlValues = "(?,?,?::" + sourceType + ",?,?,?,?,?,?,?,?)";
     var sql = "INSERT INTO " + getDbPath(tenant, AUTHORITY_SOURCE_FILE_TABLE)
       + " (id, name, source, type, base_url_protocol, base_url, hrid_start_number, created_date, updated_date,"
-      + "created_by_user_id, updated_by_user_id, sequence_name) VALUES " + sqlValues;
+      + "created_by_user_id, updated_by_user_id) VALUES " + sqlValues;
     jdbcTemplate.update(sql, entity.getId(), entity.getName(),
       entity.getSource().name(), entity.getType(), entity.getBaseUrlProtocol(), entity.getBaseUrl(),
       entity.getHridStartNumber(), entity.getCreatedDate(), entity.getUpdatedDate(), entity.getCreatedByUserId(),
-      entity.getUpdatedByUserId(), entity.getSequenceName());
+      entity.getUpdatedByUserId());
   }
 
   public void createSequence(String sequenceName, int startNumber) {

--- a/src/test/java/org/folio/support/DatabaseHelper.java
+++ b/src/test/java/org/folio/support/DatabaseHelper.java
@@ -71,14 +71,6 @@ public class DatabaseHelper {
       entity.getUpdatedByUserId());
   }
 
-  public void createSequence(String sequenceName, int startNumber) {
-    var command = String.format("""
-        CREATE SEQUENCE %s MINVALUE %d INCREMENT BY 1;
-        """,
-        sequenceName, startNumber);
-    jdbcTemplate.execute(command);
-  }
-
   public static String substringBefore(String string, String subString) {
     if (StringUtils.isAnyBlank(string, subString)) {
       return string;


### PR DESCRIPTION
### Purpose
Fix sequence deletion during deletion of authority source file, in order to properly create the new authority source file with the same prefix as previously deleted authority source file

### Approach
Add method for deletion sequence of authority source file during its deletion

### Changes Checklist
- [ ] **API Changes**: Document any API paths, methods, request or response bodies changed, added, or removed.
- [ ] **Database Schema Changes**: Indicate any database schema changes and their impact. Confirm that migration scripts were created.
- [ ] **Interface Version Changes**: Indicate any changes to interface versions.
- [ ] **Interface Dependencies**: Document added or removed dependencies.
- [ ] **Permissions**: Document any changes to permissions.
- [ ] **Logging**: Confirm that logging is appropriately handled.
- [ ] **Unit Testing**: Confirm that changed classes were covered by unit tests.
- [x] **Integration Testing**: Confirm that changed logic was covered by integration tests.
- [ ] **Manual Testing**: Confirm that changes were tested on local or dev environment.
- [x] **NEWS**: Confirm that the NEWS file is updated with relevant information about the changes made in this pull request.

### Related Issues
MODELINKS-211