### PR TITLE
fix(authority-source-files): propagation to propagate all codes

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -10,7 +10,7 @@
 * Description ([ISSUE](https://folio-org.atlassian.net/browse/ISSUE))
 
 ### Bug fixes
-* Description ([ISSUE](https://folio-org.atlassian.net/browse/ISSUE))
+* Fix authority source file propagation to propagate all codes ([MODELINKS-315](https://folio-org.atlassian.net/browse/MODELINKS-315))
 
 ### Tech Dept
 * Description ([ISSUE](https://folio-org.atlassian.net/browse/ISSUE))

--- a/src/main/java/org/folio/entlinks/domain/repository/AuthoritySourceFileJdbcRepository.java
+++ b/src/main/java/org/folio/entlinks/domain/repository/AuthoritySourceFileJdbcRepository.java
@@ -5,18 +5,18 @@ import static org.folio.entlinks.utils.JdbcUtils.getFullPath;
 import static org.folio.entlinks.utils.JdbcUtils.getParamPlaceholder;
 import static org.folio.entlinks.utils.JdbcUtils.getSchemaName;
 
+import java.util.ArrayList;
 import java.util.UUID;
 import org.folio.entlinks.domain.entity.AuthoritySourceFile;
 import org.folio.spring.FolioExecutionContext;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.stereotype.Repository;
 
-
 @Repository
 public class AuthoritySourceFileJdbcRepository {
 
-  private static final String AUTHORITY_SOURCE_FILE_CODE_TABLE = "authority_source_file_code";
-  private static final String AUTHORITY_SOURCE_FILE_TABLE = "authority_source_file";
+  static final String AUTHORITY_SOURCE_FILE_CODE_TABLE = "authority_source_file_code";
+  static final String AUTHORITY_SOURCE_FILE_TABLE = "authority_source_file";
 
   private final JdbcTemplate jdbcTemplate;
   private final FolioExecutionContext folioExecutionContext;
@@ -31,68 +31,76 @@ public class AuthoritySourceFileJdbcRepository {
     var sqlValues = "%s::%s,%s".formatted(getParamPlaceholder(3), sourceType, getParamPlaceholder(10));
 
     var sql = """
-                INSERT INTO %s (id, name, source, type, base_url_protocol, base_url, hrid_start_number, selectable,
-                _version, created_date, updated_date, created_by_user_id, updated_by_user_id)
-                VALUES (%s);
-        """;
+              INSERT INTO %s (id, name, source, type, base_url_protocol, base_url, hrid_start_number, selectable,
+              _version, created_date, updated_date, created_by_user_id, updated_by_user_id)
+              VALUES (%s);
+      """;
     jdbcTemplate.update(sql.formatted(getFullPath(folioExecutionContext, AUTHORITY_SOURCE_FILE_TABLE), sqlValues),
-        entity.getId(), entity.getName(),
-        entity.getSource().name(), entity.getType(), entity.getBaseUrlProtocol(), entity.getBaseUrl(),
-        entity.getHridStartNumber(), entity.isSelectable(), 0, entity.getCreatedDate(), entity.getUpdatedDate(),
-        entity.getCreatedByUserId(), entity.getUpdatedByUserId());
+      entity.getId(), entity.getName(),
+      entity.getSource().name(), entity.getType(), entity.getBaseUrlProtocol(), entity.getBaseUrl(),
+      entity.getHridStartNumber(), entity.isSelectable(), 0, entity.getCreatedDate(), entity.getUpdatedDate(),
+      entity.getCreatedByUserId(), entity.getUpdatedByUserId());
 
     if (isNotEmpty(entity.getAuthoritySourceFileCodes())) {
-      var sourceFileCode = entity.getAuthoritySourceFileCodes().iterator().next();
-      sql = "INSERT INTO %s (authority_source_file_id, code) VALUES (?, ?);";
-      jdbcTemplate.update(sql.formatted(getFullPath(folioExecutionContext, AUTHORITY_SOURCE_FILE_CODE_TABLE)),
-          sourceFileCode.getAuthoritySourceFile().getId(), sourceFileCode.getCode());
+      insertSourceFileCodes(entity, entity.getId());
     }
   }
 
   public void update(AuthoritySourceFile entity, int version) {
     var sourceType = getFullPath(folioExecutionContext, "authority_source_file_source");
     var sql = """
-                UPDATE %s
-                SET name=?, source=?::%s, type=?, base_url_protocol=?, base_url=?, hrid_start_number=?, selectable=?,
-                created_date=?, updated_date=?, created_by_user_id=?, updated_by_user_id=?, _version=?
-                WHERE id = ? and _version = ?;
-        """;
+              UPDATE %s
+              SET name=?, source=?::%s, type=?, base_url_protocol=?, base_url=?, hrid_start_number=?, selectable=?,
+              created_date=?, updated_date=?, created_by_user_id=?, updated_by_user_id=?, _version=?
+              WHERE id = ? and _version = ?;
+      """;
 
     var id = entity.getId();
     jdbcTemplate.update(sql.formatted(getFullPath(folioExecutionContext, AUTHORITY_SOURCE_FILE_TABLE), sourceType),
-        entity.getName(), entity.getSource().name(), entity.getType(),
-        entity.getBaseUrlProtocol(), entity.getBaseUrl(), entity.getHridStartNumber(), entity.isSelectable(),
-        entity.getCreatedDate(), entity.getUpdatedDate(), entity.getCreatedByUserId(),
-        entity.getUpdatedByUserId(), entity.getVersion(), id, version);
+      entity.getName(), entity.getSource().name(), entity.getType(),
+      entity.getBaseUrlProtocol(), entity.getBaseUrl(), entity.getHridStartNumber(), entity.isSelectable(),
+      entity.getCreatedDate(), entity.getUpdatedDate(), entity.getCreatedByUserId(),
+      entity.getUpdatedByUserId(), entity.getVersion(), id, version);
 
     if (isNotEmpty(entity.getAuthoritySourceFileCodes())) {
-      var sourceFileCode = entity.getAuthoritySourceFileCodes().iterator().next().getCode();
-
       jdbcTemplate.execute("DELETE FROM %s WHERE authority_source_file_id = '%s';"
-          .formatted(getFullPath(folioExecutionContext, AUTHORITY_SOURCE_FILE_CODE_TABLE), id));
+        .formatted(getFullPath(folioExecutionContext, AUTHORITY_SOURCE_FILE_CODE_TABLE), id));
 
-      jdbcTemplate.update("INSERT INTO %s (authority_source_file_id, code) VALUES (?, ?);"
-              .formatted(getFullPath(folioExecutionContext, AUTHORITY_SOURCE_FILE_CODE_TABLE)), id, sourceFileCode);
+      insertSourceFileCodes(entity, id);
     }
   }
 
   public void delete(UUID id) {
     jdbcTemplate.execute("DELETE FROM %s WHERE authority_source_file_id = '%s'"
-        .formatted(getFullPath(folioExecutionContext, AUTHORITY_SOURCE_FILE_CODE_TABLE), id));
+      .formatted(getFullPath(folioExecutionContext, AUTHORITY_SOURCE_FILE_CODE_TABLE), id));
     jdbcTemplate.execute("DELETE FROM %s WHERE id = '%s'"
-        .formatted(getFullPath(folioExecutionContext, AUTHORITY_SOURCE_FILE_TABLE), id));
+      .formatted(getFullPath(folioExecutionContext, AUTHORITY_SOURCE_FILE_TABLE), id));
   }
 
   public void createSequence(String sequenceName, int startNumber) {
     var command = String.format("""
-            CREATE SEQUENCE %s MINVALUE %d INCREMENT BY 1 OWNED BY %s.authority_source_file.sequence_name;
-            """,
-        sequenceName, startNumber, getSchemaName(folioExecutionContext));
+        CREATE SEQUENCE %s MINVALUE %d INCREMENT BY 1 OWNED BY %s.authority_source_file.sequence_name;
+        """,
+      sequenceName, startNumber, getSchemaName(folioExecutionContext));
     jdbcTemplate.execute(command);
   }
 
   public void dropSequence(String sequenceName) {
     var command = String.format("DROP SEQUENCE IF EXISTS %s.%s;", getSchemaName(folioExecutionContext), sequenceName);
     jdbcTemplate.execute(command);
+  }
+
+  private void insertSourceFileCodes(AuthoritySourceFile entity, UUID id) {
+    var sourceFileCodes = new ArrayList<>(entity.getAuthoritySourceFileCodes());
+    jdbcTemplate.update("INSERT INTO %s (authority_source_file_id, code) VALUES %s;"
+        .formatted(getFullPath(folioExecutionContext, AUTHORITY_SOURCE_FILE_CODE_TABLE),
+          getParamPlaceholder(sourceFileCodes.size(), 2)),
+      ps -> {
+        for (int i = 0; i < sourceFileCodes.size(); i++) {
+          var sourceFileCode = sourceFileCodes.get(i);
+          ps.setObject(i * 2 + 1, id);
+          ps.setString(i * 2 + 2, sourceFileCode.getCode());
+        }
+      });
   }
 }

--- a/src/main/java/org/folio/entlinks/utils/JdbcUtils.java
+++ b/src/main/java/org/folio/entlinks/utils/JdbcUtils.java
@@ -2,6 +2,8 @@ package org.folio.entlinks.utils;
 
 import static java.util.Collections.nCopies;
 
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 import lombok.experimental.UtilityClass;
 import org.folio.spring.FolioExecutionContext;
 
@@ -18,6 +20,16 @@ public class JdbcUtils {
 
   public static String getParamPlaceholder(int size) {
     return String.join(",", nCopies(size, "?"));
+  }
+
+  public static String getParamPlaceholder(int size, int paramsNum) {
+    if (size < 1 || paramsNum < 1) {
+      throw new IllegalArgumentException("Size and paramsNum must be greater than 0");
+    }
+    var paramGroups = IntStream.range(0, paramsNum)
+      .mapToObj(i -> "?")
+      .collect(Collectors.joining(","));
+    return String.join(",", nCopies(size, '(' + paramGroups + ')'));
   }
 
 }

--- a/src/test/java/org/folio/entlinks/domain/repository/AuthoritySourceFileJdbcRepositoryIT.java
+++ b/src/test/java/org/folio/entlinks/domain/repository/AuthoritySourceFileJdbcRepositoryIT.java
@@ -1,0 +1,138 @@
+package org.folio.entlinks.domain.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.folio.support.base.TestConstants.TENANT_ID;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.when;
+
+import java.sql.Timestamp;
+import java.time.Instant;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.UUID;
+import org.folio.entlinks.domain.entity.AuthoritySourceFile;
+import org.folio.entlinks.domain.entity.AuthoritySourceFileCode;
+import org.folio.entlinks.domain.entity.AuthoritySourceFileSource;
+import org.folio.spring.FolioExecutionContext;
+import org.folio.spring.FolioModuleMetadata;
+import org.folio.spring.testing.extension.EnablePostgres;
+import org.folio.spring.testing.type.IntegrationTest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.jdbc.JdbcTest;
+import org.springframework.boot.test.autoconfigure.json.AutoConfigureJson;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
+
+@IntegrationTest
+@JdbcTest
+@EnablePostgres
+@AutoConfigureJson
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+class AuthoritySourceFileJdbcRepositoryIT {
+
+  private @MockitoSpyBean JdbcTemplate jdbcTemplate;
+  private @MockitoBean FolioExecutionContext context;
+  private AuthoritySourceFileJdbcRepository repository;
+
+  @BeforeEach
+  void setUp() {
+    repository = spy(new AuthoritySourceFileJdbcRepository(jdbcTemplate, context));
+    when(context.getFolioModuleMetadata()).thenReturn(new FolioModuleMetadata() {
+      @Override
+      public String getModuleName() {
+        return null;
+      }
+
+      @Override
+      public String getDBSchemaName(String tenantId) {
+        return "public";
+      }
+    });
+    when(context.getTenantId()).thenReturn(TENANT_ID);
+  }
+
+  @Test
+  void testInsert() {
+    var entity = getAuthoritySourceFile();
+    repository.insert(entity);
+
+    assertSourceFile(entity);
+    assertSourceFileCode(entity.getId(), new String[] {"n", "nb"});
+  }
+
+  @Test
+  void testUpdate() {
+    var entity = getAuthoritySourceFile();
+    repository.insert(entity);
+
+    var newCodes = new HashSet<>(entity.getAuthoritySourceFileCodes());
+    newCodes.add(new AuthoritySourceFileCode(3, null, "nc"));
+    entity.setAuthoritySourceFileCodes(newCodes);
+    entity.setHridStartNumber(2);
+    entity.setBaseUrl("newBaseUrl");
+    entity.setBaseUrlProtocol("https");
+    entity.setName("newName");
+    entity.setSource(AuthoritySourceFileSource.LOCAL);
+    entity.setType("newType");
+    entity.setSelectable(false);
+    entity.setVersion(2);
+
+    repository.update(entity, 0);
+
+    assertSourceFile(entity);
+    assertSourceFileCode(entity.getId(), new String[] {"n", "nb", "nc"});
+  }
+
+  @Test
+  void testDelete() {
+    var entity = getAuthoritySourceFile();
+    repository.insert(entity);
+
+    repository.delete(entity.getId());
+
+    assertThat(jdbcTemplate.queryForObject("SELECT count(*) FROM authority_source_file WHERE id = ?",
+      Integer.class, entity.getId()))
+      .isZero();
+    assertSourceFileCode(entity.getId(), new String[] { });
+  }
+
+  private void assertSourceFileCode(UUID sourceFileId, String[] expectedCodes) {
+    var codes = jdbcTemplate
+      .queryForList("SELECT code FROM authority_source_file_code WHERE authority_source_file_id = ?",
+        String.class, sourceFileId);
+    assertThat(codes)
+      .hasSize(expectedCodes.length)
+      .containsExactlyInAnyOrder(expectedCodes);
+  }
+
+  private void assertSourceFile(AuthoritySourceFile expectedEntity) {
+    jdbcTemplate.query("SELECT * FROM authority_source_file WHERE id = ?",
+      rs -> {
+        assertThat(rs.getString("name")).isEqualTo(expectedEntity.getName());
+        assertThat(rs.getString("source")).isEqualTo(expectedEntity.getSource().name());
+        assertThat(rs.getString("type")).isEqualTo(expectedEntity.getType());
+        assertThat(rs.getString("base_url_protocol")).isEqualTo(expectedEntity.getBaseUrlProtocol());
+        assertThat(rs.getString("base_url")).isEqualTo(expectedEntity.getBaseUrl());
+        assertThat(rs.getInt("hrid_start_number")).isEqualTo(expectedEntity.getHridStartNumber());
+        assertThat(rs.getBoolean("selectable")).isEqualTo(expectedEntity.isSelectable());
+      }, expectedEntity.getId());
+  }
+
+  private AuthoritySourceFile getAuthoritySourceFile() {
+    var entity =
+      new AuthoritySourceFile(UUID.randomUUID(), "Test", "folio", "http", "baseUrl", AuthoritySourceFileSource.FOLIO,
+        Set.of(
+          new AuthoritySourceFileCode(1, null, "n"),
+          new AuthoritySourceFileCode(2, null, "nb")
+        ),
+        null, true, 1, true, 1);
+    entity.setCreatedByUserId(UUID.randomUUID());
+    entity.setUpdatedByUserId(UUID.randomUUID());
+    entity.setCreatedDate(Timestamp.from(Instant.now()));
+    entity.setUpdatedDate(Timestamp.from(Instant.now()));
+    return entity;
+  }
+}

--- a/src/test/java/org/folio/entlinks/utils/JdbcUtilsTest.java
+++ b/src/test/java/org/folio/entlinks/utils/JdbcUtilsTest.java
@@ -1,0 +1,61 @@
+package org.folio.entlinks.utils;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import org.folio.spring.FolioExecutionContext;
+import org.folio.spring.FolioModuleMetadata;
+import org.folio.spring.testing.type.UnitTest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+@UnitTest
+class JdbcUtilsTest {
+
+  private FolioExecutionContext context;
+
+  @BeforeEach
+  void setUp() {
+    var metadata = mock(FolioModuleMetadata.class);
+    context = mock(FolioExecutionContext.class);
+    when(context.getFolioModuleMetadata()).thenReturn(metadata);
+    when(context.getTenantId()).thenReturn("testTenant");
+    when(metadata.getDBSchemaName("testTenant")).thenReturn("testSchema");
+  }
+
+  @Test
+  void testGetSchemaName() {
+    String schemaName = JdbcUtils.getSchemaName(context);
+    assertEquals("testSchema", schemaName);
+  }
+
+  @Test
+  void testGetFullPath() {
+    String fullPath = JdbcUtils.getFullPath(context, "testTable");
+    assertEquals("testSchema.testTable", fullPath);
+  }
+
+  @Test
+  void testGetParamPlaceholderSingle() {
+    String placeholder = JdbcUtils.getParamPlaceholder(3);
+    assertEquals("?,?,?", placeholder);
+  }
+
+  @Test
+  void testGetParamPlaceholderMultiple() {
+    String placeholder = JdbcUtils.getParamPlaceholder(2, 3);
+    assertEquals("(?,?,?),(?,?,?)", placeholder);
+  }
+
+  @Test
+  void testGetParamPlaceholderInvalidSize() {
+    assertThrows(IllegalArgumentException.class, () -> JdbcUtils.getParamPlaceholder(0, 3));
+  }
+
+  @Test
+  void testGetParamPlaceholderInvalidParamsNum() {
+    assertThrows(IllegalArgumentException.class, () -> JdbcUtils.getParamPlaceholder(2, 0));
+  }
+}


### PR DESCRIPTION
### Purpose
Fix issue when only first code is propagated in member tenants for authority source files.

### Approach
- modify queries to save all codes
- add ITs

### Changes Checklist
- [ ] **API Changes**: Document any API paths, methods, request or response bodies changed, added, or removed.
- [ ] **Database Schema Changes**: Indicate any database schema changes and their impact. Confirm that migration scripts were created.
- [ ] **Interface Version Changes**: Indicate any changes to interface versions.
- [ ] **Interface Dependencies**: Document added or removed dependencies.
- [ ] **Permissions**: Document any changes to permissions.
- [ ] **Logging**: Confirm that logging is appropriately handled.
- [ ] **Unit Testing**: Confirm that changed classes were covered by unit tests.
- [x] **Integration Testing**: Confirm that changed logic was covered by integration tests.
- [ ] **Manual Testing**: Confirm that changes were tested on local or dev environment.
- [x] **NEWS**: Confirm that the NEWS file is updated with relevant information about the changes made in this pull request.

### Related Issues
https://folio-org.atlassian.net/browse/MODELINKS-315
