### PR TITLE
fix(consortium): Fix context mixup on data propagation

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -10,7 +10,7 @@
 * Refactor subfield handling and improve link suggestion logic ([MODELINKS-268](https://folio-org.atlassian.net/browse/MODELINKS-268))
 
 ### Bug fixes
-* Description ([ISSUE](https://folio-org.atlassian.net/browse/ISSUE))
+* Fix context mix-up on data propagation ([MODELINKS-273](https://folio-org.atlassian.net/browse/MODELINKS-273))
 
 ### Tech Dept
 * Description ([ISSUE](https://folio-org.atlassian.net/browse/ISSUE))

--- a/src/main/java/org/folio/entlinks/controller/delegate/AuthorityServiceDelegate.java
+++ b/src/main/java/org/folio/entlinks/controller/delegate/AuthorityServiceDelegate.java
@@ -83,7 +83,8 @@ public class AuthorityServiceDelegate {
 
   public AuthorityDto createAuthority(AuthorityDto authorityDto) {
     var entity = mapper.toEntity(authorityDto);
-    var created = service.create(entity, createConsumer());
+    var created = service.create(entity);
+    createConsumer().accept(created);
     return mapper.toDto(created);
   }
 
@@ -93,22 +94,20 @@ public class AuthorityServiceDelegate {
         List.of(new Parameter("id").value(String.valueOf(authorityDto.getId()))));
     }
     var modifiedEntity = mapper.toEntity(authorityDto);
-    service.update(modifiedEntity, updateConsumer());
+    var updateResult = service.update(modifiedEntity, false);
+    updateConsumer().accept(updateResult.newEntity(), updateResult.oldEntity());
   }
 
   public void deleteAuthorityById(UUID id) {
-    service.deleteById(id, authority -> {
-      eventPublisher.publishSoftDeleteEvent(mapper.toDto(authority));
-      propagationService.propagate(authority, DELETE, context.getTenantId());
-    });
-
+    var authority = service.deleteById(id);
+    eventPublisher.publishSoftDeleteEvent(mapper.toDto(authority));
+    propagationService.propagate(authority, DELETE, context.getTenantId());
   }
 
   @SneakyThrows
   public AuthorityBulkResponse createAuthorities(AuthorityBulkRequest createRequest) {
     var bulkContext = new AuthoritiesBulkContext(createRequest.getRecordsFileName());
-    var errorsCount = authorityS3Service.processAuthorities(bulkContext,
-      authorities -> service.upsert(authorities, createConsumer(), updateConsumer()));
+    var errorsCount = authorityS3Service.processAuthorities(bulkContext, this::upsertAuthorities);
 
     var authorityBulkCreateResponse = new AuthorityBulkResponse()
       .errorsNumber(errorsCount);
@@ -118,6 +117,16 @@ public class AuthorityServiceDelegate {
         .errorsFileName(bulkContext.getErrorsFilePath());
     }
     return authorityBulkCreateResponse;
+  }
+
+  private void upsertAuthorities(List<Authority> authorities) {
+    service.upsert(authorities).forEach(authorityUpdateResult -> {
+      if (authorityUpdateResult.oldEntity() == null) {
+        createConsumer().accept(authorityUpdateResult.newEntity());
+      } else {
+        updateConsumer().accept(authorityUpdateResult.newEntity(), authorityUpdateResult.oldEntity());
+      }
+    });
   }
 
   @NotNull

--- a/src/main/java/org/folio/entlinks/service/authority/AuthorityArchiveService.java
+++ b/src/main/java/org/folio/entlinks/service/authority/AuthorityArchiveService.java
@@ -1,15 +1,9 @@
 package org.folio.entlinks.service.authority;
 
-import java.util.Collection;
-import java.util.List;
-import java.util.Map;
 import java.util.UUID;
-import java.util.function.BiConsumer;
-import java.util.function.Consumer;
 import lombok.AllArgsConstructor;
 import lombok.extern.log4j.Log4j2;
 import org.apache.commons.lang3.StringUtils;
-import org.folio.entlinks.domain.entity.Authority;
 import org.folio.entlinks.domain.entity.AuthorityArchive;
 import org.folio.entlinks.domain.repository.AuthorityArchiveRepository;
 import org.folio.spring.data.OffsetRequest;
@@ -21,11 +15,10 @@ import org.springframework.transaction.annotation.Transactional;
 @Service
 @AllArgsConstructor
 @Log4j2
-public class AuthorityArchiveService implements AuthorityServiceI<AuthorityArchive> {
+public class AuthorityArchiveService {
 
   private final AuthorityArchiveRepository repository;
 
-  @Override
   public Page<AuthorityArchive> getAll(Integer offset, Integer limit, String cqlQuery) {
     log.debug("getAll:: Attempts to find all AuthorityArchive by [offset: {}, limit: {}, cql: {}]", offset, limit,
       cqlQuery);
@@ -37,7 +30,6 @@ public class AuthorityArchiveService implements AuthorityServiceI<AuthorityArchi
     return repository.findByCql(cqlQuery, new OffsetRequest(offset, limit));
   }
 
-  @Override
   public Page<UUID> getAllIds(Integer offset, Integer limit, String cqlQuery) {
     log.debug("getAll:: Attempts to find all AuthorityArchive IDs by [offset: {}, limit: {}, cql: {}]",
       offset, limit, cqlQuery);
@@ -47,79 +39,6 @@ public class AuthorityArchiveService implements AuthorityServiceI<AuthorityArchi
     }
 
     return repository.findIdsByCql(cqlQuery, new OffsetRequest(offset, limit));
-  }
-
-  @Override
-  public Map<UUID, AuthorityArchive> getAllByIds(Collection<UUID> ids) {
-    throw new UnsupportedOperationException();
-  }
-
-  @Override
-  public AuthorityArchive getById(UUID id) {
-    throw new UnsupportedOperationException();
-  }
-
-  @Override
-  public AuthorityArchive create(AuthorityArchive entity) {
-    throw new UnsupportedOperationException();
-  }
-
-  @Override
-  public AuthorityArchive create(AuthorityArchive entity, Consumer<AuthorityArchive> authorityCallback) {
-    throw new UnsupportedOperationException();
-  }
-
-  @Override
-  public AuthorityArchive update(AuthorityArchive modified) {
-    throw new UnsupportedOperationException();
-  }
-
-  @Override
-  public Authority update(Authority modified, boolean forced) {
-    throw new UnsupportedOperationException();
-  }
-
-  @Override
-  public AuthorityArchive update(AuthorityArchive modified,
-                                 BiConsumer<AuthorityArchive, AuthorityArchive> authorityCallback) {
-    throw new UnsupportedOperationException();
-  }
-
-  @Override
-  public Authority update(Authority modified, boolean forced, BiConsumer<Authority, Authority> authorityConsumer) {
-    throw new UnsupportedOperationException();
-  }
-
-  @Override
-  public List<AuthorityArchive> upsert(List<AuthorityArchive> entities,
-                                       Consumer<AuthorityArchive> authorityCreateCallback,
-                                       BiConsumer<AuthorityArchive, AuthorityArchive> authorityUpdateCallback) {
-    throw new UnsupportedOperationException();
-  }
-
-  @Override
-  public void deleteById(UUID id) {
-    throw new UnsupportedOperationException();
-  }
-
-  @Override
-  public void deleteById(UUID id, boolean forced) {
-    throw new UnsupportedOperationException();
-  }
-
-  @Override
-  public void deleteById(UUID id, Consumer<AuthorityArchive> authorityCallback) {
-    throw new UnsupportedOperationException();
-  }
-
-  @Override
-  public void deleteById(UUID id, boolean forced, Consumer<Authority> authorityCallback) {
-    throw new UnsupportedOperationException();
-  }
-
-  @Override
-  public void deleteByIds(Collection<UUID> ids) {
-    throw new UnsupportedOperationException();
   }
 
   @Transactional(propagation = Propagation.REQUIRES_NEW)

--- a/src/main/java/org/folio/entlinks/service/authority/AuthorityServiceI.java
+++ b/src/main/java/org/folio/entlinks/service/authority/AuthorityServiceI.java
@@ -4,8 +4,6 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
-import java.util.function.BiConsumer;
-import java.util.function.Consumer;
 import org.folio.entlinks.domain.entity.Authority;
 import org.springframework.data.domain.Page;
 
@@ -21,26 +19,13 @@ public interface AuthorityServiceI<T> {
 
   T create(T entity);
 
-  T create(T entity, Consumer<T> authorityCallback);
+  AuthorityUpdateResult update(Authority modified, boolean forced);
 
-  T update(T modified);
-
-  Authority update(Authority modified, boolean forced);
-
-  T update(T modified, BiConsumer<T, T> authorityCallback);
-
-  Authority update(Authority modified, boolean forced,
-                   BiConsumer<Authority, Authority> authorityConsumer);
-
-  List<T> upsert(List<T> entities, Consumer<T> authorityCreateCallback, BiConsumer<T, T> authorityUpdateCallback);
-
-  void deleteById(UUID id);
+  List<AuthorityUpdateResult> upsert(List<T> entities);
 
   void deleteById(UUID id, boolean forced);
 
-  void deleteById(UUID id, Consumer<T> authorityCallback);
-
-  void deleteById(UUID id, boolean forced, Consumer<Authority> authorityCallback);
+  T deleteById(UUID id);
 
   void deleteByIds(Collection<UUID> ids);
 }

--- a/src/main/java/org/folio/entlinks/service/authority/AuthorityUpdateResult.java
+++ b/src/main/java/org/folio/entlinks/service/authority/AuthorityUpdateResult.java
@@ -1,0 +1,5 @@
+package org.folio.entlinks.service.authority;
+
+import org.folio.entlinks.domain.entity.Authority;
+
+public record AuthorityUpdateResult(Authority oldEntity, Authority newEntity) { }

--- a/src/main/java/org/folio/entlinks/service/authority/ConsortiumAuthorityService.java
+++ b/src/main/java/org/folio/entlinks/service/authority/ConsortiumAuthorityService.java
@@ -2,8 +2,6 @@ package org.folio.entlinks.service.authority;
 
 import java.util.Optional;
 import java.util.UUID;
-import java.util.function.BiConsumer;
-import java.util.function.Consumer;
 import org.folio.entlinks.domain.entity.Authority;
 import org.folio.entlinks.domain.repository.AuthorityRepository;
 import org.folio.entlinks.exception.ConsortiumIllegalActionException;
@@ -20,20 +18,19 @@ public class ConsortiumAuthorityService extends AuthorityService {
   }
 
   @Override
-  protected Authority updateInner(Authority modified, boolean forced,
-                                  BiConsumer<Authority, Authority> authorityConsumer) {
+  protected AuthorityUpdateResult updateInner(Authority modified, boolean forced) {
     if (!forced) {
       validate(modified.getId(), "Update");
     }
-    return super.updateInner(modified, forced, authorityConsumer);
+    return super.updateInner(modified, forced);
   }
 
   @Override
-  protected void deleteByIdInner(UUID id, boolean forced, Consumer<Authority> authorityCallback) {
+  protected Authority deleteByIdInner(UUID id, boolean forced) {
     if (!forced) {
       validate(id, "Delete");
     }
-    super.deleteByIdInner(id, forced, authorityCallback);
+    return super.deleteByIdInner(id, forced);
   }
 
   private void validate(UUID id, String actionName) {

--- a/src/test/java/org/folio/entlinks/controller/AuthorityControllerIT.java
+++ b/src/test/java/org/folio/entlinks/controller/AuthorityControllerIT.java
@@ -183,7 +183,7 @@ class AuthorityControllerIT extends IntegrationTestBase {
   void getCollectionOfIdsOnly_positive_authorityArchivesFound() throws Exception {
     var createdEntities = createAuthorityArchives();
     var expectedCollection = new AuthorityDtoCollection(
-      createdEntities.stream().map(archive -> new AuthorityDto().id(archive.getId())).collect(Collectors.toList()),
+      createdEntities.stream().map(archive -> new AuthorityDto().id(archive.getId())).toList(),
       createdEntities.size()
     );
 
@@ -638,7 +638,7 @@ class AuthorityControllerIT extends IntegrationTestBase {
     doDelete(authorityEndpoint(authority.getId()));
     var event = getConsumedEvent();
     assertEquals(AuthorityDeleteEventSubType.SOFT_DELETE, event.value().getDeleteEventSubType());
-    verifyConsumedAuthorityEvent(event, DELETE, expectedDto);
+    verifyConsumedAuthorityEvent(event, DELETE, expectedDto.version(1));
 
     awaitUntilAsserted(() ->
       assertEquals(1, databaseHelper.countRows(AUTHORITY_DATA_STAT_TABLE, TENANT_ID)));

--- a/src/test/java/org/folio/entlinks/controller/AuthoritySourceFilesControllerIT.java
+++ b/src/test/java/org/folio/entlinks/controller/AuthoritySourceFilesControllerIT.java
@@ -30,7 +30,6 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import java.io.UnsupportedEncodingException;
 import java.sql.Timestamp;
 import java.time.Instant;
-import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -49,7 +48,6 @@ import org.folio.entlinks.domain.entity.AuthoritySourceFileSource;
 import org.folio.entlinks.exception.AuthoritySourceFileNotFoundException;
 import org.folio.entlinks.exception.OptimisticLockingException;
 import org.folio.entlinks.exception.RequestBodyValidationException;
-import org.folio.spring.integration.XOkapiHeaders;
 import org.folio.spring.testing.extension.DatabaseCleanup;
 import org.folio.spring.testing.type.IntegrationTest;
 import org.folio.support.base.IntegrationTestBase;
@@ -60,7 +58,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 import org.springframework.dao.DataIntegrityViolationException;
-import org.springframework.http.HttpHeaders;
 import org.springframework.test.web.servlet.ResultMatcher;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
@@ -707,12 +704,6 @@ class AuthoritySourceFilesControllerIT extends IntegrationTestBase {
 
   private ResultMatcher errorMessageMatch(Matcher<String> errorMessageMatcher) {
     return jsonPath("$.errors.[0].message", errorMessageMatcher);
-  }
-
-  private HttpHeaders tenantHeaders(String tenant) {
-    var httpHeaders = defaultHeaders();
-    httpHeaders.put(XOkapiHeaders.TENANT, Collections.singletonList(tenant));
-    return httpHeaders;
   }
 
   private AuthorityDto requestAuthority(UUID id, String tenantId)

--- a/src/test/java/org/folio/entlinks/controller/ConsortiumAuthoritySourceFilesIT.java
+++ b/src/test/java/org/folio/entlinks/controller/ConsortiumAuthoritySourceFilesIT.java
@@ -13,14 +13,12 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-import java.util.Collections;
 import java.util.List;
 import java.util.UUID;
 import lombok.SneakyThrows;
 import org.folio.entlinks.domain.dto.AuthorityDto;
 import org.folio.entlinks.domain.dto.AuthoritySourceFilePostDto;
 import org.folio.entlinks.exception.AuthorityArchiveConstraintException;
-import org.folio.spring.integration.XOkapiHeaders;
 import org.folio.spring.testing.extension.DatabaseCleanup;
 import org.folio.spring.testing.type.IntegrationTest;
 import org.folio.support.base.IntegrationTestBase;
@@ -28,7 +26,6 @@ import org.hamcrest.Matcher;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.springframework.http.HttpHeaders;
 import org.springframework.test.web.servlet.ResultMatcher;
 
 @IntegrationTest
@@ -96,11 +93,5 @@ class ConsortiumAuthoritySourceFilesIT extends IntegrationTestBase {
 
   private ResultMatcher errorMessageMatch(Matcher<String> errorMessageMatcher) {
     return jsonPath("$.errors.[0].message", errorMessageMatcher);
-  }
-
-  private HttpHeaders tenantHeaders(String tenant) {
-    var httpHeaders = defaultHeaders();
-    httpHeaders.put(XOkapiHeaders.TENANT, Collections.singletonList(tenant));
-    return httpHeaders;
   }
 }

--- a/src/test/java/org/folio/entlinks/controller/ConsortiumLinksSuggestionsIT.java
+++ b/src/test/java/org/folio/entlinks/controller/ConsortiumLinksSuggestionsIT.java
@@ -15,7 +15,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
@@ -28,7 +27,6 @@ import org.folio.entlinks.domain.dto.LinkStatus;
 import org.folio.entlinks.domain.dto.ParsedRecordContent;
 import org.folio.entlinks.domain.dto.ParsedRecordContentCollection;
 import org.folio.entlinks.domain.entity.AuthoritySourceFileCode;
-import org.folio.spring.integration.XOkapiHeaders;
 import org.folio.spring.testing.extension.DatabaseCleanup;
 import org.folio.spring.testing.type.IntegrationTest;
 import org.folio.support.DatabaseHelper;
@@ -37,7 +35,6 @@ import org.folio.support.base.IntegrationTestBase;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.springframework.http.HttpHeaders;
 
 @IntegrationTest
 @DatabaseCleanup(tables = {DatabaseHelper.AUTHORITY_TABLE, DatabaseHelper.AUTHORITY_SOURCE_FILE_CODE_TABLE,
@@ -182,11 +179,5 @@ class ConsortiumLinksSuggestionsIT extends IntegrationTestBase {
         .authorityId(UUID.fromString(LINKABLE_AUTHORITY_ID))
         .authorityNaturalId(NATURAL_ID)
         .status(linkStatus);
-  }
-
-  private HttpHeaders tenantHeaders(String tenant) {
-    var httpHeaders = defaultHeaders();
-    httpHeaders.put(XOkapiHeaders.TENANT, Collections.singletonList(tenant));
-    return httpHeaders;
   }
 }

--- a/src/test/java/org/folio/entlinks/service/authority/AuthorityServiceTest.java
+++ b/src/test/java/org/folio/entlinks/service/authority/AuthorityServiceTest.java
@@ -151,9 +151,10 @@ class AuthorityServiceTest {
 
     when(repository.findByIdAndDeletedFalse(id)).thenReturn(Optional.of(existed));
     when(repository.saveAndFlush(any(Authority.class))).thenAnswer(invocation -> invocation.getArgument(0));
-    var updated = service.update(modified);
+    var updated = service.update(modified, false);
 
-    assertThat(updated).isEqualTo(modified);
+    assertThat(updated.oldEntity()).isEqualTo(existed);
+    assertThat(updated.newEntity()).isEqualTo(modified);
     verify(repository).findByIdAndDeletedFalse(id);
     verify(repository).saveAndFlush(argThat(authorityMatch(modified)));
   }
@@ -175,9 +176,9 @@ class AuthorityServiceTest {
     when(repository.findByIdAndDeletedFalse(id)).thenReturn(Optional.of(existed));
     when(repository.saveAndFlush(any(Authority.class))).thenAnswer(invocation -> invocation.getArgument(0));
 
-    var updated = service.update(modified);
+    var updated = service.update(modified, false);
 
-    assertThat(updated.getAuthoritySourceFile()).isNull();
+    assertThat(updated.newEntity().getAuthoritySourceFile()).isNull();
     verify(repository).findByIdAndDeletedFalse(id);
     verify(repository).saveAndFlush(existed);
     verifyNoMoreInteractions(repository);
@@ -194,7 +195,7 @@ class AuthorityServiceTest {
 
     when(repository.findByIdAndDeletedFalse(id)).thenReturn(Optional.of(existing));
 
-    var thrown = assertThrows(OptimisticLockingException.class, () -> service.update(modified));
+    var thrown = assertThrows(OptimisticLockingException.class, () -> service.update(modified, false));
 
     assertThat(thrown.getMessage())
       .isEqualTo("Cannot update record " + id + " because it has been changed (optimistic locking): "
@@ -208,7 +209,7 @@ class AuthorityServiceTest {
     when(repository.findByIdAndDeletedFalse(any(UUID.class))).thenReturn(Optional.of(authority));
     when(repository.save(any(Authority.class))).thenReturn(authority);
 
-    service.deleteById(UUID.randomUUID());
+    service.deleteById(UUID.randomUUID(), false);
 
     verify(repository).findByIdAndDeletedFalse(any(UUID.class));
     verify(repository).save(any(Authority.class));
@@ -219,7 +220,7 @@ class AuthorityServiceTest {
     var id = UUID.randomUUID();
     when(repository.findByIdAndDeletedFalse(any(UUID.class))).thenReturn(Optional.empty());
 
-    var thrown = assertThrows(AuthorityNotFoundException.class, () -> service.deleteById(id));
+    var thrown = assertThrows(AuthorityNotFoundException.class, () -> service.deleteById(id, false));
 
     assertThat(thrown.getMessage()).containsOnlyOnce(id.toString());
     verify(repository).findByIdAndDeletedFalse(any(UUID.class));

--- a/src/test/java/org/folio/entlinks/service/authority/ConsortiumAuthorityServiceTest.java
+++ b/src/test/java/org/folio/entlinks/service/authority/ConsortiumAuthorityServiceTest.java
@@ -40,10 +40,9 @@ class ConsortiumAuthorityServiceTest {
     when(repository.findByIdAndDeletedFalse(any())).thenReturn(Optional.of(authority));
 
     // Act
-    consortiumAuthorityService.updateInner(authority, forced, authorityConsumer);
+    consortiumAuthorityService.updateInner(authority, forced);
 
     // Assert
-    verify(authorityConsumer).accept(any(), any());
     verify(repository).findByIdAndDeletedFalse(any());
   }
 
@@ -56,7 +55,7 @@ class ConsortiumAuthorityServiceTest {
 
     // Act
     assertThrows(ConsortiumIllegalActionException.class,
-      () -> consortiumAuthorityService.updateInner(authority, forced, authorityConsumer));
+      () -> consortiumAuthorityService.updateInner(authority, forced));
 
     // Assert
     verifyNoInteractions(authorityConsumer); // Should not call updateInner
@@ -70,10 +69,9 @@ class ConsortiumAuthorityServiceTest {
     when(repository.findByIdAndDeletedFalse(any())).thenReturn(Optional.of(authority));
 
     // Act
-    consortiumAuthorityService.deleteByIdInner(id, forced, authorityCallback);
+    consortiumAuthorityService.deleteByIdInner(id, forced);
 
     // Assert
-    verify(authorityCallback).accept(any());
     verify(repository).findByIdAndDeletedFalse(any());
   }
 
@@ -86,7 +84,7 @@ class ConsortiumAuthorityServiceTest {
 
     // Act
     assertThrows(ConsortiumIllegalActionException.class,
-      () -> consortiumAuthorityService.deleteByIdInner(id, forced, authorityCallback));
+      () -> consortiumAuthorityService.deleteByIdInner(id, forced));
 
     // Assert
     verifyNoInteractions(authorityCallback);

--- a/src/test/java/org/folio/entlinks/service/consortium/ConsortiumAuthorityPropagationServiceIT.java
+++ b/src/test/java/org/folio/entlinks/service/consortium/ConsortiumAuthorityPropagationServiceIT.java
@@ -26,12 +26,10 @@ import java.io.UnsupportedEncodingException;
 import java.sql.Timestamp;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
-import java.util.Collections;
 import java.util.List;
 import java.util.UUID;
 import lombok.SneakyThrows;
 import org.folio.entlinks.domain.dto.AuthorityDto;
-import org.folio.spring.integration.XOkapiHeaders;
 import org.folio.spring.testing.extension.DatabaseCleanup;
 import org.folio.spring.testing.type.IntegrationTest;
 import org.folio.support.base.IntegrationTestBase;
@@ -230,12 +228,6 @@ class ConsortiumAuthorityPropagationServiceIT extends IntegrationTestBase {
       .getResponse()
       .getContentAsString();
     return objectMapper.readValue(response, AuthorityDto.class);
-  }
-
-  private HttpHeaders tenantHeaders(String tenant) {
-    var httpHeaders = defaultHeaders();
-    httpHeaders.put(XOkapiHeaders.TENANT, Collections.singletonList(tenant));
-    return httpHeaders;
   }
 
 }

--- a/src/test/java/org/folio/support/base/IntegrationTestBase.java
+++ b/src/test/java/org/folio/support/base/IntegrationTestBase.java
@@ -29,6 +29,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.github.tomakehurst.wiremock.WireMockServer;
 import com.github.tomakehurst.wiremock.client.WireMock;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -171,6 +172,12 @@ public class IntegrationTestBase {
     httpHeaders.add(XOkapiHeaders.USER_ID, USER_ID);
     httpHeaders.add(URL, okapi.getOkapiUrl());
 
+    return httpHeaders;
+  }
+
+  protected static HttpHeaders tenantHeaders(String tenant) {
+    var httpHeaders = defaultHeaders();
+    httpHeaders.put(XOkapiHeaders.TENANT, Collections.singletonList(tenant));
     return httpHeaders;
   }
 


### PR DESCRIPTION
### Purpose
Fix shared authority becoming shadow copy on central tenant

### Approach
- Move consortium propagation out of central tenant transactional method
- Remove redundant AuthorityService methods

### Changes Checklist
- [ ] **API Changes**: Document any API paths, methods, request or response bodies changed, added, or removed.
- [ ] **Database Schema Changes**: Indicate any database schema changes and their impact. Confirm that migration scripts were created.
- [ ] **Interface Version Changes**: Indicate any changes to interface versions.
- [ ] **Interface Dependencies**: Document added or removed dependencies.
- [ ] **Permissions**: Document any changes to permissions.
- [ ] **Logging**: Confirm that logging is appropriately handled.
- [x] **Unit Testing**: Confirm that changed classes were covered by unit tests.
- [x] **Integration Testing**: Confirm that changed logic was covered by integration tests.
- [x] **Manual Testing**: Confirm that changes were tested on local or dev environment.
- [x] **NEWS**: Confirm that the NEWS file is updated with relevant information about the changes made in this pull request.

### Related Issues
[MODELINKS-273](https://folio-org.atlassian.net/browse/MODELINKS-273)

### Learning and Resources (if applicable)
The issue was with context mixup which caused central tenant record to be marked as consortium shadow copy.
Tested with consortium integration test (not included in a PR) which sequentially updates record 100 times and restarts multiple times. Before the fix - it failed in 2-7 run, now it succeeds event 20 runs in a row.
Manually tested on dev env by updating a record 20 times.