### PR TITLE
feature/MODELINKS-248 Do not show empty arrays for extended mapping

### DIFF
--- a/src/main/resources/swagger.api/schemas/authority-storage/authorityDto.yaml
+++ b/src/main/resources/swagger.api/schemas/authority-storage/authorityDto.yaml
@@ -149,21 +149,25 @@ properties:
     description: See also from tracing term that represents broader, more general concepts related to the authority record
     items:
       $ref: './relatedHeading.yaml'
+    x-field-extra-annotation: "@com.fasterxml.jackson.annotation.JsonInclude(com.fasterxml.jackson.annotation.JsonInclude.Include.NON_EMPTY)"
   saftNarrowerTerm:
     type: array
     description: See also from tracing term that that represents narrower, more specific concepts derived from the authority record
     items:
       $ref: './relatedHeading.yaml'
+    x-field-extra-annotation: "@com.fasterxml.jackson.annotation.JsonInclude(com.fasterxml.jackson.annotation.JsonInclude.Include.NON_EMPTY)"
   saftEarlierHeading:
     type: array
     description: See also from tracing heading that was previously used to represent the concept or entity described by the authority record. This field is used to track the evolution of terms or headings over time, facilitating the linking of historical and current data.
     items:
       $ref: './relatedHeading.yaml'
+    x-field-extra-annotation: "@com.fasterxml.jackson.annotation.JsonInclude(com.fasterxml.jackson.annotation.JsonInclude.Include.NON_EMPTY)"
   saftLaterHeading:
     type: array
     description: See also from tracing heading that replaced the current heading used in the authority record. This field helps in maintaining the continuity of catalog records by linking past headings to their more current versions.
     items:
       $ref: './relatedHeading.yaml'
+    x-field-extra-annotation: "@com.fasterxml.jackson.annotation.JsonInclude(com.fasterxml.jackson.annotation.JsonInclude.Include.NON_EMPTY)"
   identifiers:
     type: array
     description: An extensible set of name-value pairs of identifiers associated with the resource

--- a/src/test/java/org/folio/entlinks/controller/converter/AuthorityMapperTest.java
+++ b/src/test/java/org/folio/entlinks/controller/converter/AuthorityMapperTest.java
@@ -8,7 +8,11 @@ import static org.folio.support.base.TestConstants.TEST_DATE;
 import static org.folio.support.base.TestConstants.TEST_ID;
 import static org.folio.support.base.TestConstants.TEST_PROPERTY_VALUE;
 import static org.folio.support.base.TestConstants.TEST_VERSION;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import java.util.ArrayList;
 import java.util.List;
 import org.folio.entlinks.domain.dto.AuthorityDto;
@@ -297,5 +301,22 @@ class AuthorityMapperTest {
     dto.setSubjectHeadings(TEST_PROPERTY_VALUE);
     dto.setSourceFileId(TEST_ID);
     return dto;
+  }
+
+  @Test
+  void serializedDtoShouldNotContainEmptyArraysForExtendedFields() throws JsonProcessingException {
+
+    String serializedDto = new ObjectMapper().writeValueAsString(new AuthorityDto());
+
+    assertTrue(serializedDto.contains("\"saftGenreTerm\""),
+        "JSON should contain 'saftGenreTerm' key when it's an empty array");
+    assertFalse(serializedDto.contains("\"saftBroaderTerm\""),
+        "JSON should not contain 'saftBroaderTerm' key when it's an empty array");
+    assertFalse(serializedDto.contains("\"saftNarrowerTerm\""),
+        "JSON should not contain 'saftNarrowerTerm' key when it's an empty array");
+    assertFalse(serializedDto.contains("\"saftEarlierHeading\""),
+        "JSON should not contain 'saftEarlierHeading' key when it's an empty array");
+    assertFalse(serializedDto.contains("\"saftLaterHeading\""),
+        "JSON should not contain 'saftLaterHeading' key when it's an empty array");
   }
 }


### PR DESCRIPTION
### Purpose
Update serialization for AuthorityDto to not expose empty saftBroaderTerm, safrNarrowerTerm, saftEarlierHeading, saftLaterHeading in kafka messages.  It makes including extended mapping not noticeable for users who doesn't use this functionality. 

### Approach
add com.fasterxml.jackson.annotation.JsonInclude.Include.NON_EMPTY annotation for saftBroaderTerm, safrNarrowerTerm, saftEarlierHeading, saftLaterHeading fields.
### Changes Checklist
- [ ] **API Changes**: Document any API paths, methods, request or response bodies changed, added, or removed.
- [ ] **Database Schema Changes**: Indicate any database schema changes and their impact. Confirm that migration scripts were created.
- [ ] **Interface Version Changes**: Indicate any changes to interface versions.
- [ ] **Interface Dependencies**: Document added or removed dependencies.
- [ ] **Permissions**: Document any changes to permissions.
- [ ] **Logging**: Confirm that logging is appropriately handled.
- [ ] **Unit Testing**: Confirm that changed classes were covered by unit tests.
- [ ] **Integration Testing**: Confirm that changed logic was covered by integration tests.
- [ ] **Manual Testing**: Confirm that changes were tested on local or dev environment.
- [ ] **NEWS**: Confirm that the NEWS file is updated with relevant information about the changes made in this pull request.

### Related Issues
_List any Jira issues related to this pull request._

### Learning and Resources (if applicable)
_Discuss any research conducted during the development of this pull request. Include links to relevant blog posts, patterns, libraries, or addons that were used to solve the problem._

### Screenshots (if applicable)
_If this pull request involves any visual changes or new features, consider including screenshots or GIFs to illustrate the changes._
