### PR TITLE
fix: cleanup authority_data_stat foreign-key

### DIFF
--- a/src/main/resources/db/changelog/changelog-master.xml
+++ b/src/main/resources/db/changelog/changelog-master.xml
@@ -15,6 +15,7 @@
   <include file="/changes/v2.0/create-reindex-job.xml" relativeToChangelogFile="true"/>
   <include file="/changes/v2.0/replace_authority_data.xml" relativeToChangelogFile="true"/>
   <include file="/changes/v2.0/update_authority_heading.xml" relativeToChangelogFile="true"/>
+  <include file="/changes/v2.0/cleanup_authority_data_stat_constraint.xml" relativeToChangelogFile="true"/>
   <include file="/changes/v3.0/create-authority_archive.xml" relativeToChangelogFile="true"/>
   <include file="/changes/v3.0/add_authority_source_file_new_fields.xml" relativeToChangelogFile="true"/>
   <include file="/changes/v3.0/changes-authority-source-type.xml" relativeToChangelogFile="true"/>

--- a/src/main/resources/db/changelog/changes/v2.0/cleanup_authority_data_stat_constraint.xml
+++ b/src/main/resources/db/changelog/changes/v2.0/cleanup_authority_data_stat_constraint.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                   https://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
+
+  <changeSet id="MODELINKS-234@@cleanup-authority_data_stat-foreign-key" author="Pavlo_Smahin">
+    <preConditions onFail="MARK_RAN">
+      <foreignKeyConstraintExists foreignKeyName="fk_authority_data_stat_authority_id"
+                                  schemaName="${database.defaultSchemaName}"
+                                  foreignKeyTableName="authority_data_stat"/>
+    </preConditions>
+
+    <comment>Cleanup fk_authority_data_stat_authority_id constraint from authority_data_stat table</comment>
+    <dropForeignKeyConstraint baseTableName="authority_data_stat" constraintName="fk_authority_data_stat_authority_id"/>
+  </changeSet>
+
+</databaseChangeLog>


### PR DESCRIPTION
### Purpose
For some reason constraint that shouldn’t exist appeared on some envs. It’s needed to clean unneeded fk_authority_data_stat_authority_id` constraint from authority_data_stat table

Having this constraint may cause breaking bib-authority links

### Approach
Create a liquibase script for deleting the constraint.

### Changes Checklist
- [ ] **API Changes**: Document any API paths, methods, request or response bodies changed, added, or removed.
- [ ] **Database Schema Changes**: Indicate any database schema changes and their impact. Confirm that migration scripts were created.
- [ ] **Interface Version Changes**: Indicate any changes to interface versions.
- [ ] **Interface Dependencies**: Document added or removed dependencies.
- [ ] **Permissions**: Document any changes to permissions.
- [ ] **Logging**: Confirm that logging is appropriately handled.
- [ ] **Unit Testing**: Confirm that changed classes were covered by unit tests.
- [ ] **Integration Testing**: Confirm that changed logic was covered by integration tests.
- [x] **Manual Testing**: Confirm that changes were tested on local or dev environment.
- [ ] **NEWS**: Confirm that the NEWS file is updated with relevant information about the changes made in this pull request.

### Related Issues
https://folio-org.atlassian.net/browse/MODELINKS-234