### PR TITLE
fix(authority-storage): Return only ids in response when idOnly=true

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -12,6 +12,7 @@
 ### Bug fixes
 * Do not delete kafka topics if tenant collection topic feature is enabled ([MODELINKS-233](https://folio-org.atlassian.net/browse/MODELINKS-233))
 * Add checking for Authority source file references for member tenant in ECS ([MODELINKS-227](https://issues.folio.org/browse/MODELINKS-227))
+* Return only ids in response when idOnly=true ([MODELINKS-237](https://issues.folio.org/browse/MODELINKS-227))
 
 ### Tech Dept
 * Description ([ISSUE](https://folio-org.atlassian.net/browse/ISSUE))

--- a/src/main/java/org/folio/entlinks/controller/AuthorityController.java
+++ b/src/main/java/org/folio/entlinks/controller/AuthorityController.java
@@ -12,7 +12,9 @@ import org.folio.entlinks.controller.delegate.AuthorityServiceDelegate;
 import org.folio.entlinks.domain.dto.AuthorityBulkRequest;
 import org.folio.entlinks.domain.dto.AuthorityBulkResponse;
 import org.folio.entlinks.domain.dto.AuthorityDto;
-import org.folio.entlinks.domain.dto.AuthorityDtoCollection;
+import org.folio.entlinks.domain.dto.AuthorityFullDtoCollection;
+import org.folio.entlinks.domain.dto.AuthorityIdDto;
+import org.folio.entlinks.domain.dto.AuthorityIdDtoCollection;
 import org.folio.entlinks.exception.AuthoritiesRequestNotSupportedMediaTypeException;
 import org.folio.entlinks.rest.resource.AuthorityStorageApi;
 import org.folio.tenant.domain.dto.Parameter;
@@ -93,16 +95,16 @@ public class AuthorityController implements AuthorityStorageApi {
     return ResponseEntity.status(HttpStatus.ACCEPTED).build();
   }
 
-  private ResponseEntity<Object> getAuthoritiesCollectionResponse(AuthorityDtoCollection collectionDto,
+  private ResponseEntity<Object> getAuthoritiesCollectionResponse(AuthorityFullDtoCollection collectionDto,
                                                                   List<String> acceptingMediaTypes,
                                                                   Boolean idOnly) {
     var headers = new HttpHeaders();
     if (Boolean.TRUE.equals(idOnly) && CollectionUtils.isNotEmpty(acceptingMediaTypes)
-        && acceptingMediaTypes.contains(TEXT_PLAIN_VALUE)) {
+      && acceptingMediaTypes.contains(TEXT_PLAIN_VALUE)) {
       headers.setContentType(MediaType.TEXT_PLAIN);
       return new ResponseEntity<>(
-        collectionDto.getAuthorities().stream()
-          .map(AuthorityDto::getId)
+        ((AuthorityIdDtoCollection) collectionDto).getAuthorities().stream()
+          .map(AuthorityIdDto::getId)
           .map(UUID::toString)
           .collect(Collectors.joining(System.lineSeparator())),
         headers,

--- a/src/main/java/org/folio/entlinks/controller/delegate/AuthorityArchiveServiceDelegate.java
+++ b/src/main/java/org/folio/entlinks/controller/delegate/AuthorityArchiveServiceDelegate.java
@@ -8,8 +8,9 @@ import lombok.extern.log4j.Log4j2;
 import org.folio.entlinks.client.SettingsClient;
 import org.folio.entlinks.config.properties.AuthorityArchiveProperties;
 import org.folio.entlinks.controller.converter.AuthorityMapper;
-import org.folio.entlinks.domain.dto.AuthorityDto;
-import org.folio.entlinks.domain.dto.AuthorityDtoCollection;
+import org.folio.entlinks.domain.dto.AuthorityFullDtoCollection;
+import org.folio.entlinks.domain.dto.AuthorityIdDto;
+import org.folio.entlinks.domain.dto.AuthorityIdDtoCollection;
 import org.folio.entlinks.domain.entity.AuthorityArchive;
 import org.folio.entlinks.domain.entity.AuthorityBase;
 import org.folio.entlinks.domain.repository.AuthorityArchiveRepository;
@@ -37,12 +38,12 @@ public class AuthorityArchiveServiceDelegate {
   private final AuthorityMapper authorityMapper;
   private final FolioExecutionContext context;
 
-  public AuthorityDtoCollection retrieveAuthorityArchives(Integer offset, Integer limit, String cqlQuery,
-                                                          Boolean idOnly) {
+  public AuthorityFullDtoCollection retrieveAuthorityArchives(Integer offset, Integer limit, String cqlQuery,
+                                                              Boolean idOnly) {
     if (Boolean.TRUE.equals(idOnly)) {
       var entities = authorityArchiveService.getAllIds(offset, limit, cqlQuery)
-        .map(id -> new AuthorityDto().id(id)).stream().toList();
-      return new AuthorityDtoCollection(entities, entities.size());
+        .map(id -> new AuthorityIdDto().id(id)).toList();
+      return new AuthorityIdDtoCollection(entities, entities.size());
     }
 
     var entitiesPage = authorityArchiveService.getAll(offset, limit, cqlQuery)
@@ -81,7 +82,7 @@ public class AuthorityArchiveServiceDelegate {
     }
 
     if (expireSetting.isPresent() && expireSetting.get().value() != null
-        && Boolean.FALSE.equals(expireSetting.get().value().expirationEnabled())) {
+      && Boolean.FALSE.equals(expireSetting.get().value().expirationEnabled())) {
       log.info("Authority archives expiration is disabled for the tenant through setting");
       return Optional.empty();
     }

--- a/src/main/java/org/folio/entlinks/controller/delegate/AuthorityServiceDelegate.java
+++ b/src/main/java/org/folio/entlinks/controller/delegate/AuthorityServiceDelegate.java
@@ -15,7 +15,9 @@ import org.folio.entlinks.controller.converter.AuthorityMapper;
 import org.folio.entlinks.domain.dto.AuthorityBulkRequest;
 import org.folio.entlinks.domain.dto.AuthorityBulkResponse;
 import org.folio.entlinks.domain.dto.AuthorityDto;
-import org.folio.entlinks.domain.dto.AuthorityDtoCollection;
+import org.folio.entlinks.domain.dto.AuthorityFullDtoCollection;
+import org.folio.entlinks.domain.dto.AuthorityIdDto;
+import org.folio.entlinks.domain.dto.AuthorityIdDtoCollection;
 import org.folio.entlinks.domain.entity.Authority;
 import org.folio.entlinks.domain.entity.AuthorityBase;
 import org.folio.entlinks.exception.RequestBodyValidationException;
@@ -61,12 +63,12 @@ public class AuthorityServiceDelegate {
     this.authorityS3Service = authorityS3Service;
   }
 
-  public AuthorityDtoCollection retrieveAuthorityCollection(Integer offset, Integer limit, String cqlQuery,
-                                                            Boolean idOnly) {
+  public AuthorityFullDtoCollection retrieveAuthorityCollection(Integer offset, Integer limit, String cqlQuery,
+                                                                Boolean idOnly) {
     if (Boolean.TRUE.equals(idOnly)) {
       var entities = service.getAllIds(offset, limit, cqlQuery)
-        .map(id -> new AuthorityDto().id(id)).stream().toList();
-      return new AuthorityDtoCollection(entities, entities.size());
+        .map(id -> new AuthorityIdDto().id(id)).toList();
+      return new AuthorityIdDtoCollection(entities, entities.size());
     }
 
     var entitiesPage = service.getAll(offset, limit, cqlQuery)

--- a/src/main/resources/swagger.api/paths/authority-storage/authorities.yaml
+++ b/src/main/resources/swagger.api/paths/authority-storage/authorities.yaml
@@ -48,7 +48,10 @@ get:
         application/json:
           example: examples/authorities.sample
           schema:
-            $ref: '../../schemas/authority-storage/authorityDtoCollection.yaml'
+            title: authorityFullDtoCollection
+            oneOf:
+              - $ref: '../../schemas/authority-storage/authorityDtoCollection.yaml'
+              - $ref: '../../schemas/authority-storage/authorityIdDtoCollection.yaml'
         text/plain;charset=utf-8:
           schema:
             type: string

--- a/src/main/resources/swagger.api/schemas/authority-storage/authorityIdDto.yaml
+++ b/src/main/resources/swagger.api/schemas/authority-storage/authorityIdDto.yaml
@@ -1,0 +1,7 @@
+description: An authority ID record
+type: object
+properties:
+  id:
+    description: Authority UUID
+    type: string
+    format: uuid

--- a/src/main/resources/swagger.api/schemas/authority-storage/authorityIdDtoCollection.yaml
+++ b/src/main/resources/swagger.api/schemas/authority-storage/authorityIdDtoCollection.yaml
@@ -1,0 +1,14 @@
+description: A collection of authority ID records
+type: object
+properties:
+  authorities:
+    description: List of authority records
+    type: array
+    items:
+      $ref: './authorityIdDto.yaml'
+  totalRecords:
+    description: Total amount of records
+    type: integer
+required:
+  - authorities
+  - totalRecords

--- a/src/test/java/org/folio/entlinks/controller/AuthorityControllerTest.java
+++ b/src/test/java/org/folio/entlinks/controller/AuthorityControllerTest.java
@@ -14,6 +14,8 @@ import org.folio.entlinks.controller.delegate.AuthorityArchiveServiceDelegate;
 import org.folio.entlinks.controller.delegate.AuthorityServiceDelegate;
 import org.folio.entlinks.domain.dto.AuthorityDto;
 import org.folio.entlinks.domain.dto.AuthorityDtoCollection;
+import org.folio.entlinks.domain.dto.AuthorityIdDto;
+import org.folio.entlinks.domain.dto.AuthorityIdDtoCollection;
 import org.folio.entlinks.exception.AuthoritiesRequestNotSupportedMediaTypeException;
 import org.folio.spring.testing.type.UnitTest;
 import org.junit.jupiter.api.BeforeAll;
@@ -71,7 +73,9 @@ class AuthorityControllerTest {
 
   @Test
   void shouldRetrieveAuthoritiesIds() {
-    var collectionDto = new AuthorityDtoCollection(List.of(dto, dto), 1);
+    var collectionDto = new AuthorityIdDtoCollection(List.of(
+      new AuthorityIdDto().id(dto.getId()),
+      new AuthorityIdDto().id(dto.getId())), 2);
     when(authorityServiceDelegate.retrieveAuthorityCollection(anyInt(), anyInt(), anyString(), anyBoolean()))
         .thenReturn(collectionDto);
 
@@ -98,7 +102,9 @@ class AuthorityControllerTest {
 
   @Test
   void shouldRetrieveAuthorityArchivesIds() {
-    var collectionDto = new AuthorityDtoCollection(List.of(dto, dto), 1);
+    var collectionDto = new AuthorityIdDtoCollection(List.of(
+      new AuthorityIdDto().id(dto.getId()),
+      new AuthorityIdDto().id(dto.getId())), 1);
     when(authorityArchiveServiceDelegate.retrieveAuthorityArchives(anyInt(), anyInt(), anyString(), anyBoolean()))
         .thenReturn(collectionDto);
 


### PR DESCRIPTION
### Purpose
Return only ids in response when idOnly=true

### Approach
Create separate schema for ID-responses

### Changes Checklist
- [ ] **API Changes**: Document any API paths, methods, request or response bodies changed, added, or removed.
- [ ] **Database Schema Changes**: Indicate any database schema changes and their impact. Confirm that migration scripts were created.
- [ ] **Interface Version Changes**: Indicate any changes to interface versions.
- [ ] **Interface Dependencies**: Document added or removed dependencies.
- [ ] **Permissions**: Document any changes to permissions.
- [ ] **Logging**: Confirm that logging is appropriately handled.
- [ ] **Unit Testing**: Confirm that changed classes were covered by unit tests.
- [ ] **Integration Testing**: Confirm that changed logic was covered by integration tests.
- [x] **Manual Testing**: Confirm that changes were tested on local or dev environment.
- [x] **NEWS**: Confirm that the NEWS file is updated with relevant information about the changes made in this pull request.

### Related Issues
https://folio-org.atlassian.net/browse/MODELINKS-237