### PR TITLE
MODELINKS-244: Do not update (recreate) authority source file sequence for member tenant on updating source file

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -17,7 +17,7 @@
 * Close input stream on s3 file read ([MODELINKS-278](https://folio-org.atlassian.net/browse/MODELINKS-278))
 * Shadow copies of deleted Shared MARC authority from Central tenant are not deleted from Member tenants
   after specified retention period ([MODELINKS-279](https://folio-org.atlassian.net/browse/MODELINKS-279))
-* Fix persisting createdBy and updatedBy user id for shadow copies in ECS ([MODELINKS-244](https://folio-org.atlassian.net/browse/MODELINKS-244))
+* Fix persisting createdBy and updatedBy user id for authority source file shadow copies in ECS ([MODELINKS-244](https://folio-org.atlassian.net/browse/MODELINKS-244))
 
 ### Tech Dept
 * Add missing interface `source-storage-batch` dependency in module descriptor ([MODELINKS-275](https://folio-org.atlassian.net/browse/MODELINKS-275))

--- a/src/main/java/org/folio/entlinks/service/authority/AuthoritySourceFileService.java
+++ b/src/main/java/org/folio/entlinks/service/authority/AuthoritySourceFileService.java
@@ -264,7 +264,7 @@ public class AuthoritySourceFileService implements AuthoritySourceFileServiceI {
     jdbcRepository.dropSequence(sequenceName);
   }
 
-  protected void updateSequenceStartNumber(AuthoritySourceFile existing, AuthoritySourceFile modified) {
+  private void updateSequenceStartNumber(AuthoritySourceFile existing, AuthoritySourceFile modified) {
     if (!Objects.equals(existing.getHridStartNumber(), modified.getHridStartNumber())
         && existing.getHridStartNumber() != null && modified.getHridStartNumber() != null) {
       var sequenceName = existing.getSequenceName();

--- a/src/main/java/org/folio/entlinks/service/authority/PropagationAuthoritySourceFileService.java
+++ b/src/main/java/org/folio/entlinks/service/authority/PropagationAuthoritySourceFileService.java
@@ -83,8 +83,6 @@ public class PropagationAuthoritySourceFileService extends AuthoritySourceFileSe
           id, existingEntity.getVersion(), modified.getVersion());
     }
 
-    updateSequenceStartNumber(existingEntity, modified);
-
     jdbcRepository.update(modified, existingEntity.getVersion());
 
     if (publishConsumer != null) {


### PR DESCRIPTION
### Purpose
Authority source file sequence that is used for source file `hrid`'s is created and then queried with/for central tenant, thus there is not need to create it in member tenants schema and then populating the changes in patching/updating (local) source files. 

### Approach
remove logic for updating/recreating source file sequence

### Changes Checklist
- [ ] **API Changes**: Document any API paths, methods, request or response bodies changed, added, or removed.
- [ ] **Database Schema Changes**: Indicate any database schema changes and their impact. Confirm that migration scripts were created.
- [ ] **Interface Version Changes**: Indicate any changes to interface versions.
- [ ] **Interface Dependencies**: Document added or removed dependencies.
- [ ] **Permissions**: Document any changes to permissions.
- [ ] **Logging**: Confirm that logging is appropriately handled.
- [ ] **Unit Testing**: Confirm that changed classes were covered by unit tests.
- [ ] **Integration Testing**: Confirm that changed logic was covered by integration tests.
- [x] **Manual Testing**: Confirm that changes were tested on local or dev environment.
- [x] **NEWS**: Confirm that the NEWS file is updated with relevant information about the changes made in this pull request.

### Related Issues
[MODELINKS-244](https://folio-org.atlassian.net/browse/MODELINKS-244)
