### PR TITLE
fix(authority-source-files): long update/delete operation

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -23,6 +23,7 @@
 * Prevent Authority version increment after Instance Links update in ECS ([MODELINKS-279](https://folio-org.atlassian.net/browse/MODELINKS-279))
 * Fix documentation generation github workflow  ([MODELINKS-291](https://folio-org.atlassian.net/browse/MODELINKS-291))
 * Fix specification consumer startup  ([MODELINKS-298](https://folio-org.atlassian.net/browse/MODELINKS-298))
+* Fix long authority source file update/delete operation ([MODELINKS-299](https://folio-org.atlassian.net/browse/MODELINKS-299))
 
 ### Tech Dept
 * Add missing interface `source-storage-batch` dependency in module descriptor ([MODELINKS-275](https://folio-org.atlassian.net/browse/MODELINKS-275))

--- a/src/main/resources/db/changelog/changelog-master.xml
+++ b/src/main/resources/db/changelog/changelog-master.xml
@@ -26,4 +26,5 @@
   <include file="/changes/v3.1/update-linking-rules-subfields.xml" relativeToChangelogFile="true"/>
   <include file="/changes/v3.1/migrate-deleted-authorities.xml" relativeToChangelogFile="true"/>
   <include file="/changes/v3.1/update-authority-source-file-prefixes.xml" relativeToChangelogFile="true"/>
+  <include file="/changes/v4.0/add-authority-source-file-index.xml" relativeToChangelogFile="true"/>
 </databaseChangeLog>

--- a/src/main/resources/db/changelog/changes/v4.0/add-authority-source-file-index.xml
+++ b/src/main/resources/db/changelog/changes/v4.0/add-authority-source-file-index.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                   https://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
+
+  <changeSet id="MODELINKS-299@@create:index:authority:source_file_id" author="pavlo_smahin">
+    <preConditions>
+      <and>
+        <tableExists tableName="authority"/>
+        <not>
+          <indexExists tableName="authority" indexName="idx_authority_source_file_id"/>
+        </not>
+      </and>
+    </preConditions>
+
+    <comment>Create index for source_file_id in authority table</comment>
+
+    <sql>
+      CREATE
+      INDEX IF NOT EXISTS idx_authority_source_file_id
+      ON authority
+      USING btree (source_file_id) WITH (deduplicate_items= TRUE);
+    </sql>
+  </changeSet>
+
+  <changeSet id="MODELINKS-299@@alter:index:authority_archive:source_file_id:deduplicate_items=true"
+             author="pavlo_smahin">
+    <preConditions>
+      <and>
+        <tableExists tableName="authority_archive"/>
+        <indexExists tableName="authority_archive" indexName="idx_authority_archive_source_file_id"/>
+      </and>
+    </preConditions>
+
+    <comment>Alter index for source_file_id in authority_archive table: set deduplicate_items=true</comment>
+
+    <sql>
+      ALTER
+      INDEX IF EXISTS idx_authority_archive_source_file_id
+      SET (deduplicate_items=True);
+    </sql>
+  </changeSet>
+
+
+</databaseChangeLog>


### PR DESCRIPTION
### Purpose
Fix long authority source file update/delete operation

### Approach
- Create index for source_file_id in authority table
- Alter index for source_file_id in authority_archive table: set deduplicate_items=true

### Changes Checklist
- [ ] **API Changes**: Document any API paths, methods, request or response bodies changed, added, or removed.
- [x] **Database Schema Changes**: Indicate any database schema changes and their impact. Confirm that migration scripts were created.
- [ ] **Interface Version Changes**: Indicate any changes to interface versions.
- [ ] **Interface Dependencies**: Document added or removed dependencies.
- [ ] **Permissions**: Document any changes to permissions.
- [ ] **Logging**: Confirm that logging is appropriately handled.
- [ ] **Unit Testing**: Confirm that changed classes were covered by unit tests.
- [ ] **Integration Testing**: Confirm that changed logic was covered by integration tests.
- [x] **Manual Testing**: Confirm that changes were tested on local or dev environment.
- [x] **NEWS**: Confirm that the NEWS file is updated with relevant information about the changes made in this pull request.

### Related Issues
https://folio-org.atlassian.net/browse/MODELINKS-299