### PR TITLE
fix(authority-instance-link): Pass userId from authority kafka event to link update events

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -7,7 +7,7 @@
 * Requires `API_NAME vX.Y`
 
 ### Features
-* Description ([ISSUE](https://folio-org.atlassian.net/browse/ISSUE))
+* Pass userId from authority kafka event to link update events ([UIIN-3305](https://folio-org.atlassian.net/browse/UIIN-3305))
 
 ### Bug fixes
 * Fix authority source file propagation to propagate all codes ([MODELINKS-315](https://folio-org.atlassian.net/browse/MODELINKS-315))

--- a/NEWS.md
+++ b/NEWS.md
@@ -7,7 +7,7 @@
 * Requires `API_NAME vX.Y`
 
 ### Features
-* Pass userId from authority kafka event to link update events ([UIIN-3305](https://folio-org.atlassian.net/browse/UIIN-3305))
+* Pass userId from authority kafka event to link update events ([MODELINKS-322](https://folio-org.atlassian.net/browse/MODELINKS-322))
 
 ### Bug fixes
 * Fix authority source file propagation to propagate all codes ([MODELINKS-315](https://folio-org.atlassian.net/browse/MODELINKS-315))

--- a/src/main/java/org/folio/entlinks/integration/kafka/AuthorityEventListener.java
+++ b/src/main/java/org/folio/entlinks/integration/kafka/AuthorityEventListener.java
@@ -1,8 +1,14 @@
 package org.folio.entlinks.integration.kafka;
 
+import static java.util.Collections.singletonList;
+import static org.apache.commons.lang3.StringUtils.isBlank;
+import static org.folio.entlinks.utils.HeaderUtils.extractHeaderValue;
 import static org.folio.spring.tools.config.RetryTemplateConfiguration.DEFAULT_KAFKA_RETRY_TEMPLATE_NAME;
 
+import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
@@ -11,6 +17,7 @@ import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.logging.log4j.message.FormattedMessageFactory;
 import org.folio.entlinks.integration.dto.event.AuthorityDomainEvent;
 import org.folio.entlinks.service.messaging.authority.InstanceAuthorityLinkUpdateService;
+import org.folio.spring.integration.XOkapiHeaders;
 import org.folio.spring.service.SystemUserScopedExecutionService;
 import org.folio.spring.tools.batch.MessageBatchProcessor;
 import org.springframework.kafka.annotation.KafkaListener;
@@ -33,20 +40,29 @@ public class AuthorityEventListener {
   public void handleEvents(List<ConsumerRecord<String, AuthorityDomainEvent>> consumerRecords) {
     log.info("Processing authorities from Kafka events [number of records: {}]", consumerRecords.size());
 
-    var authorityEvents =
-      consumerRecords.stream()
-        .map(consumerRecord -> {
-          var value = consumerRecord.value();
-          value.setId(UUID.fromString(consumerRecord.key()));
-          return value;
-        })
-        .collect(Collectors.groupingBy(AuthorityDomainEvent::getTenant));
-
-    authorityEvents.forEach(this::handleAuthorityEventsForTenant);
+    consumerRecords.stream()
+      .collect(Collectors.groupingBy(consumerRecord ->
+        extractHeaderValue(XOkapiHeaders.USER_ID, consumerRecord.headers())))
+      .forEach(this::handleAuthorityEventsForUser);
   }
 
-  private void handleAuthorityEventsForTenant(String tenant, List<AuthorityDomainEvent> events) {
-    executionService.executeSystemUserScoped(tenant, () -> {
+  private void handleAuthorityEventsForUser(String userId, List<ConsumerRecord<String, AuthorityDomainEvent>> records) {
+    var headers = isBlank(userId)
+      ? Collections.<String, Collection<String>>emptyMap()
+      : Map.<String, Collection<String>>of(XOkapiHeaders.USER_ID, singletonList(userId));
+    records.stream()
+      .map(consumerRecord -> {
+        var value = consumerRecord.value();
+        value.setId(UUID.fromString(consumerRecord.key()));
+        return value;
+      })
+      .collect(Collectors.groupingBy(AuthorityDomainEvent::getTenant))
+      .forEach((tenant, events) -> handleAuthorityEventsForTenant(tenant, headers, events));
+  }
+
+  private void handleAuthorityEventsForTenant(String tenant, Map<String, Collection<String>> headers,
+                                              List<AuthorityDomainEvent> events) {
+    executionService.executeSystemUserScoped(tenant, headers, () -> {
       log.info("Triggering updates for authority records [number of records: {}, tenant: {}]", events.size(), tenant);
       messageBatchProcessor.consumeBatchWithFallback(events, DEFAULT_KAFKA_RETRY_TEMPLATE_NAME,
         instanceAuthorityLinkUpdateService::handleAuthoritiesChanges, this::logFailedEvent);

--- a/src/main/java/org/folio/entlinks/utils/HeaderUtils.java
+++ b/src/main/java/org/folio/entlinks/utils/HeaderUtils.java
@@ -1,0 +1,20 @@
+package org.folio.entlinks.utils;
+
+import java.util.Arrays;
+import lombok.experimental.UtilityClass;
+import org.apache.kafka.common.header.Headers;
+
+@UtilityClass
+public class HeaderUtils {
+
+  public static String extractHeaderValue(String headerKey, Headers headers) {
+    if (headerKey == null || headers == null) {
+      return "";
+    }
+    return Arrays.stream(headers.toArray())
+      .filter(header -> headerKey.equalsIgnoreCase(header.key()) && header.value() != null)
+      .findFirst()
+      .map(header -> new String(header.value()))
+      .orElse("");
+  }
+}

--- a/src/main/java/org/folio/entlinks/utils/HeaderUtils.java
+++ b/src/main/java/org/folio/entlinks/utils/HeaderUtils.java
@@ -1,20 +1,20 @@
 package org.folio.entlinks.utils;
 
 import java.util.Arrays;
+import java.util.Optional;
 import lombok.experimental.UtilityClass;
 import org.apache.kafka.common.header.Headers;
 
 @UtilityClass
 public class HeaderUtils {
 
-  public static String extractHeaderValue(String headerKey, Headers headers) {
+  public static Optional<String> extractHeaderValue(String headerKey, Headers headers) {
     if (headerKey == null || headers == null) {
-      return "";
+      return Optional.empty();
     }
     return Arrays.stream(headers.toArray())
       .filter(header -> headerKey.equalsIgnoreCase(header.key()) && header.value() != null)
       .findFirst()
-      .map(header -> new String(header.value()))
-      .orElse("");
+      .map(header -> new String(header.value()));
   }
 }

--- a/src/test/java/org/folio/entlinks/utils/HeaderUtilsTest.java
+++ b/src/test/java/org/folio/entlinks/utils/HeaderUtilsTest.java
@@ -1,6 +1,8 @@
 package org.folio.entlinks.utils;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.stream.Stream;
 import org.apache.kafka.common.header.Headers;
@@ -19,7 +21,8 @@ class HeaderUtilsTest {
 
     var actual = HeaderUtils.extractHeaderValue("test-key", headers);
 
-    assertEquals("test-value", actual);
+    assertFalse(actual.isEmpty());
+    assertEquals("test-value", actual.get());
   }
 
   @ParameterizedTest
@@ -27,7 +30,7 @@ class HeaderUtilsTest {
   void shouldReturnEmptyStringForInvalidHeaders(String headerKey, Headers headers) {
     var actual = HeaderUtils.extractHeaderValue(headerKey, headers);
 
-    assertEquals("", actual);
+    assertTrue(actual.isEmpty());
   }
 
   private static Stream<Arguments> provideInvalidHeaders() {

--- a/src/test/java/org/folio/entlinks/utils/HeaderUtilsTest.java
+++ b/src/test/java/org/folio/entlinks/utils/HeaderUtilsTest.java
@@ -1,0 +1,50 @@
+package org.folio.entlinks.utils;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.stream.Stream;
+import org.apache.kafka.common.header.Headers;
+import org.apache.kafka.common.header.internals.RecordHeaders;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+class HeaderUtilsTest {
+
+  @Test
+  void shouldExtractHeaderValueWhenKeyExists() {
+    var headers = new RecordHeaders();
+    headers.add("test-key", "test-value".getBytes());
+
+    var actual = HeaderUtils.extractHeaderValue("test-key", headers);
+
+    assertEquals("test-value", actual);
+  }
+
+  @ParameterizedTest
+  @MethodSource("provideInvalidHeaders")
+  void shouldReturnEmptyStringForInvalidHeaders(String headerKey, Headers headers) {
+    var actual = HeaderUtils.extractHeaderValue(headerKey, headers);
+
+    assertEquals("", actual);
+  }
+
+  private static Stream<Arguments> provideInvalidHeaders() {
+    return Stream.of(
+      Arguments.of("test-key", createHeaders("another-key", "value")),
+      Arguments.of("test-key", new RecordHeaders()),
+      Arguments.of("test-key", createHeaders("test-key", null)),
+      Arguments.of(null, createHeaders("test-key", "test-value")),
+      Arguments.of("test-key", null)
+    );
+  }
+
+  private static Headers createHeaders(String key, String value) {
+    var headers = new RecordHeaders();
+    if (key != null) {
+      headers.add(key, value != null ? value.getBytes() : null);
+    }
+    return headers;
+  }
+}


### PR DESCRIPTION
### Purpose
Fix `null` `userId` in `updatedByUser` field of linked instance after linked authority field update on eureka env where system user is disabled for module.

### Approach
Pass userId header to execution context on authority update so link update events has userId when system user is disabled

### Changes Checklist
- [ ] **API Changes**: Document any API paths, methods, request or response bodies changed, added, or removed.
- [ ] **Database Schema Changes**: Indicate any database schema changes and their impact. Confirm that migration scripts were created.
- [ ] **Interface Version Changes**: Indicate any changes to interface versions.
- [ ] **Interface Dependencies**: Document added or removed dependencies.
- [ ] **Permissions**: Document any changes to permissions.
- [ ] **Logging**: Confirm that logging is appropriately handled.
- [x] **Unit Testing**: Confirm that changed classes were covered by unit tests.
- [ ] **Integration Testing**: Confirm that changed logic was covered by integration tests.
- [x] **Manual Testing**: Confirm that changes were tested on local or dev environment.
- [x] **NEWS**: Confirm that the NEWS file is updated with relevant information about the changes made in this pull request.

### Related Issues
[UIIN-3305](https://folio-org.atlassian.net/browse/UIIN-3305)
[FOLSPRINGS-195](https://folio-org.atlassian.net/browse/FOLSPRINGS-195)