### PR TITLE
MODELINKS-302: Extend Authority with generalSubdivision, sftGeneralSubdivision, and saftGeneralSubdivision fields

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -12,6 +12,7 @@
 * Filter full specification updated event based on specification `family` and `profile` ([MODELINKS-276](https://folio-org.atlassian.net/browse/MODELINKS-276))
 * Add aatfg to the list of prefixes for Art & Architecture authority file ([MODELINKS-272](https://folio-org.atlassian.net/browse/MODELINKS-272))
 * Extend Authority with namedEvent, sftNamedEvent, and saftNamedEvent fields ([MODELINKS-294](https://folio-org.atlassian.net/browse/MODELINKS-294))
+* Extend Authority with generalSubdivision, sftGeneralSubdivision, and saftGeneralSubdivision fields ([MODELINKS-302](https://folio-org.atlassian.net/browse/MODELINKS-302))
 
 ### Bug fixes
 * Fix context mix-up on data propagation ([MODELINKS-273](https://folio-org.atlassian.net/browse/MODELINKS-273))

--- a/pom.xml
+++ b/pom.xml
@@ -25,10 +25,10 @@
       src/main/java/org/folio/entlinks/model/**
     </sonar.exclusions>
 
-    <folio-spring-support.version>9.0.0-SNAPSHOT</folio-spring-support.version>
-    <folio-service-tools.version>5.0.0-SNAPSHOT</folio-service-tools.version>
+    <folio-spring-support.version>9.0.0</folio-spring-support.version>
+    <folio-service-tools.version>5.0.0</folio-service-tools.version>
     <folio-s3-client.version>2.3.0-SNAPSHOT</folio-s3-client.version>
-    <mod-record-specifications-dto.version>2.0.0-SNAPSHOT</mod-record-specifications-dto.version>
+    <mod-record-specifications-dto.version>2.0.0</mod-record-specifications-dto.version>
     <aws-sdk-java.version>2.29.40</aws-sdk-java.version>
     <mapstruct.version>1.6.3</mapstruct.version>
     <lombok.mapstruct-binding.version>0.2.0</lombok.mapstruct-binding.version>

--- a/src/main/java/org/folio/entlinks/controller/converter/AuthorityUtilityMapper.java
+++ b/src/main/java/org/folio/entlinks/controller/converter/AuthorityUtilityMapper.java
@@ -6,6 +6,7 @@ import static org.folio.entlinks.domain.entity.AuthorityConstants.CORPORATE_NAME
 import static org.folio.entlinks.domain.entity.AuthorityConstants.CORPORATE_NAME_HEADING_TRUNC;
 import static org.folio.entlinks.domain.entity.AuthorityConstants.CORPORATE_NAME_TITLE_HEADING;
 import static org.folio.entlinks.domain.entity.AuthorityConstants.CORPORATE_NAME_TITLE_HEADING_TRUNC;
+import static org.folio.entlinks.domain.entity.AuthorityConstants.GENERAL_SUBDIVISION_HEADING;
 import static org.folio.entlinks.domain.entity.AuthorityConstants.GENRE_TERM_HEADING;
 import static org.folio.entlinks.domain.entity.AuthorityConstants.GENRE_TERM_HEADING_TRUNC;
 import static org.folio.entlinks.domain.entity.AuthorityConstants.GEOGRAPHIC_NAME_HEADING;
@@ -82,6 +83,11 @@ public class AuthorityUtilityMapper {
       target.setHeadingType(NAMED_EVENT_HEADING);
       return;
     }
+    if (Objects.nonNull(source.getGeneralSubdivision())) {
+      target.setHeading(source.getGeneralSubdivision());
+      target.setHeadingType(GENERAL_SUBDIVISION_HEADING);
+      return;
+    }
     if (Objects.nonNull(source.getTopicalTerm())) {
       target.setHeading(source.getTopicalTerm());
       target.setHeadingType(TOPICAL_TERM_HEADING);
@@ -124,6 +130,9 @@ public class AuthorityUtilityMapper {
     if (isNotEmpty(source.getSftNamedEvent())) {
       sftHeadings.addAll(asSftHeadings(source.getSftNamedEvent(), NAMED_EVENT_HEADING));
     }
+    if (isNotEmpty(source.getSftGeneralSubdivision())) {
+      sftHeadings.addAll(asSftHeadings(source.getSftGeneralSubdivision(), GENERAL_SUBDIVISION_HEADING));
+    }
     if (isNotEmpty(source.getSftTopicalTerm())) {
       sftHeadings.addAll(asSftHeadings(source.getSftTopicalTerm(), TOPICAL_TERM_HEADING));
     }
@@ -161,6 +170,9 @@ public class AuthorityUtilityMapper {
     }
     if (isNotEmpty(source.getSaftNamedEvent())) {
       saftHeadings.addAll(asSftHeadings(source.getSaftNamedEvent(), NAMED_EVENT_HEADING));
+    }
+    if (isNotEmpty(source.getSaftGeneralSubdivision())) {
+      saftHeadings.addAll(asSftHeadings(source.getSaftGeneralSubdivision(), GENERAL_SUBDIVISION_HEADING));
     }
     if (isNotEmpty(source.getSaftTopicalTerm())) {
       saftHeadings.addAll(asSftHeadings(source.getSaftTopicalTerm(), TOPICAL_TERM_HEADING));
@@ -244,6 +256,7 @@ public class AuthorityUtilityMapper {
       case MEETING_NAME_TITLE_HEADING -> target.setMeetingNameTitle(source.getHeading());
       case UNIFORM_TITLE_HEADING -> target.setUniformTitle(source.getHeading());
       case NAMED_EVENT_HEADING -> target.setNamedEvent(source.getHeading());
+      case GENERAL_SUBDIVISION_HEADING -> target.setGeneralSubdivision(source.getHeading());
       case TOPICAL_TERM_HEADING -> target.setTopicalTerm(source.getHeading());
       case GEOGRAPHIC_NAME_HEADING -> target.setGeographicName(source.getHeading());
       case GENRE_TERM_HEADING -> target.setGenreTerm(source.getHeading());
@@ -278,6 +291,7 @@ public class AuthorityUtilityMapper {
       case MEETING_NAME_TITLE_HEADING -> target.addSftMeetingNameTitleItem(headingRef.getHeading());
       case UNIFORM_TITLE_HEADING -> target.addSftUniformTitleItem(headingRef.getHeading());
       case NAMED_EVENT_HEADING -> target.addSftNamedEventItem(headingRef.getHeading());
+      case GENERAL_SUBDIVISION_HEADING -> target.addSftGeneralSubdivisionItem(headingRef.getHeading());
       case TOPICAL_TERM_HEADING -> target.addSftTopicalTermItem(headingRef.getHeading());
       case GEOGRAPHIC_NAME_HEADING -> target.addSftGeographicNameItem(headingRef.getHeading());
       case GENRE_TERM_HEADING -> target.addSftGenreTermItem(headingRef.getHeading());
@@ -298,6 +312,7 @@ public class AuthorityUtilityMapper {
       case MEETING_NAME_TITLE_HEADING -> target.addSaftMeetingNameTitleItem(headingRef.getHeading());
       case UNIFORM_TITLE_HEADING -> target.addSaftUniformTitleItem(headingRef.getHeading());
       case NAMED_EVENT_HEADING -> target.addSaftNamedEventItem(headingRef.getHeading());
+      case GENERAL_SUBDIVISION_HEADING -> target.addSaftGeneralSubdivisionItem(headingRef.getHeading());
       case TOPICAL_TERM_HEADING -> target.addSaftTopicalTermItem(headingRef.getHeading());
       case GEOGRAPHIC_NAME_HEADING -> target.addSaftGeographicNameItem(headingRef.getHeading());
       case GENRE_TERM_HEADING -> target.addSaftGenreTermItem(headingRef.getHeading());

--- a/src/main/java/org/folio/entlinks/domain/entity/AuthorityConstants.java
+++ b/src/main/java/org/folio/entlinks/domain/entity/AuthorityConstants.java
@@ -21,6 +21,8 @@ public class AuthorityConstants {
 
   public static final String NAMED_EVENT_HEADING = "namedEvent";
 
+  public static final String GENERAL_SUBDIVISION_HEADING = "generalSubdivision";
+
   public static final String TOPICAL_TERM_HEADING = "topicalTerm";
 
   public static final String GEOGRAPHIC_NAME_HEADING = "geographicName";

--- a/src/main/resources/swagger.api/schemas/authority-storage/authorityDto.yaml
+++ b/src/main/resources/swagger.api/schemas/authority-storage/authorityDto.yaml
@@ -115,6 +115,19 @@ properties:
     description: See also from tracing named event
     items:
       type: string
+  generalSubdivision:
+    type: string
+    description: Heading general subdivision
+  sftGeneralSubdivision:
+    type: array
+    description: See from tracing general subdivision
+    items:
+      type: string
+  saftGeneralSubdivision:
+    type: array
+    description: See also from tracing general subdivision
+    items:
+      type: string
   topicalTerm:
     type: string
     description: Heading topical term

--- a/src/test/java/org/folio/entlinks/controller/converter/AuthorityUtilityMapperTest.java
+++ b/src/test/java/org/folio/entlinks/controller/converter/AuthorityUtilityMapperTest.java
@@ -6,6 +6,7 @@ import static org.folio.entlinks.domain.entity.AuthorityConstants.CORPORATE_NAME
 import static org.folio.entlinks.domain.entity.AuthorityConstants.CORPORATE_NAME_HEADING_TRUNC;
 import static org.folio.entlinks.domain.entity.AuthorityConstants.CORPORATE_NAME_TITLE_HEADING;
 import static org.folio.entlinks.domain.entity.AuthorityConstants.CORPORATE_NAME_TITLE_HEADING_TRUNC;
+import static org.folio.entlinks.domain.entity.AuthorityConstants.GENERAL_SUBDIVISION_HEADING;
 import static org.folio.entlinks.domain.entity.AuthorityConstants.GENRE_TERM_HEADING;
 import static org.folio.entlinks.domain.entity.AuthorityConstants.GENRE_TERM_HEADING_TRUNC;
 import static org.folio.entlinks.domain.entity.AuthorityConstants.GEOGRAPHIC_NAME_HEADING;
@@ -63,6 +64,7 @@ class AuthorityUtilityMapperTest {
       case MEETING_NAME_TITLE_HEADING -> source.setMeetingNameTitle(propertyValue);
       case UNIFORM_TITLE_HEADING -> source.setUniformTitle(propertyValue);
       case NAMED_EVENT_HEADING -> source.setNamedEvent(propertyValue);
+      case GENERAL_SUBDIVISION_HEADING -> source.setGeneralSubdivision(propertyValue);
       case TOPICAL_TERM_HEADING -> source.setTopicalTerm(propertyValue);
       case GEOGRAPHIC_NAME_HEADING -> source.setGeographicName(propertyValue);
       case GENRE_TERM_HEADING -> source.setGenreTerm(propertyValue);
@@ -87,6 +89,7 @@ class AuthorityUtilityMapperTest {
       case MEETING_NAME_TITLE_HEADING -> source.setSftMeetingNameTitle(Collections.singletonList(propertyValue));
       case UNIFORM_TITLE_HEADING -> source.setSftUniformTitle(Collections.singletonList(propertyValue));
       case NAMED_EVENT_HEADING -> source.setSftNamedEvent(Collections.singletonList(propertyValue));
+      case GENERAL_SUBDIVISION_HEADING -> source.setSftGeneralSubdivision(Collections.singletonList(propertyValue));
       case TOPICAL_TERM_HEADING -> source.setSftTopicalTerm(Collections.singletonList(propertyValue));
       case GEOGRAPHIC_NAME_HEADING -> source.setSftGeographicName(Collections.singletonList(propertyValue));
       case GENRE_TERM_HEADING -> source.setSftGenreTerm(Collections.singletonList(propertyValue));
@@ -113,6 +116,7 @@ class AuthorityUtilityMapperTest {
       case MEETING_NAME_TITLE_HEADING -> source.setSaftMeetingNameTitle(Collections.singletonList(propertyValue));
       case UNIFORM_TITLE_HEADING -> source.setSaftUniformTitle(Collections.singletonList(propertyValue));
       case NAMED_EVENT_HEADING -> source.setSaftNamedEvent(Collections.singletonList(propertyValue));
+      case GENERAL_SUBDIVISION_HEADING -> source.setSaftGeneralSubdivision(Collections.singletonList(propertyValue));
       case TOPICAL_TERM_HEADING -> source.setSaftTopicalTerm(Collections.singletonList(propertyValue));
       case GEOGRAPHIC_NAME_HEADING -> source.setSaftGeographicName(Collections.singletonList(propertyValue));
       case GENRE_TERM_HEADING -> source.setSaftGenreTerm(Collections.singletonList(propertyValue));
@@ -159,6 +163,7 @@ class AuthorityUtilityMapperTest {
       case MEETING_NAME_TITLE_HEADING -> assertTrue(source.getSftMeetingNameTitle().contains(headingValue));
       case UNIFORM_TITLE_HEADING -> assertTrue(source.getSftUniformTitle().contains(headingValue));
       case NAMED_EVENT_HEADING -> assertTrue(source.getSftNamedEvent().contains(headingValue));
+      case GENERAL_SUBDIVISION_HEADING -> assertTrue(source.getSftGeneralSubdivision().contains(headingValue));
       case TOPICAL_TERM_HEADING -> assertTrue(source.getSftTopicalTerm().contains(headingValue));
       case GEOGRAPHIC_NAME_HEADING -> assertTrue(source.getSftGeographicName().contains(headingValue));
       case GENRE_TERM_HEADING -> assertTrue(source.getSftGenreTerm().contains(headingValue));
@@ -185,6 +190,7 @@ class AuthorityUtilityMapperTest {
       case MEETING_NAME_TITLE_HEADING -> assertTrue(source.getSaftMeetingNameTitle().contains(headingValue));
       case UNIFORM_TITLE_HEADING -> assertTrue(source.getSaftUniformTitle().contains(headingValue));
       case NAMED_EVENT_HEADING -> assertTrue(source.getSaftNamedEvent().contains(headingValue));
+      case GENERAL_SUBDIVISION_HEADING -> assertTrue(source.getSaftGeneralSubdivision().contains(headingValue));
       case TOPICAL_TERM_HEADING -> assertTrue(source.getSaftTopicalTerm().contains(headingValue));
       case GEOGRAPHIC_NAME_HEADING -> assertTrue(source.getSaftGeographicName().contains(headingValue));
       case GENRE_TERM_HEADING -> assertTrue(source.getSaftGenreTerm().contains(headingValue));
@@ -222,6 +228,7 @@ class AuthorityUtilityMapperTest {
       case MEETING_NAME_TITLE_HEADING -> assertThat(source.getMeetingNameTitle()).isEqualTo(headingValue);
       case UNIFORM_TITLE_HEADING -> assertThat(source.getUniformTitle()).isEqualTo(headingValue);
       case NAMED_EVENT_HEADING -> assertThat(source.getNamedEvent()).isEqualTo(headingValue);
+      case GENERAL_SUBDIVISION_HEADING -> assertThat(source.getGeneralSubdivision()).isEqualTo(headingValue);
       case TOPICAL_TERM_HEADING -> assertThat(source.getTopicalTerm()).isEqualTo(headingValue);
       case GEOGRAPHIC_NAME_HEADING -> assertThat(source.getGeographicName()).isEqualTo(headingValue);
       case GENRE_TERM_HEADING -> assertThat(source.getGenreTerm()).isEqualTo(headingValue);
@@ -262,6 +269,7 @@ class AuthorityUtilityMapperTest {
         arguments(MEETING_NAME_TITLE_HEADING, TEST_STRING),
         arguments(UNIFORM_TITLE_HEADING, TEST_STRING),
         arguments(NAMED_EVENT_HEADING, TEST_STRING),
+        arguments(GENERAL_SUBDIVISION_HEADING, TEST_STRING),
         arguments(TOPICAL_TERM_HEADING, TEST_STRING),
         arguments(GEOGRAPHIC_NAME_HEADING, TEST_STRING),
         arguments(GENRE_TERM_HEADING, TEST_STRING)
@@ -278,6 +286,7 @@ class AuthorityUtilityMapperTest {
         arguments(MEETING_NAME_TITLE_HEADING, TEST_STRING),
         arguments(UNIFORM_TITLE_HEADING, TEST_STRING),
         arguments(NAMED_EVENT_HEADING, TEST_STRING),
+        arguments(GENERAL_SUBDIVISION_HEADING, TEST_STRING),
         arguments(TOPICAL_TERM_HEADING, TEST_STRING),
         arguments(GEOGRAPHIC_NAME_HEADING, TEST_STRING),
         arguments(GENRE_TERM_HEADING, TEST_STRING),


### PR DESCRIPTION
### Purpose
Extend Authority with generalSubdivision, sftGeneralSubdivision, and saftGeneralSubdivision fields

### Changes Checklist
- [x] **Unit Testing**: Confirm that changed classes were covered by unit tests.
- [x] **NEWS**: Confirm that the NEWS file is updated with relevant information about the changes made in this pull request.

### Related Issues
[MODELINKS-302](https://folio-org.atlassian.net/browse/MODELINKS-302)
