### PR TITLE
MODELINKS-242: Fix handling heading type change update event for Authority with linked instance

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -65,6 +65,7 @@
 * Add new error code to handle authority source file deletion after authority deletion ([MODELINKS-210](https://issues.folio.org/browse/MODELINKS-210))
 * Fix authority record update and `updatedByUserId` field assignment ([MODELINKS-219](https://issues.folio.org/browse/MODELINKS-219))
 * Fix saving of Authority file with empty Base URL when another Authority file with empty Base URL already exists ([MODELINKS-216](https://issues.folio.org/browse/MODELINKS-216))
+* Fix handling of authority heading type change update event ([MODELINKS-242](https://issues.folio.org/browse/MODELINKS-242))
 
 ### Tech Dept
 * Create custom Mockito verifies for Hibernate entities ([MODELINKS-209](https://issues.folio.org/browse/MODELINKS-209))

--- a/src/test/java/org/folio/entlinks/service/messaging/authority/handler/DeleteAuthorityChangeHandlerTest.java
+++ b/src/test/java/org/folio/entlinks/service/messaging/authority/handler/DeleteAuthorityChangeHandlerTest.java
@@ -5,13 +5,16 @@ import static java.util.Collections.emptyMap;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.groups.Tuple.tuple;
 import static org.folio.entlinks.domain.dto.LinksChangeEvent.TypeEnum;
+import static org.folio.support.base.TestConstants.TENANT_ID;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyCollection;
 import static org.mockito.ArgumentMatchers.anySet;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 import java.util.Collections;
@@ -19,10 +22,12 @@ import java.util.List;
 import java.util.Set;
 import java.util.UUID;
 import org.folio.entlinks.config.properties.InstanceAuthorityChangeProperties;
+import org.folio.entlinks.domain.dto.AuthorityDto;
 import org.folio.entlinks.domain.dto.ChangeTarget;
 import org.folio.entlinks.domain.dto.ChangeTargetLink;
 import org.folio.entlinks.domain.dto.LinksChangeEvent;
 import org.folio.entlinks.integration.dto.event.AuthorityDomainEvent;
+import org.folio.entlinks.integration.dto.event.DomainEventType;
 import org.folio.entlinks.service.authority.AuthorityService;
 import org.folio.entlinks.service.links.InstanceAuthorityLinkingService;
 import org.folio.entlinks.service.messaging.authority.model.AuthorityChangeHolder;
@@ -61,11 +66,18 @@ class DeleteAuthorityChangeHandlerTest {
   }
 
   @Test
-  void handle_positive() {
-    var eventIds = Set.of(UUID.randomUUID(), UUID.randomUUID());
-    var events = eventIds.stream()
-      .map(uuid -> new AuthorityChangeHolder(new AuthorityDomainEvent(uuid), emptyMap(), emptyMap(), 1))
-      .toList();
+  void handle_positive_shouldHardDeleteAuthorityAndLinks() {
+    var id1 = UUID.randomUUID();
+    var id2 = UUID.randomUUID();
+    var authorityDto = new AuthorityDto().naturalId("n12345").personalName("name");
+    var authorityDomainEvent1 = new AuthorityDomainEvent(
+        id1, authorityDto, authorityDto, DomainEventType.DELETE, TENANT_ID);
+    var authorityDomainEvent2 = new AuthorityDomainEvent(
+        id2, authorityDto, authorityDto, DomainEventType.DELETE, TENANT_ID);
+    var events = List.of(
+        new AuthorityChangeHolder(authorityDomainEvent1, emptyMap(), emptyMap(), 1),
+        new AuthorityChangeHolder(authorityDomainEvent2, emptyMap(), emptyMap(), 1)
+    );
     var instanceId1 = UUID.randomUUID();
     var instanceId2 = UUID.randomUUID();
     var instanceId3 = UUID.randomUUID();
@@ -75,28 +87,57 @@ class DeleteAuthorityChangeHandlerTest {
 
     doNothing().when(linkingService).deleteByAuthorityIdIn(anySet());
     when(properties.getNumPartitions()).thenReturn(1);
-    when(linkingService.getLinksByAuthorityId(eq(events.get(0).getAuthorityId()), any())).thenReturn(
+    when(linkingService.getLinksByAuthorityId(eq(id1), any())).thenReturn(
       new PageImpl<>(List.of(link1.toEntity(instanceId1)), Pageable.ofSize(1), 2)
     ).thenReturn(
       new PageImpl<>(List.of(link2.toEntity(instanceId2)))
     );
-    when(linkingService.getLinksByAuthorityId(eq(events.get(1).getAuthorityId()), any())).thenReturn(
+    when(linkingService.getLinksByAuthorityId(eq(id2), any())).thenReturn(
       new PageImpl<>(List.of(link3.toEntity(instanceId3)))
     );
 
     var actual = handler.handle(events);
 
-    verify(linkingService).deleteByAuthorityIdIn(eventIds);
+    verify(linkingService).deleteByAuthorityIdIn(Set.of(id1, id2));
+    verify(linkingService, times(3)).getLinksByAuthorityId(any(UUID.class), any(Pageable.class));
 
     assertThat(actual)
       .hasSize(3)
       .extracting(LinksChangeEvent::getAuthorityId, LinksChangeEvent::getType, LinksChangeEvent::getUpdateTargets)
       .contains(
-        tuple(events.get(0).getAuthorityId(), TypeEnum.DELETE, List.of(changeTarget(instanceId1, link1))),
-        tuple(events.get(0).getAuthorityId(), TypeEnum.DELETE, List.of(changeTarget(instanceId2, link2))),
-        tuple(events.get(1).getAuthorityId(), TypeEnum.DELETE, List.of(changeTarget(instanceId3, link3)))
+        tuple(id1, TypeEnum.DELETE, List.of(changeTarget(instanceId1, link1))),
+        tuple(id1, TypeEnum.DELETE, List.of(changeTarget(instanceId2, link2))),
+        tuple(id2, TypeEnum.DELETE, List.of(changeTarget(instanceId3, link3)))
       );
     verify(authorityService).deleteByIds(anyCollection());
+  }
+
+  @Test
+  void handle_positive_shouldDeleteLinksOnlyOnHeadingTypeChangeUpdateEvent() {
+    var id = UUID.randomUUID();
+    var authorityDomainEvent = new AuthorityDomainEvent(
+        id,
+        new AuthorityDto().naturalId("n12345").corporateName("Beatles"),
+        new AuthorityDto().naturalId("n12345").corporateNameTitle("Beatles mono"),
+        DomainEventType.UPDATE,
+        TENANT_ID);
+    var authorityEvents = List.of(new AuthorityChangeHolder(authorityDomainEvent, emptyMap(), emptyMap(), 1));
+    var link = TestDataUtils.Link.of(1, 1);
+    var instanceId = UUID.randomUUID();
+    doNothing().when(linkingService).deleteByAuthorityIdIn(Set.of(id));
+    when(properties.getNumPartitions()).thenReturn(1);
+    when(linkingService.getLinksByAuthorityId(eq(id), any())).thenReturn(
+        new PageImpl<>(List.of(link.toEntity(instanceId)), Pageable.ofSize(1), 1));
+
+    var actual = handler.handle(authorityEvents);
+
+    verify(linkingService).getLinksByAuthorityId(eq(id), any());
+    verify(linkingService).deleteByAuthorityIdIn(Set.of(id));
+    assertThat(actual)
+        .hasSize(1)
+        .extracting(LinksChangeEvent::getAuthorityId, LinksChangeEvent::getType, LinksChangeEvent::getUpdateTargets)
+        .contains(tuple(id, TypeEnum.DELETE, List.of(changeTarget(instanceId, link))));
+    verifyNoInteractions(authorityService);
   }
 
   @Test


### PR DESCRIPTION
### Purpose
_Fix handling of heading type change event for Authority with linked instances_

### Approach
- keep deleting the existing link
- do not hard delete authority if handling heading type is changed.

### Changes Checklist
- [ ] **API Changes**: Document any API paths, methods, request or response bodies changed, added, or removed.
- [ ] **Database Schema Changes**: Indicate any database schema changes and their impact. Confirm that migration scripts were created.
- [ ] **Interface Version Changes**: Indicate any changes to interface versions.
- [ ] **Interface Dependencies**: Document added or removed dependencies.
- [ ] **Permissions**: Document any changes to permissions.
- [ ] **Logging**: Confirm that logging is appropriately handled.
- [x] **Unit Testing**: Confirm that changed classes were covered by unit tests.
- [ ] **Integration Testing**: Confirm that changed logic was covered by integration tests.
- [x] **Manual Testing**: Confirm that changes were tested on local or dev environment.
- [x] **NEWS**: Confirm that the NEWS file is updated with relevant information about the changes made in this pull request.

### Related Issues
[MODELINKS-242](https://folio-org.atlassian.net/browse/MODELINKS-242)
