### PR TITLE
fix(authority): Close input stream on s3 file read

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -14,6 +14,7 @@
 
 ### Bug fixes
 * Fix context mix-up on data propagation ([MODELINKS-273](https://folio-org.atlassian.net/browse/MODELINKS-273))
+* Close input stream on s3 file read ([MODELINKS-278](https://folio-org.atlassian.net/browse/MODELINKS-278))
 
 ### Tech Dept
 * Add missing interface `source-storage-batch` dependency in module descriptor ([MODELINKS-275](https://folio-org.atlassian.net/browse/MODELINKS-275))

--- a/src/test/java/org/folio/entlinks/service/authority/BulkAuthorityS3ClientTest.java
+++ b/src/test/java/org/folio/entlinks/service/authority/BulkAuthorityS3ClientTest.java
@@ -2,6 +2,7 @@ package org.folio.entlinks.service.authority;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -15,6 +16,9 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+/**
+ * Code partially generated using GitHub Copilot.
+ * */
 @UnitTest
 @ExtendWith(MockitoExtension.class)
 class BulkAuthorityS3ClientTest {
@@ -40,6 +44,33 @@ class BulkAuthorityS3ClientTest {
     assertEquals(1, resultList.size());
     var stringAuthority = resultList.get(0);
     assertThat(stringAuthority).contains(AUTHORITY_UUID, "Test Authority");
+  }
+
+  @Test
+  void readFile_ReturnsEmptyListWhenFileIsEmpty() {
+    // Arrange
+    var remoteFileName = "empty-file";
+    var inputStream = new ByteArrayInputStream(new byte[0]);
+    when(s3Client.read(remoteFileName)).thenReturn(inputStream);
+
+    // Act
+    var resultList = client.readFile(remoteFileName);
+
+    // Assert
+    assertThat(resultList).isEmpty();
+  }
+
+  @Test
+  void readFile_ThrowsIllegalStateExceptionWhenIoExceptionOccurs() {
+    // Arrange
+    var remoteFileName = "error-file";
+    when(s3Client.read(remoteFileName)).thenAnswer(invocation -> {
+      throw new IOException("Test IOException");
+    });
+
+    // Act & Assert
+    var exception = assertThrows(IllegalStateException.class, () -> client.readFile(remoteFileName));
+    assertThat(exception).hasMessageContaining("Error reading file: " + remoteFileName);
   }
 
   @Test


### PR DESCRIPTION
### Purpose
Close input stream on s3 file read

### Changes Checklist
- [ ] **API Changes**: Document any API paths, methods, request or response bodies changed, added, or removed.
- [ ] **Database Schema Changes**: Indicate any database schema changes and their impact. Confirm that migration scripts were created.
- [ ] **Interface Version Changes**: Indicate any changes to interface versions.
- [ ] **Interface Dependencies**: Document added or removed dependencies.
- [ ] **Permissions**: Document any changes to permissions.
- [ ] **Logging**: Confirm that logging is appropriately handled.
- [x] **Unit Testing**: Confirm that changed classes were covered by unit tests.
- [ ] **Integration Testing**: Confirm that changed logic was covered by integration tests.
- [ ] **Manual Testing**: Confirm that changes were tested on local or dev environment.
- [x] **NEWS**: Confirm that the NEWS file is updated with relevant information about the changes made in this pull request.

### Related Issues
[MODELINKS-278](https://folio-org.atlassian.net/browse/MODELINKS-278)