### PR TITLE
Change default value for 6XX rules should have autoLinkingEnabled flag to true

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -23,6 +23,7 @@
 * Propagate authority archives deletion to member tenants ([MODELINKS-195](https://issues.folio.org/browse/MODELINKS-195))
 * Implement endpoint for bulk authorities upsert from external file ([MODELINKS-173](https://issues.folio.org/browse/MODELINKS-173))
 * Add possibility to filter Authority records by (un)defined fields in Cql query ([MODELINKS-214](https://issues.folio.org/browse/MODELINKS-214))
+* Set auto_linking_enabled in instance_authority_linking_rule for 6xx fields ([MODELINKS-220](https://folio-org.atlassian.net/browse/MODELINKS-220))
 
 ### Bug fixes
 * Fix secure setup of system users by default ([MODELINKS-135](https://issues.folio.org/browse/MODELINKS-135))

--- a/src/main/resources/db/changelog/changelog-master.xml
+++ b/src/main/resources/db/changelog/changelog-master.xml
@@ -21,4 +21,5 @@
   <include file="/changes/v3.0/add_authority_archives_indices.xml" relativeToChangelogFile="true"/>
   <include file="/changes/v3.0/add-authority-source-protocol.xml" relativeToChangelogFile="true"/>
   <include file="/changes/v3.0/add-authority-source-file-optimistic-locking.xml" relativeToChangelogFile="true"/>
+  <include file="/changes/v3.0/update-auto-linking_enabled.xml" relativeToChangelogFile="true"/>
 </databaseChangeLog>

--- a/src/main/resources/db/changelog/changes/v3.0/update-auto-linking_enabled.xml
+++ b/src/main/resources/db/changelog/changes/v3.0/update-auto-linking_enabled.xml
@@ -1,0 +1,21 @@
+<?xml version="1.1" encoding="UTF-8" standalone="no"?>
+<databaseChangeLog xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                   http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.18.xsd">
+
+  <changeSet id="MODELINKS-220@@set_auto_linking_enabled_for_6xx_fields" author="Tsaghik_Khachatryan">
+    <preConditions>
+      <tableExists tableName="instance_authority_linking_rule"/>
+    </preConditions>
+
+    <comment>Set auto_linking_enabled in instance_authority_linking_rule for 6xx fields</comment>
+
+    <sql>
+      UPDATE instance_authority_linking_rule
+      SET auto_linking_enabled = 'true'
+      WHERE bib_field like ('6%')
+    </sql>
+  </changeSet>
+
+</databaseChangeLog>

--- a/src/test/java/org/folio/entlinks/controller/LinksSuggestionsIT.java
+++ b/src/test/java/org/folio/entlinks/controller/LinksSuggestionsIT.java
@@ -168,23 +168,23 @@ class LinksSuggestionsIT extends IntegrationTestBase {
 
   @Test
   @SneakyThrows
-  void getAuthDataStat_shouldFillErrorDetails_whenAutoLinkingDisabled() {
+  void getAuthDataStat_shouldSuggestNewLink_whenOneField_is_600() {
     var givenSubfields = Map.of("0", NATURAL_ID);
     var givenRecord = getRecord("100", null, givenSubfields);
-    var disabledAutoLinkingRecord = getRecord("600", null, givenSubfields);
-
-    var expectedErrorDetails = new LinkDetails().status(ERROR).errorCause(DISABLED_AUTO_LINKING.getCode());
-    var expectedErrorRecord = getRecord("600", expectedErrorDetails, givenSubfields);
-
     var expectedLinkDetails = getLinkDetails(NEW, NATURAL_ID);
     var expectedSubfields = Map.of("a", "new $a value", "0", FULL_BASE_URL + NATURAL_ID, "9", LINKABLE_AUTHORITY_ID);
     var expectedRecord = getRecord("100", expectedLinkDetails, expectedSubfields);
 
-    var requestBody = new ParsedRecordContentCollection().records(List.of(givenRecord, disabledAutoLinkingRecord));
+    var givenSecondRecord = getRecord("600", null, givenSubfields);
+    var expectedSecondLinkDetails = getLinkDetails(NEW, NATURAL_ID, 8);
+    var expectedSecondSubfields = Map.of("a", "new $a value", "0", FULL_BASE_URL + NATURAL_ID, "9", LINKABLE_AUTHORITY_ID);
+    var expectedSecondRecord = getRecord("600", expectedSecondLinkDetails, expectedSecondSubfields);
+
+    var requestBody = new ParsedRecordContentCollection().records(List.of(givenRecord, givenSecondRecord));
     doPost(linksSuggestionsEndpoint(), requestBody)
       .andExpect(status().isOk())
       .andExpect(content().json(asJson(new ParsedRecordContentCollection()
-        .records(List.of(expectedRecord, expectedErrorRecord)), objectMapper)));
+        .records(List.of(expectedRecord, expectedSecondRecord)), objectMapper)));
   }
 
   @Test
@@ -232,12 +232,13 @@ class LinksSuggestionsIT extends IntegrationTestBase {
 
   @Test
   @SneakyThrows
-  void getAuthDataStat_shouldFillErrorDetails_whenAutoLinkingDisabled_andOnlyOneRecord() {
+  void getAuthDataStat_shouldSuggestNewLink_whenBibField_is_600() {
     var givenSubfields = Map.of("0", NATURAL_ID);
     var givenRecord = getRecord("600", null, givenSubfields);
 
-    var expectedLinkDetails = new LinkDetails().status(ERROR).errorCause(DISABLED_AUTO_LINKING.getCode());
-    var expectedRecord = getRecord("600", expectedLinkDetails, givenSubfields);
+    var expectedLinkDetails = getLinkDetails(NEW, NATURAL_ID, 8);
+    var expectedSubfields = Map.of("a", "new $a value", "0", FULL_BASE_URL + NATURAL_ID, "9", LINKABLE_AUTHORITY_ID);
+    var expectedRecord = getRecord("600", expectedLinkDetails, expectedSubfields);
 
     var requestBody = new ParsedRecordContentCollection().records(List.of(givenRecord));
     doPost(linksSuggestionsEndpoint(), requestBody)

--- a/src/test/java/org/folio/entlinks/controller/LinksSuggestionsIT.java
+++ b/src/test/java/org/folio/entlinks/controller/LinksSuggestionsIT.java
@@ -169,29 +169,6 @@ class LinksSuggestionsIT extends IntegrationTestBase {
 
   @Test
   @SneakyThrows
-  void getAuthDataStat_shouldSuggestNewLink_whenOneField_is_600() {
-    var givenSubfields = Map.of("0", NATURAL_ID);
-    var givenRecord = getRecord("100", null, givenSubfields);
-    var expectedLinkDetails = getLinkDetails(NEW, NATURAL_ID);
-    var expectedSubfields = Map.of("a", "new $a value", "0",
-        FULL_BASE_URL + NATURAL_ID, "9", LINKABLE_AUTHORITY_ID);
-    var expectedRecord = getRecord("100", expectedLinkDetails, expectedSubfields);
-
-    var givenSecondRecord = getRecord("600", null, givenSubfields);
-    var expectedSecondLinkDetails = getLinkDetails(NEW, NATURAL_ID, 8);
-    var expectedSecondSubfields = Map.of("a", "new $a value", "0",
-        FULL_BASE_URL + NATURAL_ID, "9", LINKABLE_AUTHORITY_ID);
-    var expectedSecondRecord = getRecord("600", expectedSecondLinkDetails, expectedSecondSubfields);
-
-    var requestBody = new ParsedRecordContentCollection().records(List.of(givenRecord, givenSecondRecord));
-    doPost(linksSuggestionsEndpoint(), requestBody)
-      .andExpect(status().isOk())
-      .andExpect(content().json(asJson(new ParsedRecordContentCollection()
-        .records(List.of(expectedRecord, expectedSecondRecord)), objectMapper)));
-  }
-
-  @Test
-  @SneakyThrows
   void getAuthDataStat_shouldFillErrorDetails_whenAutoLinkingDisabled() {
     databaseHelper.disableAutoLinking(TENANT_ID, RULE_ID_OF_600_FIELD);
 
@@ -208,12 +185,11 @@ class LinksSuggestionsIT extends IntegrationTestBase {
 
     var requestBody = new ParsedRecordContentCollection().records(List.of(givenRecord, disabledAutoLinkingRecord));
     doPost(linksSuggestionsEndpoint(), requestBody)
-        .andExpect(status().isOk())
-        .andExpect(content().json(asJson(new ParsedRecordContentCollection()
-            .records(List.of(expectedRecord, expectedErrorRecord)), objectMapper)));
+      .andExpect(status().isOk())
+      .andExpect(content().json(asJson(new ParsedRecordContentCollection()
+        .records(List.of(expectedRecord, expectedErrorRecord)), objectMapper)));
 
     databaseHelper.enableAutoLinking(TENANT_ID, RULE_ID_OF_600_FIELD);
-
   }
 
   @Test

--- a/src/test/java/org/folio/entlinks/controller/LinksSuggestionsIT.java
+++ b/src/test/java/org/folio/entlinks/controller/LinksSuggestionsIT.java
@@ -170,7 +170,7 @@ class LinksSuggestionsIT extends IntegrationTestBase {
   @Test
   @SneakyThrows
   void getAuthDataStat_shouldFillErrorDetails_whenAutoLinkingDisabled() {
-    databaseHelper.disableAutoLinking(TENANT_ID, RULE_ID_OF_600_FIELD);
+    databaseHelper.updateAutoLinking(TENANT_ID, RULE_ID_OF_600_FIELD, false);
 
     var givenSubfields = Map.of("0", NATURAL_ID);
     var givenRecord = getRecord("100", null, givenSubfields);
@@ -189,7 +189,7 @@ class LinksSuggestionsIT extends IntegrationTestBase {
       .andExpect(content().json(asJson(new ParsedRecordContentCollection()
         .records(List.of(expectedRecord, expectedErrorRecord)), objectMapper)));
 
-    databaseHelper.enableAutoLinking(TENANT_ID, RULE_ID_OF_600_FIELD);
+    databaseHelper.updateAutoLinking(TENANT_ID, RULE_ID_OF_600_FIELD, true);
   }
 
   @Test
@@ -255,7 +255,7 @@ class LinksSuggestionsIT extends IntegrationTestBase {
   @Test
   @SneakyThrows
   void getAuthDataStat_shouldFillErrorDetails_whenAutoLinkingDisabled_andOnlyOneRecord() {
-    databaseHelper.disableAutoLinking(TENANT_ID, RULE_ID_OF_600_FIELD);
+    databaseHelper.updateAutoLinking(TENANT_ID, RULE_ID_OF_600_FIELD, false);
 
     var givenSubfields = Map.of("0", NATURAL_ID);
     var givenRecord = getRecord("600", null, givenSubfields);
@@ -269,7 +269,7 @@ class LinksSuggestionsIT extends IntegrationTestBase {
         .andExpect(content().json(asJson(new ParsedRecordContentCollection()
             .records(List.of(expectedRecord)), objectMapper)));
 
-    databaseHelper.enableAutoLinking(TENANT_ID, RULE_ID_OF_600_FIELD);
+    databaseHelper.updateAutoLinking(TENANT_ID, RULE_ID_OF_600_FIELD, true);
   }
 
   private ParsedRecordContent getRecord(String bibField, LinkDetails linkDetails, Map<String, String> subfields) {

--- a/src/test/java/org/folio/entlinks/controller/LinksSuggestionsIT.java
+++ b/src/test/java/org/folio/entlinks/controller/LinksSuggestionsIT.java
@@ -1,6 +1,5 @@
 package org.folio.entlinks.controller;
 
-import static org.folio.entlinks.config.constants.ErrorCode.DISABLED_AUTO_LINKING;
 import static org.folio.entlinks.config.constants.ErrorCode.MORE_THAN_ONE_SUGGESTIONS;
 import static org.folio.entlinks.config.constants.ErrorCode.NO_SUGGESTIONS;
 import static org.folio.entlinks.domain.dto.LinkStatus.ACTUAL;
@@ -172,12 +171,14 @@ class LinksSuggestionsIT extends IntegrationTestBase {
     var givenSubfields = Map.of("0", NATURAL_ID);
     var givenRecord = getRecord("100", null, givenSubfields);
     var expectedLinkDetails = getLinkDetails(NEW, NATURAL_ID);
-    var expectedSubfields = Map.of("a", "new $a value", "0", FULL_BASE_URL + NATURAL_ID, "9", LINKABLE_AUTHORITY_ID);
+    var expectedSubfields = Map.of("a", "new $a value", "0",
+        FULL_BASE_URL + NATURAL_ID, "9", LINKABLE_AUTHORITY_ID);
     var expectedRecord = getRecord("100", expectedLinkDetails, expectedSubfields);
 
     var givenSecondRecord = getRecord("600", null, givenSubfields);
     var expectedSecondLinkDetails = getLinkDetails(NEW, NATURAL_ID, 8);
-    var expectedSecondSubfields = Map.of("a", "new $a value", "0", FULL_BASE_URL + NATURAL_ID, "9", LINKABLE_AUTHORITY_ID);
+    var expectedSecondSubfields = Map.of("a", "new $a value", "0",
+        FULL_BASE_URL + NATURAL_ID, "9", LINKABLE_AUTHORITY_ID);
     var expectedSecondRecord = getRecord("600", expectedSecondLinkDetails, expectedSecondSubfields);
 
     var requestBody = new ParsedRecordContentCollection().records(List.of(givenRecord, givenSecondRecord));

--- a/src/test/java/org/folio/support/DatabaseHelper.java
+++ b/src/test/java/org/folio/support/DatabaseHelper.java
@@ -26,6 +26,7 @@ public class DatabaseHelper {
   public static final String AUTHORITY_TABLE = "authority";
   public static final String AUTHORITY_ARCHIVE_TABLE = "authority_archive";
   public static final String AUTHORITY_REINDEX_JOB_TABLE = "reindex_job";
+  public static final String INSTANCE_AUTHORITY_LINKING_RULE = "instance_authority_linking_rule";
 
   private final FolioModuleMetadata metadata;
   private final JdbcTemplate jdbcTemplate;
@@ -97,6 +98,18 @@ public class DatabaseHelper {
     var sql = "SELECT last_value FROM " + metadata.getDBSchemaName(tenant) + "."
         + queryAuthoritySourceFileSequenceName(tenant, id);
     return jdbcTemplate.queryForObject(sql, Integer.class);
+  }
+
+  public void disableAutoLinking(String tenant, Integer ruleId){
+    var sql = "UPDATE " + getDbPath(tenant, INSTANCE_AUTHORITY_LINKING_RULE)
+        + " SET auto_linking_enabled = ? where id = ?";
+    jdbcTemplate.update(sql, false, ruleId);
+  }
+
+  public void enableAutoLinking(String tenant, Integer ruleId){
+    var sql = "UPDATE " + getDbPath(tenant, INSTANCE_AUTHORITY_LINKING_RULE)
+        + " SET auto_linking_enabled = ? where id = ?";
+    jdbcTemplate.update(sql, true, ruleId);
   }
 
   public Integer queryAuthoritySourceFileSequenceStartNumber(String sequenceName) {

--- a/src/test/java/org/folio/support/DatabaseHelper.java
+++ b/src/test/java/org/folio/support/DatabaseHelper.java
@@ -100,13 +100,13 @@ public class DatabaseHelper {
     return jdbcTemplate.queryForObject(sql, Integer.class);
   }
 
-  public void disableAutoLinking(String tenant, Integer ruleId){
+  public void disableAutoLinking(String tenant, Integer ruleId) {
     var sql = "UPDATE " + getDbPath(tenant, INSTANCE_AUTHORITY_LINKING_RULE)
         + " SET auto_linking_enabled = ? where id = ?";
     jdbcTemplate.update(sql, false, ruleId);
   }
 
-  public void enableAutoLinking(String tenant, Integer ruleId){
+  public void enableAutoLinking(String tenant, Integer ruleId) {
     var sql = "UPDATE " + getDbPath(tenant, INSTANCE_AUTHORITY_LINKING_RULE)
         + " SET auto_linking_enabled = ? where id = ?";
     jdbcTemplate.update(sql, true, ruleId);

--- a/src/test/java/org/folio/support/DatabaseHelper.java
+++ b/src/test/java/org/folio/support/DatabaseHelper.java
@@ -100,16 +100,10 @@ public class DatabaseHelper {
     return jdbcTemplate.queryForObject(sql, Integer.class);
   }
 
-  public void disableAutoLinking(String tenant, Integer ruleId) {
+  public void updateAutoLinking(String tenant, Integer ruleId, Boolean isAutoLinkingEnabled) {
     var sql = "UPDATE " + getDbPath(tenant, INSTANCE_AUTHORITY_LINKING_RULE)
         + " SET auto_linking_enabled = ? where id = ?";
-    jdbcTemplate.update(sql, false, ruleId);
-  }
-
-  public void enableAutoLinking(String tenant, Integer ruleId) {
-    var sql = "UPDATE " + getDbPath(tenant, INSTANCE_AUTHORITY_LINKING_RULE)
-        + " SET auto_linking_enabled = ? where id = ?";
-    jdbcTemplate.update(sql, true, ruleId);
+    jdbcTemplate.update(sql, isAutoLinkingEnabled, ruleId);
   }
 
   public Integer queryAuthoritySourceFileSequenceStartNumber(String sequenceName) {

--- a/src/test/resources/linking-rules/instance-authority.json
+++ b/src/test/resources/linking-rules/instance-authority.json
@@ -201,7 +201,7 @@
       "s",
       "t"
     ],
-    "autoLinkingEnabled": false
+    "autoLinkingEnabled": true
   },
   {
     "id": 9,
@@ -225,7 +225,7 @@
       "s",
       "t"
     ],
-    "autoLinkingEnabled": false
+    "autoLinkingEnabled": true
   },
   {
     "id": 10,
@@ -247,7 +247,7 @@
       "g",
       "n"
     ],
-    "autoLinkingEnabled": false
+    "autoLinkingEnabled": true
   },
   {
     "id": 11,
@@ -269,7 +269,7 @@
       "s",
       "t"
     ],
-    "autoLinkingEnabled": false
+    "autoLinkingEnabled": true
   },
   {
     "id": 12,
@@ -280,7 +280,7 @@
       "b",
       "g"
     ],
-    "autoLinkingEnabled": false
+    "autoLinkingEnabled": true
   },
   {
     "id": 13,
@@ -290,7 +290,7 @@
       "a",
       "g"
     ],
-    "autoLinkingEnabled": false
+    "autoLinkingEnabled": true
   },
   {
     "id": 14,
@@ -299,7 +299,7 @@
     "authoritySubfields": [
       "a"
     ],
-    "autoLinkingEnabled": false
+    "autoLinkingEnabled": true
   },
   {
     "id": 15,


### PR DESCRIPTION
### Purpose
Change default value for 6XX rules should have autoLinkingEnabled flag to true

### Approach
Create SQL script which updates autoLinkingEnabled flag to true for 6xx fields

### Changes Checklist
- [ ] **API Changes**: Document any API paths, methods, request or response bodies changed, added, or removed.
- [x] **Database Schema Changes**: Indicate any database schema changes and their impact. Confirm that migration scripts were created.
- [ ] **Interface Version Changes**: Indicate any changes to interface versions.
- [ ] **Interface Dependencies**: Document added or removed dependencies.
- [ ] **Permissions**: Document any changes to permissions.
- [ ] **Logging**: Confirm that logging is appropriately handled.
- [ ] **Unit Testing**: Confirm that changed classes were covered by unit tests.
- [ ] **Integration Testing**: Confirm that changed logic was covered by integration tests.
- [ ] **Manual Testing**: Confirm that changes were tested on local or dev environment.
- [x] **NEWS**: Confirm that the NEWS file is updated with relevant information about the changes made in this pull request.

### Related Issues
https://folio-org.atlassian.net/browse/MODELINKS-220
