### PR TITLE
feat(linking-rules): update instance-authority linking rules to include v, x, y, z subfields

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -7,6 +7,7 @@
 * Requires `instance-storage v10.0 or v11.0`
 
 ### Features
+* Update instance-authority linking rules to include v, x, y, z subfields ([MODELINKS-252](https://folio-org.atlassian.net//browse/MODELINKS-252))
 * Define $9 subfield definitions for MARC bibliographic records ([MODELINKS-255](https://folio-org.atlassian.net//browse/MODELINKS-255))
 
 ### Bug fixes

--- a/src/main/resources/db/changelog/changelog-master.xml
+++ b/src/main/resources/db/changelog/changelog-master.xml
@@ -23,4 +23,5 @@
   <include file="/changes/v3.0/add-authority-source-protocol.xml" relativeToChangelogFile="true"/>
   <include file="/changes/v3.0/add-authority-source-file-optimistic-locking.xml" relativeToChangelogFile="true"/>
   <include file="/changes/v3.0/update-auto-linking_enabled.xml" relativeToChangelogFile="true"/>
+  <include file="/changes/v3.1/update-linking-rules-subfields.xml" relativeToChangelogFile="true"/>
 </databaseChangeLog>

--- a/src/main/resources/db/changelog/changes/v3.1/update-linking-rules-subfields.xml
+++ b/src/main/resources/db/changelog/changes/v3.1/update-linking-rules-subfields.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                   https://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
+
+  <changeSet id="MODELINKS-252@@default-data:linking-rules:add-additional-subfields" author="pavlo_smahin">
+    <preConditions>
+      <tableExists tableName="instance_authority_linking_rule"/>
+    </preConditions>
+
+    <comment>Add v,x,y,z subfields to linking rules</comment>
+
+    <sql>
+      UPDATE instance_authority_linking_rule
+      SET authority_subfields = authority_subfields || 'vxyz'
+      WHERE bib_field != '240';
+    </sql>
+  </changeSet>
+
+</databaseChangeLog>

--- a/src/test/java/org/folio/entlinks/integration/kafka/AuthorityEventListenerIT.java
+++ b/src/test/java/org/folio/entlinks/integration/kafka/AuthorityEventListenerIT.java
@@ -309,7 +309,11 @@ class AuthorityEventListenerIT extends IntegrationTestBase {
         subfieldChangeEmpty("c"),
         subfieldChange("d", "1756-1791."),
         subfieldChangeEmpty("j"),
-        subfieldChange("q", "(Jules)")
+        subfieldChange("q", "(Jules)"),
+        subfieldChangeEmpty("v"),
+        subfieldChangeEmpty("x"),
+        subfieldChangeEmpty("y"),
+        subfieldChangeEmpty("z")
       )),
       new FieldChange().field("600").subfields(List.of(
         subfieldChange("a", "Lansing, John"),
@@ -329,7 +333,11 @@ class AuthorityEventListenerIT extends IntegrationTestBase {
         subfieldChange("q", "(Jules)"),
         subfieldChangeEmpty("r"),
         subfieldChangeEmpty("s"),
-        subfieldChange("t", "Black Eagles")
+        subfieldChange("t", "Black Eagles"),
+        subfieldChangeEmpty("v"),
+        subfieldChangeEmpty("x"),
+        subfieldChangeEmpty("y"),
+        subfieldChangeEmpty("z")
       )),
       new FieldChange().field("700").subfields(List.of(
         subfieldChange("a", "Lansing, John"),
@@ -349,7 +357,11 @@ class AuthorityEventListenerIT extends IntegrationTestBase {
         subfieldChange("q", "(Jules)"),
         subfieldChangeEmpty("r"),
         subfieldChangeEmpty("s"),
-        subfieldChange("t", "Black Eagles")
+        subfieldChange("t", "Black Eagles"),
+        subfieldChangeEmpty("v"),
+        subfieldChangeEmpty("x"),
+        subfieldChangeEmpty("y"),
+        subfieldChangeEmpty("z")
       )),
       new FieldChange().field("800").subfields(List.of(
         subfieldChange("a", "Lansing, John"),
@@ -369,7 +381,11 @@ class AuthorityEventListenerIT extends IntegrationTestBase {
         subfieldChange("q", "(Jules)"),
         subfieldChangeEmpty("r"),
         subfieldChangeEmpty("s"),
-        subfieldChange("t", "Black Eagles")
+        subfieldChange("t", "Black Eagles"),
+        subfieldChangeEmpty("v"),
+        subfieldChangeEmpty("x"),
+        subfieldChangeEmpty("y"),
+        subfieldChangeEmpty("z")
       )),
       new FieldChange().field("240").subfields(List.of(
         subfieldChange("a", "Black Eagles"),

--- a/src/test/resources/linking-rules/instance-authority.json
+++ b/src/test/resources/linking-rules/instance-authority.json
@@ -9,7 +9,11 @@
       "c",
       "d",
       "j",
-      "q"
+      "q",
+      "v",
+      "x",
+      "y",
+      "z"
     ],
     "validation": {
       "existence": [
@@ -27,7 +31,11 @@
     "authoritySubfields": [
       "a",
       "b",
-      "c"
+      "c",
+      "v",
+      "x",
+      "y",
+      "z"
     ],
     "validation": {
       "existence": [
@@ -46,7 +54,11 @@
       "a",
       "c",
       "e",
-      "q"
+      "q",
+      "v",
+      "x",
+      "y",
+      "z"
     ],
     "validation": {
       "existence": [
@@ -75,7 +87,11 @@
       "p",
       "r",
       "s",
-      "t"
+      "t",
+      "v",
+      "x",
+      "y",
+      "z"
     ],
     "autoLinkingEnabled": true
   },
@@ -199,7 +215,11 @@
       "p",
       "r",
       "s",
-      "t"
+      "t",
+      "v",
+      "x",
+      "y",
+      "z"
     ],
     "autoLinkingEnabled": true
   },
@@ -223,7 +243,11 @@
       "p",
       "r",
       "s",
-      "t"
+      "t",
+      "v",
+      "x",
+      "y",
+      "z"
     ],
     "autoLinkingEnabled": true
   },
@@ -245,7 +269,11 @@
       "t",
       "d",
       "g",
-      "n"
+      "n",
+      "v",
+      "x",
+      "y",
+      "z"
     ],
     "autoLinkingEnabled": true
   },
@@ -267,7 +295,11 @@
       "p",
       "r",
       "s",
-      "t"
+      "t",
+      "v",
+      "x",
+      "y",
+      "z"
     ],
     "autoLinkingEnabled": true
   },
@@ -278,7 +310,11 @@
     "authoritySubfields": [
       "a",
       "b",
-      "g"
+      "g",
+      "v",
+      "x",
+      "y",
+      "z"
     ],
     "autoLinkingEnabled": true
   },
@@ -288,7 +324,11 @@
     "authorityField": "151",
     "authoritySubfields": [
       "a",
-      "g"
+      "g",
+      "v",
+      "x",
+      "y",
+      "z"
     ],
     "autoLinkingEnabled": true
   },
@@ -297,7 +337,11 @@
     "bibField": "655",
     "authorityField": "155",
     "authoritySubfields": [
-      "a"
+      "a",
+      "v",
+      "x",
+      "y",
+      "z"
     ],
     "autoLinkingEnabled": true
   },
@@ -323,7 +367,11 @@
       "r",
       "s",
       "t",
-      "g"
+      "g",
+      "v",
+      "x",
+      "y",
+      "z"
     ],
     "autoLinkingEnabled": true
   },
@@ -347,7 +395,11 @@
       "t",
       "d",
       "g",
-      "n"
+      "n",
+      "v",
+      "x",
+      "y",
+      "z"
     ],
     "autoLinkingEnabled": true
   },
@@ -369,7 +421,11 @@
       "t",
       "d",
       "g",
-      "n"
+      "n",
+      "v",
+      "x",
+      "y",
+      "z"
     ],
     "autoLinkingEnabled": true
   },
@@ -391,7 +447,11 @@
       "p",
       "r",
       "s",
-      "t"
+      "t",
+      "v",
+      "x",
+      "y",
+      "z"
     ],
     "autoLinkingEnabled": true
   },
@@ -417,7 +477,11 @@
       "r",
       "s",
       "t",
-      "g"
+      "g",
+      "v",
+      "x",
+      "y",
+      "z"
     ],
     "autoLinkingEnabled": true
   },
@@ -441,7 +505,11 @@
       "t",
       "d",
       "g",
-      "n"
+      "n",
+      "v",
+      "x",
+      "y",
+      "z"
     ],
     "autoLinkingEnabled": true
   },
@@ -463,7 +531,11 @@
       "t",
       "d",
       "g",
-      "n"
+      "n",
+      "v",
+      "x",
+      "y",
+      "z"
     ],
     "autoLinkingEnabled": true
   },
@@ -485,7 +557,11 @@
       "p",
       "r",
       "s",
-      "t"
+      "t",
+      "v",
+      "x",
+      "y",
+      "z"
     ],
     "autoLinkingEnabled": true
   }


### PR DESCRIPTION
### Purpose
Update instance-authority linking rules to include v, x, y, z subfields

### Approach
Create migration script for linking rules.

### Changes Checklist
- [ ] **API Changes**: Document any API paths, methods, request or response bodies changed, added, or removed.
- [ ] **Database Schema Changes**: Indicate any database schema changes and their impact. Confirm that migration scripts were created.
- [ ] **Interface Version Changes**: Indicate any changes to interface versions.
- [ ] **Interface Dependencies**: Document added or removed dependencies.
- [ ] **Permissions**: Document any changes to permissions.
- [ ] **Logging**: Confirm that logging is appropriately handled.
- [x] **Unit Testing**: Confirm that changed classes were covered by unit tests.
- [x] **Integration Testing**: Confirm that changed logic was covered by integration tests.
- [x] **Manual Testing**: Confirm that changes were tested on local or dev environment.
- [x] **NEWS**: Confirm that the NEWS file is updated with relevant information about the changes made in this pull request.

### Related Issues
https://folio-org.atlassian.net/browse/MODELINKS-252
