### PR TITLE
MODELINKS-319: Fix propagation of instance-authority link record creation/update to member tenants

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -11,6 +11,7 @@
 
 ### Bug fixes
 * Fix authority source file propagation to propagate all codes ([MODELINKS-315](https://folio-org.atlassian.net/browse/MODELINKS-315))
+* Fix instance-authority link record propagation to member tenants ([MODELINKS-319](https://folio-org.atlassian.net/browse/MODELINKS-319))
 
 ### Tech Dept
 * Description ([ISSUE](https://folio-org.atlassian.net/browse/ISSUE))

--- a/src/main/java/org/folio/entlinks/domain/entity/InstanceAuthorityLink.java
+++ b/src/main/java/org/folio/entlinks/domain/entity/InstanceAuthorityLink.java
@@ -67,6 +67,14 @@ public class InstanceAuthorityLink extends AuditableEntity {
   @Column(name = "error_cause")
   private String errorCause;
 
+  public InstanceAuthorityLink(InstanceAuthorityLink other) {
+    this.authority = other.authority;
+    this.instanceId = other.instanceId;
+    this.linkingRule = other.linkingRule;
+    this.status = other.status;
+    this.errorCause = other.errorCause;
+  }
+
   @Override
   public int hashCode() {
     return getClass().hashCode();

--- a/src/main/java/org/folio/entlinks/service/consortium/propagation/ConsortiumLinksPropagationService.java
+++ b/src/main/java/org/folio/entlinks/service/consortium/propagation/ConsortiumLinksPropagationService.java
@@ -1,5 +1,6 @@
 package org.folio.entlinks.service.consortium.propagation;
 
+import org.folio.entlinks.domain.entity.InstanceAuthorityLink;
 import org.folio.entlinks.service.consortium.ConsortiumTenantsService;
 import org.folio.entlinks.service.consortium.propagation.model.LinksPropagationData;
 import org.folio.entlinks.service.links.InstanceAuthorityLinkingService;
@@ -23,9 +24,13 @@ public class ConsortiumLinksPropagationService extends ConsortiumPropagationServ
   @Override
   protected void doPropagation(LinksPropagationData propagationData,
                                PropagationType propagationType) {
+    var instanceId = propagationData.instanceId();
+    var links = propagationData.links().stream()
+        .map(InstanceAuthorityLink::new)
+        .toList();
     switch (propagationType) {
       case CREATE, DELETE -> throw new IllegalArgumentException(ILLEGAL_PROPAGATION_MSG.formatted(propagationType));
-      case UPDATE -> instanceAuthorityLinkingService.updateLinks(propagationData.instanceId(), propagationData.links());
+      case UPDATE -> instanceAuthorityLinkingService.updateLinks(instanceId, links);
       default -> throw new IllegalStateException("Unexpected value: " + propagationType);
     }
   }

--- a/src/test/java/org/folio/entlinks/controller/InstanceAuthorityLinksIT.java
+++ b/src/test/java/org/folio/entlinks/controller/InstanceAuthorityLinksIT.java
@@ -17,7 +17,6 @@ import static org.folio.support.TestDataUtils.linksDtoCollection;
 import static org.folio.support.base.TestConstants.TENANT_ID;
 import static org.folio.support.base.TestConstants.authoritiesLinksCountEndpoint;
 import static org.folio.support.base.TestConstants.linksInstanceEndpoint;
-import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.hasSize;
@@ -28,9 +27,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import java.util.Collection;
-import java.util.LinkedHashMap;
 import java.util.List;
-import java.util.Objects;
 import java.util.UUID;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
@@ -48,8 +45,6 @@ import org.folio.support.DatabaseHelper;
 import org.folio.support.TestDataUtils;
 import org.folio.support.TestDataUtils.Link;
 import org.folio.support.base.IntegrationTestBase;
-import org.hamcrest.BaseMatcher;
-import org.hamcrest.Description;
 import org.hamcrest.Matcher;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
@@ -406,47 +401,5 @@ class InstanceAuthorityLinksIT extends IntegrationTestBase {
 
   private ResultMatcher linksMatch(Matcher<Collection<? extends InstanceLinkDto>> matcher) {
     return jsonPath("$.links", matcher);
-  }
-
-  @SuppressWarnings("unchecked")
-  private ResultMatcher linksMatch(InstanceLinkDtoCollection links) {
-    var linkMatchers = links.getLinks().stream()
-      .map(LinkMatcher::linkMatch)
-      .toArray(Matcher[]::new);
-    return jsonPath("$.links", containsInAnyOrder(linkMatchers));
-  }
-
-  private static final class LinkMatcher extends BaseMatcher<InstanceLinkDto> {
-
-    private final InstanceLinkDto expectedLink;
-
-    private LinkMatcher(InstanceLinkDto expectedLink) {
-      this.expectedLink = expectedLink;
-    }
-
-    @Override
-    @SuppressWarnings("rawtypes")
-    public boolean matches(Object actual) {
-      if (actual instanceof LinkedHashMap actualLink) {
-        return Objects.equals(expectedLink.getAuthorityId().toString(), actualLink.get("authorityId"))
-          && Objects.equals(expectedLink.getAuthorityNaturalId(), actualLink.get("authorityNaturalId"))
-          && Objects.equals(expectedLink.getInstanceId().toString(), actualLink.get("instanceId"))
-          && Objects.equals(expectedLink.getLinkingRuleId(), actualLink.get("linkingRuleId"))
-          && Objects.equals(expectedLink.getStatus(), actualLink.get("status"))
-          && Objects.equals(expectedLink.getErrorCause(), actualLink.get("errorCause"));
-      }
-
-      return false;
-    }
-
-    @Override
-    public void describeTo(Description description) {
-      description.appendValue(expectedLink);
-    }
-
-    static LinkMatcher linkMatch(InstanceLinkDto expectedLink) {
-      return new LinkMatcher(expectedLink);
-    }
-
   }
 }

--- a/src/test/java/org/folio/entlinks/controller/delegate/LinkingServiceDelegateTest.java
+++ b/src/test/java/org/folio/entlinks/controller/delegate/LinkingServiceDelegateTest.java
@@ -182,7 +182,7 @@ class LinkingServiceDelegateTest {
 
     verify(linkingService).updateLinks(INSTANCE_ID, links);
     verify(propagationService).propagate(propagationData, ConsortiumAuthorityPropagationService.PropagationType.UPDATE,
-      TENANT_ID);
+        TENANT_ID);
   }
 
   @Test

--- a/src/test/java/org/folio/entlinks/service/consortium/ConsortiumInstanceAuthorityLinksIT.java
+++ b/src/test/java/org/folio/entlinks/service/consortium/ConsortiumInstanceAuthorityLinksIT.java
@@ -1,0 +1,115 @@
+package org.folio.entlinks.service.consortium;
+
+import static java.util.Collections.singletonList;
+import static java.util.UUID.randomUUID;
+import static org.folio.entlinks.service.consortium.ConsortiumAuthorityPropagationServiceIT.COLLEGE_TENANT_ID;
+import static org.folio.entlinks.service.consortium.ConsortiumAuthorityPropagationServiceIT.UNIVERSITY_TENANT_ID;
+import static org.folio.support.DatabaseHelper.AUTHORITY_SOURCE_FILE_CODE_TABLE;
+import static org.folio.support.DatabaseHelper.AUTHORITY_SOURCE_FILE_TABLE;
+import static org.folio.support.DatabaseHelper.AUTHORITY_TABLE;
+import static org.folio.support.DatabaseHelper.INSTANCE_AUTHORITY_LINK_TABLE;
+import static org.folio.support.TestDataUtils.AuthorityTestData.authority;
+import static org.folio.support.TestDataUtils.AuthorityTestData.authoritySourceFile;
+import static org.folio.support.TestDataUtils.linksDto;
+import static org.folio.support.TestDataUtils.linksDtoCollection;
+import static org.folio.support.base.TestConstants.CENTRAL_TENANT_ID;
+import static org.folio.support.base.TestConstants.linksInstanceEndpoint;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.UUID;
+import java.util.stream.IntStream;
+import lombok.SneakyThrows;
+import org.folio.entlinks.domain.dto.InstanceLinkDto;
+import org.folio.entlinks.domain.dto.InstanceLinkDtoCollection;
+import org.folio.spring.integration.XOkapiHeaders;
+import org.folio.spring.testing.extension.DatabaseCleanup;
+import org.folio.spring.testing.type.IntegrationTest;
+import org.folio.support.TestDataUtils;
+import org.folio.support.TestDataUtils.Link;
+import org.folio.support.base.IntegrationTestBase;
+import org.hamcrest.Matcher;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.web.servlet.ResultMatcher;
+
+
+@IntegrationTest
+@DatabaseCleanup(
+    tables = {INSTANCE_AUTHORITY_LINK_TABLE, AUTHORITY_TABLE, AUTHORITY_SOURCE_FILE_CODE_TABLE,
+      AUTHORITY_SOURCE_FILE_TABLE},
+    tenants = {CENTRAL_TENANT_ID, COLLEGE_TENANT_ID, UNIVERSITY_TENANT_ID}
+)
+class ConsortiumInstanceAuthorityLinksIT extends IntegrationTestBase {
+
+  @BeforeAll
+  static void prepare() {
+    setUpConsortium(CENTRAL_TENANT_ID, List.of(COLLEGE_TENANT_ID, UNIVERSITY_TENANT_ID), true);
+  }
+
+  @Test
+  @SneakyThrows
+  void updateInstanceLinks_positive_saveIncomingLinks_whenAnyExist() {
+    var instanceId = randomUUID();
+    var sourceFile = authoritySourceFile(0);
+    final var incomingLinks = createLinkDtoCollection(2, instanceId);
+    databaseHelper.saveAuthoritySourceFile(CENTRAL_TENANT_ID, sourceFile);
+    databaseHelper.saveAuthoritySourceFile(COLLEGE_TENANT_ID, sourceFile);
+    databaseHelper.saveAuthoritySourceFile(UNIVERSITY_TENANT_ID, sourceFile);
+    createAuthoritiesForLinks(incomingLinks.getLinks());
+
+    var httpHeaders = defaultHeaders();
+    httpHeaders.put(XOkapiHeaders.TENANT, singletonList(CENTRAL_TENANT_ID));
+
+    doPut(linksInstanceEndpoint(), incomingLinks, httpHeaders, instanceId);
+
+
+    doGet(linksInstanceEndpoint(), httpHeaders, instanceId)
+      .andExpect(linksMatch(hasSize(2)))
+      .andExpect(linksMatch(incomingLinks))
+      .andExpect(totalRecordsMatch(2));
+
+    httpHeaders.put(XOkapiHeaders.TENANT, singletonList(COLLEGE_TENANT_ID));
+    awaitUntilAsserted(() ->
+        doGet(linksInstanceEndpoint(), httpHeaders, instanceId)
+            .andExpect(linksMatch(hasSize(2)))
+            .andExpect(linksMatch(incomingLinks))
+            .andExpect(totalRecordsMatch(2)));
+
+    httpHeaders.put(XOkapiHeaders.TENANT, singletonList(UNIVERSITY_TENANT_ID));
+    awaitUntilAsserted(() ->
+        doGet(linksInstanceEndpoint(), httpHeaders, instanceId)
+            .andExpect(linksMatch(hasSize(2)))
+            .andExpect(linksMatch(incomingLinks))
+            .andExpect(totalRecordsMatch(2)));
+  }
+
+  private InstanceLinkDtoCollection createLinkDtoCollection(int num, UUID instanceId) {
+    var links = IntStream.range(0, num)
+      .mapToObj(i -> Link.of(i, i, TestDataUtils.NATURAL_IDS[i]))
+      .toArray(Link[]::new);
+    return linksDtoCollection(linksDto(instanceId, links));
+  }
+
+  private void createAuthoritiesForLinks(List<InstanceLinkDto> links) {
+    var authority = authority(0, 0);
+    links.forEach(link -> {
+      authority.setId(link.getAuthorityId());
+      authority.setNaturalId(link.getAuthorityNaturalId());
+      databaseHelper.saveAuthority(CENTRAL_TENANT_ID, authority);
+      databaseHelper.saveAuthority(COLLEGE_TENANT_ID, authority);
+      databaseHelper.saveAuthority(UNIVERSITY_TENANT_ID, authority);
+    });
+  }
+
+  private ResultMatcher totalRecordsMatch(int recordsTotal) {
+    return jsonPath("$.totalRecords", is(recordsTotal));
+  }
+
+  private ResultMatcher linksMatch(Matcher<Collection<? extends InstanceLinkDto>> matcher) {
+    return jsonPath("$.links", matcher);
+  }
+}

--- a/src/test/java/org/folio/entlinks/service/consortium/ConsortiumLinksPropagationServiceTest.java
+++ b/src/test/java/org/folio/entlinks/service/consortium/ConsortiumLinksPropagationServiceTest.java
@@ -1,10 +1,14 @@
 package org.folio.entlinks.service.consortium;
 
 import static java.util.Collections.emptyList;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.folio.entlinks.service.consortium.propagation.ConsortiumPropagationService.PropagationType.CREATE;
+import static org.folio.entlinks.service.consortium.propagation.ConsortiumPropagationService.PropagationType.UPDATE;
 import static org.folio.support.base.TestConstants.TENANT_ID;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.times;
@@ -15,7 +19,6 @@ import java.util.List;
 import java.util.UUID;
 import org.folio.entlinks.domain.entity.InstanceAuthorityLink;
 import org.folio.entlinks.exception.FolioIntegrationException;
-import org.folio.entlinks.service.consortium.propagation.ConsortiumAuthorityPropagationService;
 import org.folio.entlinks.service.consortium.propagation.ConsortiumLinksPropagationService;
 import org.folio.entlinks.service.consortium.propagation.model.LinksPropagationData;
 import org.folio.entlinks.service.links.InstanceAuthorityLinkingService;
@@ -23,6 +26,7 @@ import org.folio.spring.service.SystemUserScopedExecutionService;
 import org.folio.spring.testing.type.UnitTest;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -40,17 +44,23 @@ class ConsortiumLinksPropagationServiceTest {
   void testPropagateUpdate() {
     var instanceId = UUID.randomUUID();
     var link = new InstanceAuthorityLink();
+    link.setId(1L);
     link.setInstanceId(instanceId);
     List<InstanceAuthorityLink> links = List.of(link);
     final var propagationData = new LinksPropagationData(instanceId, links);
+    final var captor = ArgumentCaptor.forClass(List.class);
 
     doMocks();
-    propagationService.propagate(
-        propagationData, ConsortiumAuthorityPropagationService.PropagationType.UPDATE, TENANT_ID);
+    propagationService.propagate(propagationData, UPDATE, TENANT_ID);
 
     verify(tenantsService).getConsortiumTenants(TENANT_ID);
     verify(executionService, times(3)).executeAsyncSystemUserScoped(any(), any());
-    verify(instanceAuthorityLinkingService, times(3)).updateLinks(instanceId, links);
+    verify(instanceAuthorityLinkingService, times(3)).updateLinks(eq(instanceId), captor.capture());
+
+    assertThat(captor.getValue())
+        .usingRecursiveComparison()
+        .ignoringFields("id")
+        .isEqualTo(links);
   }
 
   @Test
@@ -60,8 +70,7 @@ class ConsortiumLinksPropagationServiceTest {
     doMocks();
 
     var exception = assertThrows(IllegalArgumentException.class,
-      () -> propagationService.propagate(propagationData, ConsortiumAuthorityPropagationService.PropagationType.CREATE,
-        TENANT_ID));
+        () -> propagationService.propagate(propagationData, CREATE, TENANT_ID));
 
     assertEquals("Propagation type 'CREATE' is not supported for links.", exception.getMessage());
   }
@@ -72,8 +81,7 @@ class ConsortiumLinksPropagationServiceTest {
 
     final var propagationData = new LinksPropagationData(null, emptyList());
 
-    propagationService.propagate(
-        propagationData, ConsortiumAuthorityPropagationService.PropagationType.UPDATE, TENANT_ID);
+    propagationService.propagate(propagationData, UPDATE, TENANT_ID);
 
     verify(tenantsService, times(1)).getConsortiumTenants(any());
     verify(executionService, times(0)).executeAsyncSystemUserScoped(any(), any());


### PR DESCRIPTION
### Purpose
After instance-authority link record is created in central tenant's DB it fails to do the same for member tenants. Due to the latest changes hibernate assumes that if generated id column is set with a value for an entity then it already exists in DB and if does not exists it throws optimistic locking exception thinking entity is modified/removed while it is being persisted

### Approach
copy instances to be persisted without getting their id before propagation

### Changes Checklist
- [ ] **API Changes**: Document any API paths, methods, request or response bodies changed, added, or removed.
- [ ] **Database Schema Changes**: Indicate any database schema changes and their impact. Confirm that migration scripts were created.
- [ ] **Interface Version Changes**: Indicate any changes to interface versions.
- [ ] **Interface Dependencies**: Document added or removed dependencies.
- [ ] **Permissions**: Document any changes to permissions.
- [ ] **Logging**: Confirm that logging is appropriately handled.
- [x] **Unit Testing**: Confirm that changed classes were covered by unit tests.
- [x] **Integration Testing**: Confirm that changed logic was covered by integration tests.
- [x] **Manual Testing**: Confirm that changes were tested on local or dev environment.
- [x] **NEWS**: Confirm that the NEWS file is updated with relevant information about the changes made in this pull request.

### Related Issues
[MODELINKS-319](https://folio-org.atlassian.net/browse/MODELINKS-319)

### Learning and Resources (if applicable)
If the id field is provided, Hibernate assumes the entity already exists in the database. If no matching row is found, Hibernate interprets this as the entity having been deleted by another transaction, resulting in an OptimisticLockException.

https://docs.jboss.org/hibernate/orm/6.6/migration-guide/migration-guide.html#merge-versioned-deleted
