### PR TITLE
fix(authority): Fix totalRecords count when idOnly=true on authirity-storage/authorities

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -13,6 +13,7 @@
 * Do not delete kafka topics if tenant collection topic feature is enabled ([MODELINKS-233](https://folio-org.atlassian.net/browse/MODELINKS-233))
 * Add checking for Authority source file references for member tenant in ECS ([MODELINKS-227](https://issues.folio.org/browse/MODELINKS-227))
 * Return only ids in response when idOnly=true ([MODELINKS-237](https://issues.folio.org/browse/MODELINKS-227))
+* Fix totalRecords count when idOnly=true ([MODELINKS-239](https://issues.folio.org/browse/MODELINKS-239))
 
 ### Tech Dept
 * Fix issue that causes repeated update of same entity with latest Hibernate versions ([MODELINKS-237](https://issues.folio.org/browse/MODELINKS-227))

--- a/src/main/java/org/folio/entlinks/controller/delegate/AuthorityArchiveServiceDelegate.java
+++ b/src/main/java/org/folio/entlinks/controller/delegate/AuthorityArchiveServiceDelegate.java
@@ -41,9 +41,9 @@ public class AuthorityArchiveServiceDelegate {
   public AuthorityFullDtoCollection retrieveAuthorityArchives(Integer offset, Integer limit, String cqlQuery,
                                                               Boolean idOnly) {
     if (Boolean.TRUE.equals(idOnly)) {
-      var entities = authorityArchiveService.getAllIds(offset, limit, cqlQuery)
-        .map(id -> new AuthorityIdDto().id(id)).toList();
-      return new AuthorityIdDtoCollection(entities, entities.size());
+      var idsPage = authorityArchiveService.getAllIds(offset, limit, cqlQuery);
+      var ids = idsPage.map(id -> new AuthorityIdDto().id(id)).toList();
+      return new AuthorityIdDtoCollection(ids, (int) idsPage.getTotalElements());
     }
 
     var entitiesPage = authorityArchiveService.getAll(offset, limit, cqlQuery)

--- a/src/main/java/org/folio/entlinks/controller/delegate/AuthorityServiceDelegate.java
+++ b/src/main/java/org/folio/entlinks/controller/delegate/AuthorityServiceDelegate.java
@@ -66,9 +66,9 @@ public class AuthorityServiceDelegate {
   public AuthorityFullDtoCollection retrieveAuthorityCollection(Integer offset, Integer limit, String cqlQuery,
                                                                 Boolean idOnly) {
     if (Boolean.TRUE.equals(idOnly)) {
-      var entities = service.getAllIds(offset, limit, cqlQuery)
-        .map(id -> new AuthorityIdDto().id(id)).toList();
-      return new AuthorityIdDtoCollection(entities, entities.size());
+      var idsPage = service.getAllIds(offset, limit, cqlQuery);
+      var ids = idsPage.map(id -> new AuthorityIdDto().id(id)).toList();
+      return new AuthorityIdDtoCollection(ids, (int) idsPage.getTotalElements());
     }
 
     var entitiesPage = service.getAll(offset, limit, cqlQuery)


### PR DESCRIPTION
### Purpose
Fix totalRecords count when idOnly=true on authirity-storage/authorities

### Approach
- Use page's totalElements instead of returned collection size for totalRecord of authorities
- Use page's totalElements instead of returned collection size for totalRecord of authority archives

### Changes Checklist
- [ ] **API Changes**: Document any API paths, methods, request or response bodies changed, added, or removed.
- [ ] **Database Schema Changes**: Indicate any database schema changes and their impact. Confirm that migration scripts were created.
- [ ] **Interface Version Changes**: Indicate any changes to interface versions.
- [ ] **Interface Dependencies**: Document added or removed dependencies.
- [ ] **Permissions**: Document any changes to permissions.
- [ ] **Logging**: Confirm that logging is appropriately handled.
- [x] **Unit Testing**: Confirm that changed classes were covered by unit tests.
- [ ] **Integration Testing**: Confirm that changed logic was covered by integration tests.
- [ ] **Manual Testing**: Confirm that changes were tested on local or dev environment.
- [ ] **NEWS**: Confirm that the NEWS file is updated with relevant information about the changes made in this pull request.

### Related Issues
[MODELINKS-239](https://folio-org.atlassian.net/browse/MODELINKS-239)
