### PR TITLE
MODELINKS-219: Fix authority record update and updatedByUserId field assignment

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -37,6 +37,7 @@
 * Use generic topic name instead of creating new for each tenant ([MODELINKS-213](https://issues.folio.org/browse/MODELINKS-213))
 * Fix modifying and deleting of source file referenced by authority of member tenant in ECS ([MODELINKS-217](https://issues.folio.org/browse/MODELINKS-217))
 * Add new error code to handle authority source file deletion after authority deletion ([MODELINKS-210](https://issues.folio.org/browse/MODELINKS-210))
+* Fix authority record update and `updatedByUserId` field assignment ([MODELINKS-219](https://issues.folio.org/browse/MODELINKS-219))
 
 ### Tech Dept
 * Create custom Mockito verifies for Hibernate entities ([MODELINKS-209](https://issues.folio.org/browse/MODELINKS-209))

--- a/src/main/java/org/folio/entlinks/domain/entity/Authority.java
+++ b/src/main/java/org/folio/entlinks/domain/entity/Authority.java
@@ -23,7 +23,7 @@ import org.springframework.data.domain.Persistable;
 @Entity
 @AllArgsConstructor
 @NoArgsConstructor
-@ToString
+@ToString(callSuper = true)
 @Table(name = "authority")
 public class Authority extends AuthorityBase implements Persistable<UUID>, Identifiable<UUID> {
 

--- a/src/main/java/org/folio/entlinks/domain/entity/AuthorityBase.java
+++ b/src/main/java/org/folio/entlinks/domain/entity/AuthorityBase.java
@@ -16,11 +16,13 @@ import lombok.NoArgsConstructor;
 import lombok.Setter;
 import lombok.ToString;
 import org.apache.commons.lang3.StringUtils;
+import org.hibernate.Hibernate;
 import org.hibernate.annotations.JdbcTypeCode;
 import org.hibernate.type.SqlTypes;
 
 @Getter
 @Setter
+@ToString(callSuper = true)
 @NoArgsConstructor
 @AllArgsConstructor
 @MappedSuperclass
@@ -93,6 +95,7 @@ public class AuthorityBase extends MetadataEntity {
     this.id = other.id;
     this.naturalId = other.naturalId;
     this.authoritySourceFile = Optional.ofNullable(other.authoritySourceFile)
+        .map(sourceFile -> Hibernate.unproxy(sourceFile, AuthoritySourceFile.class))
         .map(AuthoritySourceFile::new)
         .orElse(null);
     this.source = other.source;

--- a/src/main/java/org/folio/entlinks/domain/entity/AuthoritySourceFile.java
+++ b/src/main/java/org/folio/entlinks/domain/entity/AuthoritySourceFile.java
@@ -1,5 +1,7 @@
 package org.folio.entlinks.domain.entity;
 
+import static java.util.stream.Collectors.toSet;
+
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -94,7 +96,7 @@ public class AuthoritySourceFile extends MetadataEntity implements Persistable<U
       .orElse(Set.of())
       .stream()
       .map(AuthoritySourceFileCode::new)
-      .collect(java.util.stream.Collectors.toSet());
+      .collect(toSet());
     this.sequenceName = other.sequenceName;
     this.selectable = other.selectable;
     this.hridStartNumber = other.hridStartNumber;

--- a/src/main/java/org/folio/entlinks/domain/entity/MetadataEntity.java
+++ b/src/main/java/org/folio/entlinks/domain/entity/MetadataEntity.java
@@ -9,6 +9,7 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+import lombok.ToString;
 import org.springframework.data.annotation.CreatedBy;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedBy;
@@ -19,6 +20,7 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 @Setter
 @NoArgsConstructor
 @AllArgsConstructor
+@ToString
 @MappedSuperclass
 @EntityListeners(AuditingEntityListener.class)
 public class MetadataEntity {

--- a/src/main/java/org/folio/entlinks/service/authority/AuthorityService.java
+++ b/src/main/java/org/folio/entlinks/service/authority/AuthorityService.java
@@ -203,7 +203,7 @@ public class AuthorityService implements AuthorityServiceI<Authority> {
 
     copyModifiableFields(existing, modified);
 
-    var saved = repository.save(existing);
+    var saved = repository.saveAndFlush(existing);
     if (authorityConsumer != null) {
       authorityConsumer.accept(saved, detachedExisting);
     }

--- a/src/test/java/org/folio/entlinks/service/authority/AuthorityServiceTest.java
+++ b/src/test/java/org/folio/entlinks/service/authority/AuthorityServiceTest.java
@@ -150,12 +150,12 @@ class AuthorityServiceTest {
     modified.setAuthoritySourceFile(sourceFileNew);
 
     when(repository.findByIdAndDeletedFalse(id)).thenReturn(Optional.of(existed));
-    when(repository.save(any(Authority.class))).thenAnswer(invocation -> invocation.getArgument(0));
+    when(repository.saveAndFlush(any(Authority.class))).thenAnswer(invocation -> invocation.getArgument(0));
     var updated = service.update(modified);
 
     assertThat(updated).isEqualTo(modified);
     verify(repository).findByIdAndDeletedFalse(id);
-    verify(repository).save(argThat(authorityMatch(modified)));
+    verify(repository).saveAndFlush(argThat(authorityMatch(modified)));
   }
 
   @Test
@@ -173,13 +173,13 @@ class AuthorityServiceTest {
     modified.setAuthoritySourceFile(null);
 
     when(repository.findByIdAndDeletedFalse(id)).thenReturn(Optional.of(existed));
-    when(repository.save(any(Authority.class))).thenAnswer(invocation -> invocation.getArgument(0));
+    when(repository.saveAndFlush(any(Authority.class))).thenAnswer(invocation -> invocation.getArgument(0));
 
     var updated = service.update(modified);
 
     assertThat(updated.getAuthoritySourceFile()).isNull();
     verify(repository).findByIdAndDeletedFalse(id);
-    verify(repository).save(existed);
+    verify(repository).saveAndFlush(existed);
     verifyNoMoreInteractions(repository);
   }
 

--- a/src/test/java/org/folio/support/base/TestConstants.java
+++ b/src/test/java/org/folio/support/base/TestConstants.java
@@ -17,6 +17,7 @@ public class TestConstants {
   public static final String CENTRAL_TENANT_ID = "consortium";
   public static final String CONSORTIUM_SOURCE_PREFIX = "CONSORTIUM-";
   public static final String USER_ID = "38d3a441-c100-5e8d-bd12-71bde492b723";
+  public static final String UPDATER_USER_ID = "4df34034-dc86-4364-8d8a-65ab22d44063";
   public static final String SOURCE_FILE_NAME = "sourceFileName";
   public static final String SOURCE_FILE_TYPE = "sourceFileType";
   public static final String SOURCE_FILE_CODE = "sourceFileType";

--- a/src/test/resources/mappings/users.json
+++ b/src/test/resources/mappings/users.json
@@ -28,6 +28,19 @@
     },
     {
       "request": {
+        "method": "GET",
+        "url": "/users?query=id%3D%284df34034-dc86-4364-8d8a-65ab22d44063%29"
+      },
+      "response": {
+        "status": 200,
+        "body": "{\n \"users\": [\n {\n \"id\": \"4df34034-dc86-4364-8d8a-65ab22d44063\",\n \"username\": \"nikola.tesla\",\n \"personal\": {\n \"firstName\": \"Nikola\",\n \"lastName\": \"Tesla\"\n }\n }\n ],\n \"totalRecords\": 1\n}",
+        "headers": {
+          "Content-Type": "application/json"
+        }
+      }
+    },
+    {
+      "request": {
         "method": "POST",
         "url": "/users"
       },


### PR DESCRIPTION
### Purpose
_Capture the changes for authority record's ```updatedByUserId``` attribute before forming and sending the Update domain event DTO so that the DTO also has the right value at ```updatedByUserId``` (Authority Data Stat's ```startedByUserId``` attribute take the value from domain event's updatedByUserId). Also, fix the authority copy constructor to copy the authority source file._

### Approach
_After the update/save of the authority changes immediately flush them so that Hibernate immediately updates the audit attributes._

### Changes Checklist
- [ ] **API Changes**: Document any API paths, methods, request or response bodies changed, added, or removed.
- [ ] **Database Schema Changes**: Indicate any database schema changes and their impact. Confirm that migration scripts were created.
- [ ] **Interface Version Changes**: Indicate any changes to interface versions.
- [ ] **Interface Dependencies**: Document added or removed dependencies.
- [ ] **Permissions**: Document any changes to permissions.
- [ ] **Logging**: Confirm that logging is appropriately handled.
- [ ] **Unit Testing**: Confirm that changed classes were covered by unit tests.
- [x] **Integration Testing**: Confirm that changed logic was covered by integration tests.
- [ ] **Manual Testing**: Confirm that changes were tested on local or dev environment.
- [x] **NEWS**: Confirm that the NEWS file is updated with relevant information about the changes made in this pull request.

### Related Issues
[MODELINKS-219](https://folio-org.atlassian.net/browse/MODELINKS-219)