### PR TITLE
fix(authority-storage): fix issue that causes repeated update of same entity with latest Hibernate versions

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -15,7 +15,7 @@
 * Return only ids in response when idOnly=true ([MODELINKS-237](https://issues.folio.org/browse/MODELINKS-227))
 
 ### Tech Dept
-* Description ([ISSUE](https://folio-org.atlassian.net/browse/ISSUE))
+* Fix issue that causes repeated update of same entity with latest Hibernate versions ([MODELINKS-237](https://issues.folio.org/browse/MODELINKS-227))
 
 ### Dependencies
 * Bump `LIB_NAME` from `OLD_VERSION` to `NEW_VERSION`

--- a/pom.xml
+++ b/pom.xml
@@ -150,18 +150,6 @@
       <scope>provided</scope>
     </dependency>
 
-    <!-- Hibernate 6.4.1.Final has issue with saving or persisting JsonType fields and this was observed for authorities
-    when they are persisted hibernate increased version property twice (one for insert and one for update).
-    There is similar to this one issue in their issue tracker: https://hibernate.atlassian.net/browse/HHH-17660, we can
-    track its status and once it fixed we can try to upgrade version of hibernate which is enough to remove this dependency
-    and use the one from parent spring-boot -->
-    <dependency>
-      <groupId>org.hibernate.orm</groupId>
-      <artifactId>hibernate-core</artifactId>
-      <version>6.3.1.Final</version>
-    </dependency>
-
-
     <dependency>
       <groupId>org.hibernate.validator</groupId>
       <artifactId>hibernate-validator</artifactId>

--- a/src/main/java/org/folio/entlinks/domain/entity/AuthorityIdentifier.java
+++ b/src/main/java/org/folio/entlinks/domain/entity/AuthorityIdentifier.java
@@ -3,6 +3,7 @@ package org.folio.entlinks.domain.entity;
 import java.io.Serializable;
 import java.util.UUID;
 import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
@@ -13,6 +14,7 @@ import lombok.ToString;
 @NoArgsConstructor
 @AllArgsConstructor
 @ToString
+@EqualsAndHashCode
 public class AuthorityIdentifier implements Serializable {
 
   private String value;

--- a/src/main/java/org/folio/entlinks/domain/entity/AuthorityNote.java
+++ b/src/main/java/org/folio/entlinks/domain/entity/AuthorityNote.java
@@ -3,6 +3,7 @@ package org.folio.entlinks.domain.entity;
 import java.io.Serializable;
 import java.util.UUID;
 import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
@@ -13,6 +14,7 @@ import lombok.ToString;
 @NoArgsConstructor
 @AllArgsConstructor
 @ToString
+@EqualsAndHashCode
 public class AuthorityNote implements Serializable {
 
   private UUID noteTypeId;

--- a/src/main/java/org/folio/entlinks/domain/entity/HeadingRef.java
+++ b/src/main/java/org/folio/entlinks/domain/entity/HeadingRef.java
@@ -2,6 +2,7 @@ package org.folio.entlinks.domain.entity;
 
 import java.io.Serializable;
 import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
@@ -12,6 +13,7 @@ import lombok.ToString;
 @NoArgsConstructor
 @AllArgsConstructor
 @ToString
+@EqualsAndHashCode
 public class HeadingRef implements Serializable {
 
   private String headingType;


### PR DESCRIPTION
### Purpose
Repeated updates of same entity with the latest Hibernate versions caused by some fields are `jsonb` type

### Approach
Add equals and hashcode for jsonb-converted entities

### Changes Checklist
- [ ] **API Changes**: Document any API paths, methods, request or response bodies changed, added, or removed.
- [ ] **Database Schema Changes**: Indicate any database schema changes and their impact. Confirm that migration scripts were created.
- [ ] **Interface Version Changes**: Indicate any changes to interface versions.
- [ ] **Interface Dependencies**: Document added or removed dependencies.
- [ ] **Permissions**: Document any changes to permissions.
- [ ] **Logging**: Confirm that logging is appropriately handled.
- [ ] **Unit Testing**: Confirm that changed classes were covered by unit tests.
- [x] **Integration Testing**: Confirm that changed logic was covered by integration tests.
- [ ] **Manual Testing**: Confirm that changes were tested on local or dev environment.
- [x] **NEWS**: Confirm that the NEWS file is updated with relevant information about the changes made in this pull request.

### Related Issues
https://folio-org.atlassian.net/browse/MODELINKS-238
