### PR TITLE
fix(linking-rules): improve converter of subfields to ignore empty strings

### DIFF
--- a/src/main/java/org/folio/entlinks/controller/converter/LinkingRulesMapper.java
+++ b/src/main/java/org/folio/entlinks/controller/converter/LinkingRulesMapper.java
@@ -2,6 +2,7 @@ package org.folio.entlinks.controller.converter;
 
 import java.util.List;
 import java.util.Map;
+import org.apache.commons.lang3.StringUtils;
 import org.folio.entlinks.domain.dto.LinkingRuleDto;
 import org.folio.entlinks.domain.dto.LinkingRulePatchRequest;
 import org.folio.entlinks.domain.dto.SubfieldValidation;
@@ -30,29 +31,41 @@ public interface LinkingRulesMapper {
     return new SubfieldValidation().existence(List.of(existence));
   }
 
+  /**
+   * Converts a list of strings to a sorted character array containing the first character of each string.
+   * Letters are sorted before non-letters, and characters are sorted naturally within their groups.
+   *
+   * @param list the input list of strings
+   * @return sorted array of first characters from non-empty strings, or empty array if input is null
+   */
   default char[] stringListToCharArray(List<String> list) {
     if (list == null) {
       return new char[0];
     }
 
-    char[] charTmp = new char[list.size()];
-    list.sort((s1, s2) -> {
-      boolean s1Alpha = Character.isLetter(s1.charAt(0));
-      boolean s2Alpha = Character.isLetter(s2.charAt(0));
-      if (s1Alpha && !s2Alpha) {
-        return -1;
-      }
-      if (!s1Alpha && s2Alpha) {
-        return 1;
-      }
-      return s1.compareToIgnoreCase(s2);
-    });
-    int i = 0;
-    for (String string : list) {
-      charTmp[i] = string.charAt(0);
-      i++;
-    }
+    var firstCharacters = list.stream()
+      .filter(StringUtils::isNotEmpty)
+      .map(s -> s.charAt(0))
+      .sorted(this::compareCharacters)
+      .toList();
 
-    return charTmp;
+    char[] result = new char[firstCharacters.size()];
+    for (int i = 0; i < result.length; i++) {
+      result[i] = firstCharacters.get(i);
+    }
+    return result;
+  }
+
+  private int compareCharacters(char first, char second) {
+    boolean isFirstLetter = Character.isLetter(first);
+    boolean isSecondLetter = Character.isLetter(second);
+
+    if (isFirstLetter && !isSecondLetter) {
+      return -1;
+    }
+    if (!isFirstLetter && isSecondLetter) {
+      return 1;
+    }
+    return Character.compare(first, second);
   }
 }

--- a/src/test/java/org/folio/entlinks/controller/converter/LinkingRulesMapperTest.java
+++ b/src/test/java/org/folio/entlinks/controller/converter/LinkingRulesMapperTest.java
@@ -93,4 +93,29 @@ class LinkingRulesMapperTest {
     rule.setSubfieldModifications(List.of(subfieldModification));
     return rule;
   }
+
+  @Test
+  void testStringListToCharArray_withValidInput() {
+    var input = List.of("b", "1", "a", "", "2");
+
+    char[] result = mapper.stringListToCharArray(input);
+
+    assertThat(result).containsExactly('a', 'b', '1', '2');
+  }
+
+  @Test
+  void testStringListToCharArray_withEmptyList() {
+    var input = List.<String>of();
+
+    char[] result = mapper.stringListToCharArray(input);
+
+    assertThat(result).isEmpty();
+  }
+
+  @Test
+  void testStringListToCharArray_withNullInput() {
+    char[] result = mapper.stringListToCharArray(null);
+
+    assertThat(result).isEmpty();
+  }
 }


### PR DESCRIPTION
### Purpose
Ignore empty subfields

### Approach

- Refactored stringListToCharArray to improve code readability and logic clarity by using Java Streams and a helper method for character comparison.
- Added input validation using StringUtils::isNotEmpty for non-empty string filtering.
- Introduced a new private method compareCharacters for sorting logic to distinguish letters from non-letters.
- Added three new unit tests in LinkingRulesMapperTest to test various edge cases (valid input, null input, and empty list)

### Changes Checklist
- [ ] **API Changes**: Document any API paths, methods, request or response bodies changed, added, or removed.
- [ ] **Database Schema Changes**: Indicate any database schema changes and their impact. Confirm that migration scripts were created.
- [ ] **Interface Version Changes**: Indicate any changes to interface versions.
- [ ] **Interface Dependencies**: Document added or removed dependencies.
- [ ] **Permissions**: Document any changes to permissions.
- [ ] **Logging**: Confirm that logging is appropriately handled.
- [x] **Unit Testing**: Confirm that changed classes were covered by unit tests.
- [ ] **Integration Testing**: Confirm that changed logic was covered by integration tests.
- [ ] **Manual Testing**: Confirm that changes were tested on local or dev environment.
- [ ] **NEWS**: Confirm that the NEWS file is updated with relevant information about the changes made in this pull request.

### Related Issues
https://folio-org.atlassian.net/browse/MODELINKS-326
