### PR TITLE
fix(authority-source-files): In ECS, fix persisting authority source file selectable field

### DIFF
--- a/src/main/java/org/folio/entlinks/domain/repository/AuthoritySourceFileJdbcRepository.java
+++ b/src/main/java/org/folio/entlinks/domain/repository/AuthoritySourceFileJdbcRepository.java
@@ -28,18 +28,18 @@ public class AuthoritySourceFileJdbcRepository {
 
   public void insert(AuthoritySourceFile entity) {
     var sourceType = getFullPath(folioExecutionContext, "authority_source_file_source");
-    var sqlValues = "%s::%s,%s".formatted(getParamPlaceholder(3), sourceType, getParamPlaceholder(9));
+    var sqlValues = "%s::%s,%s".formatted(getParamPlaceholder(3), sourceType, getParamPlaceholder(10));
 
     var sql = """
-                INSERT INTO %s (id, name, source, type, base_url_protocol, base_url, hrid_start_number, _version,
-                created_date, updated_date, created_by_user_id, updated_by_user_id)
+                INSERT INTO %s (id, name, source, type, base_url_protocol, base_url, hrid_start_number, selectable,
+                _version, created_date, updated_date, created_by_user_id, updated_by_user_id)
                 VALUES (%s);
         """;
     jdbcTemplate.update(sql.formatted(getFullPath(folioExecutionContext, AUTHORITY_SOURCE_FILE_TABLE), sqlValues),
         entity.getId(), entity.getName(),
         entity.getSource().name(), entity.getType(), entity.getBaseUrlProtocol(), entity.getBaseUrl(),
-        entity.getHridStartNumber(), 0, entity.getCreatedDate(), entity.getUpdatedDate(), entity.getCreatedByUserId(),
-        entity.getUpdatedByUserId());
+        entity.getHridStartNumber(), entity.isSelectable(), 0, entity.getCreatedDate(), entity.getUpdatedDate(),
+        entity.getCreatedByUserId(), entity.getUpdatedByUserId());
 
     if (isNotEmpty(entity.getAuthoritySourceFileCodes())) {
       var sourceFileCode = entity.getAuthoritySourceFileCodes().iterator().next();
@@ -53,7 +53,7 @@ public class AuthoritySourceFileJdbcRepository {
     var sourceType = getFullPath(folioExecutionContext, "authority_source_file_source");
     var sql = """
                 UPDATE %s
-                SET name=?, source=?::%s, type=?, base_url_protocol=?, base_url=?, hrid_start_number=?,
+                SET name=?, source=?::%s, type=?, base_url_protocol=?, base_url=?, hrid_start_number=?, selectable=?,
                 created_date=?, updated_date=?, created_by_user_id=?, updated_by_user_id=?, _version=?
                 WHERE id = ? and _version = ?;
         """;
@@ -61,7 +61,7 @@ public class AuthoritySourceFileJdbcRepository {
     var id = entity.getId();
     jdbcTemplate.update(sql.formatted(getFullPath(folioExecutionContext, AUTHORITY_SOURCE_FILE_TABLE), sourceType),
         entity.getName(), entity.getSource().name(), entity.getType(),
-        entity.getBaseUrlProtocol(), entity.getBaseUrl(), entity.getHridStartNumber(),
+        entity.getBaseUrlProtocol(), entity.getBaseUrl(), entity.getHridStartNumber(), entity.isSelectable(),
         entity.getCreatedDate(), entity.getUpdatedDate(), entity.getCreatedByUserId(),
         entity.getUpdatedByUserId(), entity.getVersion(), id, version);
 

--- a/src/test/java/org/folio/entlinks/controller/ConsortiumAuthoritySourceFilesIT.java
+++ b/src/test/java/org/folio/entlinks/controller/ConsortiumAuthoritySourceFilesIT.java
@@ -95,7 +95,7 @@ class ConsortiumAuthoritySourceFilesIT extends IntegrationTestBase {
   void createAndUpdateSourceFile_positive_shouldPreserveCreatedByAndUpdatedByUserIdForShadowCopies() {
     var sourceFileId = UUID.randomUUID();
     var dto = new AuthoritySourceFilePostDto()
-        .id(sourceFileId).name("authority source file").code("code").type("type");
+        .id(sourceFileId).name("authority source file").code("code").type("type").selectable(true);
 
     // create source file with user id = UPDATER_USER_ID
     doPost(authoritySourceFilesEndpoint(), dto, tenantAndUserIdHeaders(CENTRAL_TENANT_ID, UPDATER_USER_ID));
@@ -109,13 +109,14 @@ class ConsortiumAuthoritySourceFilesIT extends IntegrationTestBase {
         .andExpect(status().isOk())
         .andExpect(jsonPath("totalRecords", is(1)))
         .andExpect(jsonPath("authoritySourceFiles[0]._version", is(0)))
+        .andExpect(jsonPath("authoritySourceFiles[0].selectable", is(true)))
         .andExpect(jsonPath("authoritySourceFiles[0].metadata", notNullValue()))
         .andExpect(jsonPath("authoritySourceFiles[0].metadata.createdDate", notNullValue()))
         .andExpect(jsonPath("authoritySourceFiles[0].metadata.updatedDate", notNullValue()))
         .andExpect(jsonPath("authoritySourceFiles[0].metadata.createdByUserId", is(UPDATER_USER_ID)))
         .andExpect(jsonPath("authoritySourceFiles[0].metadata.updatedByUserId", is(UPDATER_USER_ID)));
 
-    var patch = new AuthoritySourceFilePatchDto(0).name("updated").code("codeUpdated");
+    var patch = new AuthoritySourceFilePatchDto(0).name("updated").code("codeUpdated").selectable(false);
     // update source file with user id = UPDATER_USER_ID
     tryPatch(authoritySourceFilesEndpoint(sourceFileId), patch,
         tenantAndUserIdHeaders(CENTRAL_TENANT_ID, UPDATER_USER_ID))
@@ -128,13 +129,14 @@ class ConsortiumAuthoritySourceFilesIT extends IntegrationTestBase {
         assertEquals(1, databaseHelper.countRowsWhere(AUTHORITY_SOURCE_FILE_CODE_TABLE, COLLEGE_TENANT_ID,
             "code = 'codeUpdated'")));
 
-    tryGet(authoritySourceFilesEndpoint(), tenantHeaders(CENTRAL_TENANT_ID))
+    tryGet(authoritySourceFilesEndpoint(), tenantHeaders(COLLEGE_TENANT_ID))
         .andExpect(status().isOk())
         .andExpect(jsonPath("totalRecords", is(1)))
         .andExpect(jsonPath("authoritySourceFiles[0]._version", is(1)))
         .andExpect(jsonPath("authoritySourceFiles[0].metadata", notNullValue()))
         .andExpect(jsonPath("authoritySourceFiles[0].codes", hasSize(1)))
         .andExpect(jsonPath("authoritySourceFiles[0].codes[0]", is(patch.getCode())))
+        .andExpect(jsonPath("authoritySourceFiles[0].selectable", is(false)))
         .andExpect(jsonPath("authoritySourceFiles[0].metadata.createdByUserId", is(UPDATER_USER_ID)))
         .andExpect(jsonPath("authoritySourceFiles[0].metadata.updatedByUserId", is(UPDATER_USER_ID)));
 


### PR DESCRIPTION
### Purpose
_`selectable` field was missing in insert and update queries for propagating changes to ECS member tenants_

### Approach
_include missing `selectable` field into SQL queries_

### Changes Checklist
- [ ] **API Changes**: Document any API paths, methods, request or response bodies changed, added, or removed.
- [ ] **Database Schema Changes**: Indicate any database schema changes and their impact. Confirm that migration scripts were created.
- [ ] **Interface Version Changes**: Indicate any changes to interface versions.
- [ ] **Interface Dependencies**: Document added or removed dependencies.
- [ ] **Permissions**: Document any changes to permissions.
- [ ] **Logging**: Confirm that logging is appropriately handled.
- [ ] **Unit Testing**: Confirm that changed classes were covered by unit tests.
- [x] **Integration Testing**: Confirm that changed logic was covered by integration tests.
- [ ] **Manual Testing**: Confirm that changes were tested on local or dev environment.
- [ ] **NEWS**: Confirm that the NEWS file is updated with relevant information about the changes made in this pull request.

### Related Issues
[MODELINKS-244](https://folio-org.atlassian.net/browse/MODELINKS-244)
