### PR TITLE
MODELINKS-268 Fix adding uncontrolled field when subfield modification exists in links suggestions

### DIFF
--- a/src/test/java/org/folio/entlinks/service/links/LinksSuggestionsServiceTest.java
+++ b/src/test/java/org/folio/entlinks/service/links/LinksSuggestionsServiceTest.java
@@ -153,6 +153,34 @@ class LinksSuggestionsServiceTest {
 
   @ParameterizedTest
   @ValueSource(chars = {NATURAL_ID_SUBFIELD_CODE, ID_SUBFIELD_CODE})
+  void fillLinkDetailsWithSuggestedAuthorities_shouldUpdateAndRemoveControlledSubfieldWithModification(
+    char linkingMatchSubfield) {
+    var rules = getMapRule("100", "100");
+    var initialBibSubfields = new HashMap<String, String>();
+    initialBibSubfields.put("b", "b value");
+    var bib = getBibParsedRecordContent("100", initialBibSubfields, null);
+    var authority = getAuthorityParsedRecordContent("100");
+    when(authoritySourceFileService.getById(SOURCE_FILE_ID)).thenReturn(authoritySourceFile);
+
+    linksSuggestionsService
+      .fillLinkDetailsWithSuggestedAuthorities(List.of(bib), List.of(authority), rules, linkingMatchSubfield, false);
+
+    var bibField = bib.getFields().get(0);
+    var linkDetails = bibField.getLinkDetails();
+    assertEquals(LinkStatus.NEW, linkDetails.getStatus());
+    assertEquals(AUTHORITY_ID, linkDetails.getAuthorityId());
+    assertEquals(NATURAL_ID, linkDetails.getAuthorityNaturalId());
+    assertEquals(1, linkDetails.getLinkingRuleId());
+    assertNull(linkDetails.getErrorCause());
+
+    assertEquals(1, bibField.getSubfields('b').size());
+    assertEquals("test", bibField.getSubfields('b').get(0).value());
+    assertEquals(AUTHORITY_ID.toString(), bibField.getSubfields('9').get(0).value());
+    assertEquals(BASE_URL + NATURAL_ID, bibField.getSubfields('0').get(0).value());
+  }
+
+  @ParameterizedTest
+  @ValueSource(chars = {NATURAL_ID_SUBFIELD_CODE, ID_SUBFIELD_CODE})
   void fillLinkDetailsWithSuggestedAuthorities_shouldFillLinkDetails_withActualLink(char linkingMatchSubfield) {
     var rules = getMapRule("100", "100");
     var bib = getBibParsedRecordContent("100", getActualLinksDetails());


### PR DESCRIPTION
### Purpose
Fix adding uncontrolled field when subfield modification exists in links suggestions

### Approach
Add subfield modification to filtering logic

### Changes Checklist
- [ ] **API Changes**: Document any API paths, methods, request or response bodies changed, added, or removed.
- [ ] **Database Schema Changes**: Indicate any database schema changes and their impact. Confirm that migration scripts were created.
- [ ] **Interface Version Changes**: Indicate any changes to interface versions.
- [ ] **Interface Dependencies**: Document added or removed dependencies.
- [ ] **Permissions**: Document any changes to permissions.
- [ ] **Logging**: Confirm that logging is appropriately handled.
- [x] **Unit Testing**: Confirm that changed classes were covered by unit tests.
- [ ] **Integration Testing**: Confirm that changed logic was covered by integration tests.
- [x] **Manual Testing**: Confirm that changes were tested on local or dev environment.
- [ ] **NEWS**: Confirm that the NEWS file is updated with relevant information about the changes made in this pull request.

### Related Issues
https://folio-org.atlassian.net/browse/MODELINKS-268
