### PR TITLE
fix(authority-source-files-base-url): Authority file with empty “Base URL” is saved

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -34,6 +34,7 @@
 * Fix authority source file sequence deletion ([MODELINKS-211](https://issues.folio.org/browse/MODELINKS-211))
 * Fix authority source file prefix validation for PATCH request ([MODELINKS-208](https://folio-org.atlassian.net/browse/MODELINKS-208))
 * Use generic topic name instead of creating new for each tenant ([MODELINKS-213](https://issues.folio.org/browse/MODELINKS-213))
+* Save an Authority file with an empty "Base URL" when another one with an empty url already exists ([MODELINKS-216](https://issues.folio.org/browse/MODELINKS-216))
 
 ### Tech Dept
 * Create custom Mockito verifies for Hibernate entities ([MODELINKS-209](https://issues.folio.org/browse/MODELINKS-209))

--- a/src/main/java/org/folio/entlinks/controller/converter/AuthoritySourceFileMapper.java
+++ b/src/main/java/org/folio/entlinks/controller/converter/AuthoritySourceFileMapper.java
@@ -145,7 +145,11 @@ public interface AuthoritySourceFileMapper {
   }
 
   private static void setUrlProperties(String baseUrlDto, AuthoritySourceFile target) {
-    if (StringUtils.isBlank(baseUrlDto)) {
+    if (baseUrlDto == null) {
+      return;
+    }
+    if (baseUrlDto.isEmpty()) {
+      target.setBaseUrl(null);
       return;
     }
 

--- a/src/test/java/org/folio/entlinks/controller/converter/AuthoritySourceFileMapperTest.java
+++ b/src/test/java/org/folio/entlinks/controller/converter/AuthoritySourceFileMapperTest.java
@@ -99,6 +99,30 @@ class AuthoritySourceFileMapperTest {
   }
 
   @Test
+  void testPartialUpdateWithEmptyBaseUrl() {
+    var sourceFile = createAuthoritySourceFile();
+    var patchDto = new AuthoritySourceFilePatchDto();
+    patchDto.setName(UPDATED_NAME);
+    patchDto.setType(UPDATED_TYPE);
+    patchDto.setCode(UPDATED_CODE);
+    patchDto.setBaseUrl("");
+    patchDto.selectable(true);
+    patchDto.hridManagement(new AuthoritySourceFilePatchDtoHridManagement().startNumber(5));
+
+    var updatedFile = mapper.partialUpdate(patchDto, sourceFile);
+
+    assertThat(updatedFile).isNotNull();
+    assertThat(updatedFile.getName()).isEqualTo(patchDto.getName());
+    assertThat(updatedFile.getType()).isEqualTo(patchDto.getType());
+    assertThat(updatedFile.getAuthoritySourceFileCodes().iterator().next().getCode()).isEqualTo(patchDto.getCode());
+    assertThat(updatedFile.getFullBaseUrl()).isEqualTo(null);
+    assertThat(updatedFile.isSelectable()).isEqualTo(patchDto.getSelectable());
+    assertThat(updatedFile.getHridStartNumber()).isEqualTo(patchDto.getHridManagement().getStartNumber());
+    assertThat(updatedFile.getSource()).isEqualTo(sourceFile.getSource());
+    assertThat(updatedFile.getSequenceName()).isEqualTo(sourceFile.getSequenceName());
+  }
+
+  @Test
   void testPartialUpdate_noCodesUpdate() {
     var code = new AuthoritySourceFileCode();
     code.setCode("a");


### PR DESCRIPTION
### Purpose
Ensure that a user can save an "Authority file" with an empty "Base URL" when another "Authority file" with an empty "Base URL" already exists in the system.

### Approach
Implement a check that when the "baseURL" field is an empty string, the corresponding database entry is saved with a null value.

### Changes Checklist
- [ ] **API Changes**: Document any API paths, methods, request or response bodies changed, added, or removed.
- [ ] **Database Schema Changes**: Indicate any database schema changes and their impact. Confirm that migration scripts were created.
- [ ] **Interface Version Changes**: Indicate any changes to interface versions.
- [ ] **Interface Dependencies**: Document added or removed dependencies.
- [ ] **Permissions**: Document any changes to permissions.
- [ ] **Logging**: Confirm that logging is appropriately handled.
- [ ] **Unit Testing**: Confirm that changed classes were covered by unit tests.
- [ ] **Integration Testing**: Confirm that changed logic was covered by integration tests.
- [ ] **Manual Testing**: Confirm that changes were tested on local or dev environment.
- [ ] **NEWS**: Confirm that the NEWS file is updated with relevant information about the changes made in this pull request.

### Learning and Resources (if applicable)
https://folio-org.atlassian.net/browse/MODELINKS-216

