### PR TITLE
refactor(kafka-utils): Use generic topic name instead of creating new for each tenant

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -33,6 +33,7 @@
 * Fix base url of authority file after linking ([MODELINKS-192](https://folio-org.atlassian.net/browse/MODELINKS-192))
 * Fix authority source file sequence deletion ([MODELINKS-211](https://issues.folio.org/browse/MODELINKS-211))
 * Fix authority source file prefix validation for PATCH request ([MODELINKS-208](https://folio-org.atlassian.net/browse/MODELINKS-208))
+* Use generic topic name instead of creating new for each tenant ([MODELINKS-213](https://issues.folio.org/browse/MODELINKS-213))
 
 ### Tech Dept
 * Create custom Mockito verifies for Hibernate entities ([MODELINKS-209](https://issues.folio.org/browse/MODELINKS-209))

--- a/src/main/java/org/folio/entlinks/integration/kafka/EventProducer.java
+++ b/src/main/java/org/folio/entlinks/integration/kafka/EventProducer.java
@@ -75,6 +75,6 @@ public class EventProducer<T extends BaseEvent> {
   }
 
   private String topicName() {
-    return KafkaUtils.getTenantTopicName(topicName, context.getTenantId());
+    return org.folio.spring.tools.kafka.KafkaUtils.getTenantTopicName(topicName, context.getTenantId());
   }
 }

--- a/src/main/java/org/folio/entlinks/utils/KafkaUtils.java
+++ b/src/main/java/org/folio/entlinks/utils/KafkaUtils.java
@@ -1,7 +1,5 @@
 package org.folio.entlinks.utils;
 
-import static org.folio.spring.config.properties.FolioEnvironment.getFolioEnvName;
-
 import java.nio.charset.StandardCharsets;
 import java.util.Collection;
 import java.util.Collections;
@@ -13,17 +11,6 @@ import org.apache.kafka.common.header.internals.RecordHeader;
 
 @UtilityClass
 public class KafkaUtils {
-
-  /**
-   * Returns topic name in the format - `{env}.{tenant}.{topic-name}`
-   *
-   * @param initialName initial topic name as {@link String}
-   * @param tenantId    tenant id as {@link String}
-   * @return topic name as {@link String} object
-   */
-  public static String getTenantTopicName(String initialName, String tenantId) {
-    return String.format("%s.%s.%s", getFolioEnvName(), tenantId, initialName);
-  }
 
   public static List<Header> toKafkaHeaders(Map<String, Collection<String>> requestHeaders) {
     if (requestHeaders == null || requestHeaders.isEmpty()) {

--- a/src/test/java/org/folio/entlinks/integration/kafka/EventProducerTest.java
+++ b/src/test/java/org/folio/entlinks/integration/kafka/EventProducerTest.java
@@ -1,0 +1,64 @@
+package org.folio.entlinks.integration.kafka;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.UUID;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.folio.entlinks.domain.dto.AuthorityDto;
+import org.folio.entlinks.integration.dto.event.DomainEvent;
+import org.folio.spring.FolioExecutionContext;
+import org.folio.spring.testing.type.UnitTest;
+import org.folio.spring.tools.kafka.KafkaUtils;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@UnitTest
+@ExtendWith(MockitoExtension.class)
+class EventProducerTest {
+
+  private static final String TOPIC = "TEST_TOPIC";
+  private static final String TENANT_ID = "TEST_TENANT";
+
+  @Mock
+  KafkaTemplate<String, DomainEvent<?>> template;
+
+  @Mock
+  private FolioExecutionContext context;
+
+  private EventProducer<DomainEvent<?>> eventProducer;
+
+  @BeforeEach
+  void setup() {
+    eventProducer = new EventProducer<>(template, TOPIC);
+    ReflectionTestUtils.setField(eventProducer, "context", context);
+  }
+
+  @Test
+  void shouldSendMessageToTenantCollectionTopic() {
+    ReflectionTestUtils.setField(KafkaUtils.class, "TENANT_COLLECTION_TOPICS_ENABLED", true);
+    ReflectionTestUtils.setField(KafkaUtils.class, "TENANT_COLLECTION_TOPIC_QUALIFIER", "COLLECTION");
+    when(context.getTenantId()).thenReturn(TENANT_ID);
+    var messageId = UUID.randomUUID();
+    var payload = new AuthorityDto().id(messageId);
+    var domainEvent = DomainEvent.createEvent(messageId, payload, TENANT_ID);
+    final var expectedTopicName = "folio.COLLECTION." + TOPIC;
+
+    eventProducer.sendMessage(messageId.toString(), domainEvent, "headerKey", "headerVal");
+
+    var captor = ArgumentCaptor.forClass(ProducerRecord.class);
+    verify(template).send(captor.capture());
+    var capturedRecord = (ProducerRecord<String, DomainEvent<AuthorityDto>>) captor.getValue();
+    assertNotNull(capturedRecord);
+    assertEquals(expectedTopicName, capturedRecord.topic());
+    assertEquals(domainEvent, capturedRecord.value());
+  }
+}

--- a/src/test/java/org/folio/entlinks/utils/KafkaUtilsTest.java
+++ b/src/test/java/org/folio/entlinks/utils/KafkaUtilsTest.java
@@ -2,7 +2,6 @@ package org.folio.entlinks.utils;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.tuple;
-import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.List;
 import java.util.Map;
@@ -12,13 +11,6 @@ import org.junit.jupiter.api.Test;
 
 @UnitTest
 class KafkaUtilsTest {
-
-  @Test
-  void getTenantTopicName_positive() {
-    var actual = KafkaUtils.getTenantTopicName("topic-name", "tenant");
-
-    assertEquals("folio.tenant.topic-name", actual);
-  }
 
   @Test
   void toKafkaHeaders_positive() {


### PR DESCRIPTION
### Purpose
_Use generic topic name instead of creating new for each tenant_

### Approach
_Reuse KafkaUtils and respective method for topic name creation from folio-service-tools module_

### Changes Checklist
- [ ] **API Changes**: Document any API paths, methods, request or response bodies changed, added, or removed.
- [ ] **Database Schema Changes**: Indicate any database schema changes and their impact. Confirm that migration scripts were created.
- [ ] **Interface Version Changes**: Indicate any changes to interface versions.
- [ ] **Interface Dependencies**: Document added or removed dependencies.
- [ ] **Permissions**: Document any changes to permissions.
- [ ] **Logging**: Confirm that logging is appropriately handled.
- [ ] **Unit Testing**: Confirm that changed classes were covered by unit tests.
- [ ] **Integration Testing**: Confirm that changed logic was covered by integration tests.
- [ ] **Manual Testing**: Confirm that changes were tested on local or dev environment.
- [x] **NEWS**: Confirm that the NEWS file is updated with relevant information about the changes made in this pull request.

### Related Issues
[MODELINKS-213](https://folio-org.atlassian.net/browse/MODELINKS-213)
