### PR TITLE
fix(authority-source-files): Fix validation of authority source file prefix for PATCH request

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -32,6 +32,7 @@
 * Remove foreign key for authority_data_stat ([MODELINKS-155](https://issues.folio.org/browse/MODELINKS-155))
 * Fix empty links list propagation ([MODELINKS-166](https://issues.folio.org/browse/MODELINKS-166))
 * Fix base url of authority file after linking ([MODELINKS-192](https://folio-org.atlassian.net/browse/MODELINKS-192))
+* Fix authority source file prefix validation for PATCH request ([MODELINKS-208](https://folio-org.atlassian.net/browse/MODELINKS-208))
 
 ### Tech Dept
 * Description ([ISSUE_NUMBER](https://issues.folio.org/browse/ISSUE_NUMBER))

--- a/src/main/java/org/folio/entlinks/controller/converter/AuthoritySourceFileMapper.java
+++ b/src/main/java/org/folio/entlinks/controller/converter/AuthoritySourceFileMapper.java
@@ -115,12 +115,12 @@ public interface AuthoritySourceFileMapper {
 
   default Set<AuthoritySourceFileCode> toEntityCodes(AuthoritySourceFilePatchDto authoritySourceFileDto,
                                                      AuthoritySourceFile authoritySourceFile) {
-    var dtoCodes = authoritySourceFileDto.getCodes();
-    if (dtoCodes == null) {
+    var dtoCode = authoritySourceFileDto.getCode();
+    if (dtoCode == null) {
       return authoritySourceFile.getAuthoritySourceFileCodes();
     }
 
-    return toEntityCodes(dtoCodes);
+    return toEntityCodes(List.of(dtoCode));
   }
 
   default AuthoritySourceFileCode toEntityCode(String code) {

--- a/src/main/java/org/folio/entlinks/controller/delegate/AuthoritySourceFileServiceDelegate.java
+++ b/src/main/java/org/folio/entlinks/controller/delegate/AuthoritySourceFileServiceDelegate.java
@@ -127,9 +127,8 @@ public class AuthoritySourceFileServiceDelegate {
       errorParameters.add(new Parameter("name")
         .value(String.join(",", patchDto.getName())));
     }
-    if (patchDto.getCodes() != null) {
-      errorParameters.add(new Parameter("codes")
-        .value(String.join(",", patchDto.getCodes())));
+    if (patchDto.getCode() != null) {
+      errorParameters.add(new Parameter("code").value(patchDto.getCode()));
     }
     if (patchDto.getHridManagement() != null && patchDto.getHridManagement().getStartNumber() != null) {
       errorParameters.add(new Parameter("hridManagement.startNumber")

--- a/src/main/resources/swagger.api/schemas/authority-source-file/authoritySourceFilePatchDto.yaml
+++ b/src/main/resources/swagger.api/schemas/authority-source-file/authoritySourceFilePatchDto.yaml
@@ -4,12 +4,11 @@ properties:
   name:
     type: string
     description: Authority source file name
-  codes:
-    type: array
-    description: List of identifying prefix
-    items:
-      type: string
-      description: identifying prefix, i.e. 'n', 'D', 'fst'
+  code:
+    type: string
+    minLength: 1
+    maxLength: 25
+    description: identifying prefix, i.e. 'n', 'D', 'fst'
   type:
     type: string
     description: Type of authority records stored in source file

--- a/src/test/java/org/folio/entlinks/controller/AuthoritySourceFilesControllerIT.java
+++ b/src/test/java/org/folio/entlinks/controller/AuthoritySourceFilesControllerIT.java
@@ -316,8 +316,7 @@ class AuthoritySourceFilesControllerIT extends IntegrationTestBase {
       .type("type1")
       .baseUrl("https://url/")
       .selectable(false)
-      // remove code and insert code2 and code3
-      .codes(List.of("code2", "code3"))
+      .code("replacedCode")
       .hridManagement(new AuthoritySourceFilePatchDtoHridManagement().startNumber(hridStartNumber));
 
     var created = doPostAndReturn(authoritySourceFilesEndpoint(), createDto, AuthoritySourceFileDto.class);
@@ -325,23 +324,19 @@ class AuthoritySourceFilesControllerIT extends IntegrationTestBase {
     doPatch(authoritySourceFilesEndpoint(created.getId()), partiallyModified)
       .andExpect(status().isNoContent());
 
-    var content = doGet(authoritySourceFilesEndpoint(created.getId()))
+    doGet(authoritySourceFilesEndpoint(created.getId()))
       .andExpect(jsonPath("source", is(SourceEnum.LOCAL.getValue())))
       .andExpect(jsonPath("name", is(partiallyModified.getName())))
       .andExpect(jsonPath("type", is(partiallyModified.getType())))
       .andExpect(jsonPath("baseUrl", is(partiallyModified.getBaseUrl())))
       .andExpect(jsonPath("selectable", is(partiallyModified.getSelectable())))
-      .andExpect(jsonPath("codes", hasSize(2)))
+      .andExpect(jsonPath("codes", is(List.of("replacedCode"))))
       .andExpect(jsonPath("_version", is(1)))
       .andExpect(jsonPath("hridManagement.startNumber", is(hridStartNumber)))
       .andExpect(jsonPath("metadata.createdDate", notNullValue()))
       .andExpect(jsonPath("metadata.updatedDate", notNullValue()))
       .andExpect(jsonPath("metadata.updatedByUserId", is(USER_ID)))
-      .andExpect(jsonPath("metadata.createdByUserId", is(USER_ID)))
-      .andReturn().getResponse().getContentAsString();
-    var resultDto = objectMapper.readValue(content, AuthoritySourceFileDto.class);
-
-    assertThat(new HashSet<>(resultDto.getCodes()), equalTo(new HashSet<>(partiallyModified.getCodes())));
+      .andExpect(jsonPath("metadata.createdByUserId", is(USER_ID)));
   }
 
   @Test

--- a/src/test/java/org/folio/entlinks/controller/converter/AuthoritySourceFileMapperTest.java
+++ b/src/test/java/org/folio/entlinks/controller/converter/AuthoritySourceFileMapperTest.java
@@ -80,7 +80,7 @@ class AuthoritySourceFileMapperTest {
     var patchDto = new AuthoritySourceFilePatchDto();
     patchDto.setName(UPDATED_NAME);
     patchDto.setType(UPDATED_TYPE);
-    patchDto.setCodes(List.of(UPDATED_CODE));
+    patchDto.setCode(UPDATED_CODE);
     patchDto.setBaseUrl(UPDATED_BASE_URL);
     patchDto.selectable(true);
     patchDto.hridManagement(new AuthoritySourceFilePatchDtoHridManagement().startNumber(5));
@@ -90,8 +90,7 @@ class AuthoritySourceFileMapperTest {
     assertThat(updatedFile).isNotNull();
     assertThat(updatedFile.getName()).isEqualTo(patchDto.getName());
     assertThat(updatedFile.getType()).isEqualTo(patchDto.getType());
-    assertThat(updatedFile.getAuthoritySourceFileCodes().stream().map(AuthoritySourceFileCode::getCode).toList())
-        .isEqualTo(patchDto.getCodes());
+    assertThat(updatedFile.getAuthoritySourceFileCodes().iterator().next().getCode()).isEqualTo(patchDto.getCode());
     assertThat(updatedFile.getFullBaseUrl()).isEqualTo(patchDto.getBaseUrl());
     assertThat(updatedFile.isSelectable()).isEqualTo(patchDto.getSelectable());
     assertThat(updatedFile.getHridStartNumber()).isEqualTo(patchDto.getHridManagement().getStartNumber());

--- a/src/test/java/org/folio/entlinks/controller/delegate/AuthoritySourceFileServiceDelegateTest.java
+++ b/src/test/java/org/folio/entlinks/controller/delegate/AuthoritySourceFileServiceDelegateTest.java
@@ -194,7 +194,7 @@ class AuthoritySourceFileServiceDelegateTest {
       .selectable(true)
       .version(1)
       .baseUrl("baseUrl")
-      .codes(List.of("a", "b"))
+      .code("a")
       .hridManagement(new AuthoritySourceFilePatchDtoHridManagement().startNumber(1));
     var expected = new RequestBodyValidationException(
       "Unable to patch. Authority source file source is FOLIO or it has authority references", errors);
@@ -347,9 +347,9 @@ class AuthoritySourceFileServiceDelegateTest {
   static Stream<Arguments> patchValidationFailureData() {
     return Stream.of(
       Arguments.of(AuthoritySourceFileSource.FOLIO, false, List.of(new Parameter("name").value("name"),
-        new Parameter("codes").value("a,b"),
+        new Parameter("code").value("a"),
         new Parameter("hridManagement.startNumber").value("1"))),
-      Arguments.of(AuthoritySourceFileSource.LOCAL, true, List.of(new Parameter("codes").value("a,b"),
+      Arguments.of(AuthoritySourceFileSource.LOCAL, true, List.of(new Parameter("code").value("a"),
         new Parameter("hridManagement.startNumber").value("1"))));
   }
 

--- a/src/test/java/org/folio/entlinks/service/authority/AuthoritySourceFileServiceTest.java
+++ b/src/test/java/org/folio/entlinks/service/authority/AuthoritySourceFileServiceTest.java
@@ -171,7 +171,7 @@ class AuthoritySourceFileServiceTest {
   }
 
   @ParameterizedTest
-  @ValueSource(strings = {"", "123", "#", "abc123", "abc def"})
+  @ValueSource(strings = {"", "123", "#", "abc123", "abc def", "abc,def"})
   void shouldNotBePossibleToCreateAuthoritySourceFileWithInvalidCode(String code) {
     var sourceFileCode = new AuthoritySourceFileCode();
     sourceFileCode.setCode(code);
@@ -258,6 +258,27 @@ class AuthoritySourceFileServiceTest {
     assertThat(thrown.getInvalidParameters()).hasSize(1);
     assertThat(thrown.getInvalidParameters().get(0).getKey()).isEqualTo("id");
     assertThat(thrown.getInvalidParameters().get(0).getValue()).isEqualTo(id.toString());
+    verifyNoInteractions(repository);
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {"", "123", "#", "abc123", "abc def", "abc,def"})
+  void shouldThrowExceptionWhenProvidedInvalidSourceFileCode(String code) {
+    var entity = new AuthoritySourceFile();
+    UUID id = UUID.randomUUID();
+    entity.setId(id);
+    var sourceFileCode = new AuthoritySourceFileCode();
+    sourceFileCode.setCode(code);
+    entity.addCode(sourceFileCode);
+
+    var thrown = assertThrows(RequestBodyValidationException.class, () -> service.update(id, entity));
+
+    assertThat(thrown.getInvalidParameters()).hasSize(1);
+    assertThat(thrown.getInvalidParameters().get(0).getKey()).isEqualTo("code");
+    assertThat(thrown.getInvalidParameters().get(0).getValue())
+        .isEqualTo(sourceFileCode.getCode());
+    assertThat(thrown.getMessage())
+        .isEqualTo("Authority Source File prefix should be non-empty sequence of letters");
     verifyNoInteractions(repository);
   }
 

--- a/src/test/java/org/folio/support/TestDataUtils.java
+++ b/src/test/java/org/folio/support/TestDataUtils.java
@@ -306,7 +306,7 @@ public class TestDataUtils {
         UUID.fromString("453e9a34-31a3-4f82-b3f5-1057f20b050e"),
         UUID.fromString("08c9fd60-d038-46bb-be83-45f93a8e53b7")};
     private static final Integer[] SOURCE_FILE_CODE_IDS = new Integer[] {1, 2, 3};
-    private static final String[] SOURCE_FILE_CODES = new String[] {"code1", "code2", "code3"};
+    private static final String[] SOURCE_FILE_CODES = new String[] {"codeOne", "codeTwo", "codeThree"};
     private static final String[] SOURCE_FILE_NAMES = new String[] {"name1", "name2", "name3"};
     private static final AuthoritySourceFileSource[] SOURCE_FILE_SOURCES = new AuthoritySourceFileSource[] {
       AuthoritySourceFileSource.LOCAL,


### PR DESCRIPTION
### Purpose
_Fix validation of authority source file prefix for PATCH request_

### Approach
- do not allow to provide more than one preifx in request body for PATCH request
- add validation for the prefix same as for POST request

### Changes Checklist
- [ ] **API Changes**: Document any API paths, methods, request or response bodies changed, added, or removed.
- [ ] **Database Schema Changes**: Indicate any database schema changes and their impact. Confirm that migration scripts were created.
- [ ] **Interface Version Changes**: Indicate any changes to interface versions.
- [ ] **Interface Dependencies**: Document added or removed dependencies.
- [ ] **Permissions**: Document any changes to permissions.
- [ ] **Logging**: Confirm that logging is appropriately handled.
- [x] **Unit Testing**: Confirm that changed classes were covered by unit tests.
- [ ] **Integration Testing**: Confirm that changed logic was covered by integration tests.
- [ ] **Manual Testing**: Confirm that changes were tested on local or dev environment.
- [x] **NEWS**: Confirm that the NEWS file is updated with relevant information about the changes made in this pull request.

### Related Issues
[MODELINKS-208](https://folio-org.atlassian.net/browse/MODELINKS-208)
