### PR TITLE
fix: do not delete kafka topics if tenant collection topic feature is enabled

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,25 @@
+## v3.1.0 YYYY-mm-DD - In progress
+### Breaking changes
+* Description ([ISSUE](https://folio-org.atlassian.net/browse/ISSUE))
+
+### New APIs versions
+* Provides `API_NAME vX.Y`
+* Requires `API_NAME vX.Y`
+
+### Features
+* Description ([ISSUE](https://folio-org.atlassian.net//browse/ISSUE))
+
+### Bug fixes
+* Do not delete kafka topics if tenant collection topic feature is enabled ([MODELINKS-233](https://folio-org.atlassian.net/browse/MODELINKS-233))
+
+### Tech Dept
+* Description ([ISSUE](https://folio-org.atlassian.net/browse/ISSUE))
+
+### Dependencies
+* Bump `LIB_NAME` from `OLD_VERSION` to `NEW_VERSION`
+* Add `LIB_NAME` `VERSION`
+* Remove `LIB_NAME`
+
 ## v3.0.0 2024-03-19
 ### Breaking changes
 * Delete PUT endpoint from authority-source-files api([MODELINKS-161](https://issues.folio.org/browse/MODELINKS-161))

--- a/pom.xml
+++ b/pom.xml
@@ -25,9 +25,9 @@
       src/main/java/org/folio/entlinks/model/**
     </sonar.exclusions>
 
-    <folio-spring-support.version>8.1.0</folio-spring-support.version>
-    <folio-service-tools.version>4.0.0</folio-service-tools.version>
-    <folio-s3-client.version>2.1.0</folio-s3-client.version>
+    <folio-spring-support.version>8.2.0-SNAPSHOT</folio-spring-support.version>
+    <folio-service-tools.version>4.1.0-SNAPSHOT</folio-service-tools.version>
+    <folio-s3-client.version>2.2.0-SNAPSHOT</folio-s3-client.version>
     <aws-sdk-java.version>2.25.27</aws-sdk-java.version>
     <mapstruct.version>1.5.5.Final</mapstruct.version>
     <lombok.mapstruct-binding.version>0.2.0</lombok.mapstruct-binding.version>


### PR DESCRIPTION
### Purpose
do not delete kafka topics if tenant collection topic feature is enabled

### Approach
Use newest version of folio-service-tools

### Changes Checklist
- [ ] **API Changes**: Document any API paths, methods, request or response bodies changed, added, or removed.
- [ ] **Database Schema Changes**: Indicate any database schema changes and their impact. Confirm that migration scripts were created.
- [ ] **Interface Version Changes**: Indicate any changes to interface versions.
- [ ] **Interface Dependencies**: Document added or removed dependencies.
- [ ] **Permissions**: Document any changes to permissions.
- [ ] **Logging**: Confirm that logging is appropriately handled.
- [ ] **Unit Testing**: Confirm that changed classes were covered by unit tests.
- [ ] **Integration Testing**: Confirm that changed logic was covered by integration tests.
- [ ] **Manual Testing**: Confirm that changes were tested on local or dev environment.
- [x] **NEWS**: Confirm that the NEWS file is updated with relevant information about the changes made in this pull request.

### Related Issues
https://folio-org.atlassian.net/browse/MODELINKS-233