### PR TITLE
fix(specification): Fix specification consumer startup

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -20,6 +20,7 @@
 * Fix persisting createdBy and updatedBy user id for authority source file shadow copies in ECS ([MODELINKS-244](https://folio-org.atlassian.net/browse/MODELINKS-244))
 * Prevent Authority version increment after Instance Links update in ECS ([MODELINKS-279](https://folio-org.atlassian.net/browse/MODELINKS-279))
 * Fix documentation generation github workflow  ([MODELINKS-291](https://folio-org.atlassian.net/browse/MODELINKS-291))
+* Fix specification consumer startup  ([MODELINKS-298](https://folio-org.atlassian.net/browse/MODELINKS-298))
 
 ### Tech Dept
 * Add missing interface `source-storage-batch` dependency in module descriptor ([MODELINKS-275](https://folio-org.atlassian.net/browse/MODELINKS-275))

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -99,6 +99,7 @@ folio:
         concurrency: 1
         topic-pattern: (${folio.environment}\.)(.*\.)specification-storage\.specification\.updated
         group-id: ${folio.environment}-mod-entities-specification-storage-group
+        auto-offset-reset: EARLIEST
   instance-authority:
     change:
       numPartitions: ${KAFKA_INSTANCE_AUTHORITY_CHANGE_PARTITIONS:100}

--- a/src/test/resources/application-test.yaml
+++ b/src/test/resources/application-test.yaml
@@ -73,6 +73,7 @@ folio:
         concurrency: 1
         topic-pattern: (${folio.environment}\.)(.*\.)specification-storage\.specification\.updated
         group-id: ${folio.environment}-mod-entities-specification-storage-group
+        auto-offset-reset: EARLIEST
   retry:
     enabled: true
   tenant:


### PR DESCRIPTION
### Purpose
Fix specification consumer startup

### Approach
Set auto.offset.reset to EARLIEST so if mod-record-specifications starts first and sends specification updated event - mod-entities-links will set appropriate offset and consume event sent before it started

### Changes Checklist
- [ ] **API Changes**: Document any API paths, methods, request or response bodies changed, added, or removed.
- [ ] **Database Schema Changes**: Indicate any database schema changes and their impact. Confirm that migration scripts were created.
- [ ] **Interface Version Changes**: Indicate any changes to interface versions.
- [ ] **Interface Dependencies**: Document added or removed dependencies.
- [ ] **Permissions**: Document any changes to permissions.
- [ ] **Logging**: Confirm that logging is appropriately handled.
- [ ] **Unit Testing**: Confirm that changed classes were covered by unit tests.
- [ ] **Integration Testing**: Confirm that changed logic was covered by integration tests.
- [ ] **Manual Testing**: Confirm that changes were tested on local or dev environment.
- [x] **NEWS**: Confirm that the NEWS file is updated with relevant information about the changes made in this pull request.

### Related Issues
[MODELINKS-298](https://folio-org.atlassian.net/browse/MODELINKS-298)