### PR TITLE
MODELINKS-242: Fix handling update event for heading type change of authority with linked instance

### DIFF
--- a/src/main/java/org/folio/entlinks/service/messaging/authority/handler/DeleteAuthorityChangeHandler.java
+++ b/src/main/java/org/folio/entlinks/service/messaging/authority/handler/DeleteAuthorityChangeHandler.java
@@ -8,6 +8,7 @@ import java.util.stream.Collectors;
 import org.apache.commons.collections4.CollectionUtils;
 import org.folio.entlinks.config.properties.InstanceAuthorityChangeProperties;
 import org.folio.entlinks.domain.dto.LinksChangeEvent;
+import org.folio.entlinks.integration.dto.event.DomainEventType;
 import org.folio.entlinks.service.authority.AuthorityService;
 import org.folio.entlinks.service.links.InstanceAuthorityLinkingService;
 import org.folio.entlinks.service.messaging.authority.model.AuthorityChangeHolder;
@@ -45,7 +46,7 @@ public class DeleteAuthorityChangeHandler extends AbstractAuthorityChangeHandler
 
     var authorityIds = linksEvents.stream().map(LinksChangeEvent::getAuthorityId).collect(Collectors.toSet());
     var softDeleteAuthorityIds = changes.stream()
-        .filter(change -> change.getChangeType().equals(DELETE))
+        .filter(change -> DomainEventType.DELETE.equals(change.getEvent().getType()))
         .map(AuthorityChangeHolder::getAuthorityId)
         .toList();
 

--- a/src/test/java/org/folio/entlinks/service/messaging/authority/handler/DeleteAuthorityChangeHandlerTest.java
+++ b/src/test/java/org/folio/entlinks/service/messaging/authority/handler/DeleteAuthorityChangeHandlerTest.java
@@ -5,6 +5,8 @@ import static java.util.Collections.emptyMap;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.groups.Tuple.tuple;
 import static org.folio.entlinks.domain.dto.LinksChangeEvent.TypeEnum;
+import static org.folio.entlinks.service.messaging.authority.model.AuthorityChangeField.CORPORATE_NAME;
+import static org.folio.entlinks.service.messaging.authority.model.AuthorityChangeField.CORPORATE_NAME_TITLE;
 import static org.folio.support.base.TestConstants.TENANT_ID;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
@@ -19,6 +21,7 @@ import static org.mockito.Mockito.when;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
 import org.folio.entlinks.config.properties.InstanceAuthorityChangeProperties;
@@ -30,6 +33,7 @@ import org.folio.entlinks.integration.dto.event.AuthorityDomainEvent;
 import org.folio.entlinks.integration.dto.event.DomainEventType;
 import org.folio.entlinks.service.authority.AuthorityService;
 import org.folio.entlinks.service.links.InstanceAuthorityLinkingService;
+import org.folio.entlinks.service.messaging.authority.model.AuthorityChange;
 import org.folio.entlinks.service.messaging.authority.model.AuthorityChangeHolder;
 import org.folio.entlinks.service.messaging.authority.model.AuthorityChangeType;
 import org.folio.spring.testing.type.UnitTest;
@@ -113,7 +117,7 @@ class DeleteAuthorityChangeHandlerTest {
   }
 
   @Test
-  void handle_positive_shouldDeleteLinksOnlyOnHeadingTypeChangeUpdateEvent() {
+  void handle_positive_shouldDeleteLinksOnlyWithoutDeletingAuthoritiesOnHeadingTypeChangeUpdateEvent() {
     var id = UUID.randomUUID();
     var authorityDomainEvent = new AuthorityDomainEvent(
         id,
@@ -121,7 +125,11 @@ class DeleteAuthorityChangeHandlerTest {
         new AuthorityDto().naturalId("n12345").corporateNameTitle("Beatles mono"),
         DomainEventType.UPDATE,
         TENANT_ID);
-    var authorityEvents = List.of(new AuthorityChangeHolder(authorityDomainEvent, emptyMap(), emptyMap(), 1));
+    var changes = Map.of(
+        CORPORATE_NAME, new AuthorityChange(CORPORATE_NAME, null, "Beatles"),
+        CORPORATE_NAME_TITLE, new AuthorityChange(CORPORATE_NAME, "Beatles mono", null)
+    );
+    var authorityEvents = List.of(new AuthorityChangeHolder(authorityDomainEvent, changes, emptyMap(), 1));
     var link = TestDataUtils.Link.of(1, 1);
     var instanceId = UUID.randomUUID();
     doNothing().when(linkingService).deleteByAuthorityIdIn(Set.of(id));


### PR DESCRIPTION
### Purpose
_Do not hard delete authority when handling authority update event for heading type change_

### Approach
_check domain event type when handling authority update event inside delete handler_

### Changes Checklist
- [ ] **API Changes**: Document any API paths, methods, request or response bodies changed, added, or removed.
- [ ] **Database Schema Changes**: Indicate any database schema changes and their impact. Confirm that migration scripts were created.
- [ ] **Interface Version Changes**: Indicate any changes to interface versions.
- [ ] **Interface Dependencies**: Document added or removed dependencies.
- [ ] **Permissions**: Document any changes to permissions.
- [ ] **Logging**: Confirm that logging is appropriately handled.
- [x] **Unit Testing**: Confirm that changed classes were covered by unit tests.
- [ ] **Integration Testing**: Confirm that changed logic was covered by integration tests.
- [x] **Manual Testing**: Confirm that changes were tested on local or dev environment.
- [ ] **NEWS**: Confirm that the NEWS file is updated with relevant information about the changes made in this pull request.

### Related Issues
[MODELINKS-242](https://folio-org.atlassian.net/browse/MODELINKS-242)