### PR TITLE
feat(linking-rules): remove cache for linking rules

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -13,6 +13,7 @@
 ### Bug fixes
 * Fix authority source file propagation to propagate all codes ([MODELINKS-315](https://folio-org.atlassian.net/browse/MODELINKS-315))
 * Fix instance-authority link record propagation to member tenants ([MODELINKS-319](https://folio-org.atlassian.net/browse/MODELINKS-319))
+* Fix outdated linking rules by removing the cache for linking rules ([MODELINKS-333](https://folio-org.atlassian.net/browse/MODELINKS-333))
 
 ### Tech Dept
 * Description ([ISSUE](https://folio-org.atlassian.net/browse/ISSUE))

--- a/src/main/java/org/folio/entlinks/config/constants/CacheNames.java
+++ b/src/main/java/org/folio/entlinks/config/constants/CacheNames.java
@@ -7,7 +7,6 @@ import lombok.NoArgsConstructor;
 public class CacheNames {
 
   public static final String AUTHORITY_MAPPING_RULES_CACHE = "authority-mapping-rules-cache";
-  public static final String AUTHORITY_LINKING_RULES_CACHE = "authority-linking-rules-cache";
   public static final String CONSORTIUM_TENANTS_CACHE = "consortium-tenants-cache";
   public static final String CONSORTIUM_CENTRAL_TENANT = "consortium-central-tenant-cache";
 }

--- a/src/main/java/org/folio/entlinks/service/links/InstanceAuthorityLinkingRulesService.java
+++ b/src/main/java/org/folio/entlinks/service/links/InstanceAuthorityLinkingRulesService.java
@@ -1,7 +1,5 @@
 package org.folio.entlinks.service.links;
 
-import static org.folio.entlinks.config.constants.CacheNames.AUTHORITY_LINKING_RULES_CACHE;
-
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
@@ -9,8 +7,6 @@ import org.folio.entlinks.domain.entity.InstanceAuthorityLinkingRule;
 import org.folio.entlinks.domain.repository.LinkingRulesRepository;
 import org.folio.entlinks.exception.LinkingRuleNotFoundException;
 import org.folio.entlinks.service.links.validator.LinkingRuleValidator;
-import org.springframework.cache.annotation.CacheEvict;
-import org.springframework.cache.annotation.Cacheable;
 import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -23,17 +19,11 @@ public class InstanceAuthorityLinkingRulesService {
   private final LinkingRulesRepository repository;
   private final LinkingRuleValidator validator;
 
-  @Cacheable(cacheNames = AUTHORITY_LINKING_RULES_CACHE,
-             key = "@folioExecutionContext.tenantId",
-             unless = "#result.isEmpty()")
   public List<InstanceAuthorityLinkingRule> getLinkingRules() {
     log.info("Loading linking rules");
     return repository.findAll(Sort.by("id").ascending());
   }
 
-  @Cacheable(cacheNames = AUTHORITY_LINKING_RULES_CACHE,
-             key = "@folioExecutionContext.tenantId + ':' + #authorityField",
-             unless = "#result.isEmpty()")
   public List<InstanceAuthorityLinkingRule> getLinkingRulesByAuthorityField(String authorityField) {
     log.info("Loading linking rules for [authorityField: {}]", authorityField);
     return repository.findByAuthorityField(authorityField);
@@ -46,7 +36,6 @@ public class InstanceAuthorityLinkingRulesService {
   }
 
   @Transactional
-  @CacheEvict(cacheNames = AUTHORITY_LINKING_RULES_CACHE, allEntries = true)
   public void updateLinkingRule(Integer ruleId, InstanceAuthorityLinkingRule linkingRulePatch) {
     log.info("Updating linking rule [ruleId: {}, change: {}]", ruleId, linkingRulePatch);
     var existingRule = getLinkingRule(ruleId);

--- a/src/test/java/org/folio/entlinks/service/links/InstanceAuthorityLinkingRulesServiceTest.java
+++ b/src/test/java/org/folio/entlinks/service/links/InstanceAuthorityLinkingRulesServiceTest.java
@@ -2,7 +2,6 @@ package org.folio.entlinks.service.links;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.folio.entlinks.config.constants.CacheNames.AUTHORITY_LINKING_RULES_CACHE;
 import static org.folio.support.base.TestConstants.TENANT_ID;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.verify;
@@ -23,12 +22,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
-import org.springframework.boot.autoconfigure.cache.CacheAutoConfiguration;
 import org.springframework.boot.test.context.TestConfiguration;
-import org.springframework.cache.Cache;
-import org.springframework.cache.CacheManager;
-import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Import;
 import org.springframework.data.domain.Sort;
@@ -36,17 +30,14 @@ import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 @UnitTest
-@EnableCaching
 @ExtendWith(SpringExtension.class)
 @Import(InstanceAuthorityLinkingRulesService.class)
-@ImportAutoConfiguration(CacheAutoConfiguration.class)
 class InstanceAuthorityLinkingRulesServiceTest {
 
   private @MockitoBean LinkingRulesRepository repository;
   private @MockitoBean LinkingRuleValidator validator;
 
   private @Autowired InstanceAuthorityLinkingRulesService service;
-  private @Autowired CacheManager cacheManager;
 
   @Test
   void getLinkingRules_positive() {
@@ -85,11 +76,6 @@ class InstanceAuthorityLinkingRulesServiceTest {
 
     assertThat(actual)
       .containsExactlyInAnyOrder(rule);
-
-    assertThat(getCache().get(TENANT_ID + ":" + authorityField))
-      .as("Rule cached")
-      .extracting(Cache.ValueWrapper::get)
-      .isEqualTo(actual);
   }
 
   @Test
@@ -123,7 +109,7 @@ class InstanceAuthorityLinkingRulesServiceTest {
   }
 
   @Test
-  void updateLinkingRule_positive_onlyExpectedFieldAndCacheInvalidated() {
+  void updateLinkingRule_positive_onlyExpectedField() {
     var ruleId = 1;
     var existedRule = InstanceAuthorityLinkingRule.builder()
       .id(ruleId)
@@ -134,9 +120,6 @@ class InstanceAuthorityLinkingRulesServiceTest {
       .subfieldModifications(List.of(new SubfieldModification().target("a").source("b")))
       .autoLinkingEnabled(false)
       .build();
-
-    // add some value into cache
-    getCache().put(TENANT_ID, existedRule);
 
     when(repository.findById(ruleId)).thenReturn(Optional.of(existedRule));
 
@@ -153,7 +136,6 @@ class InstanceAuthorityLinkingRulesServiceTest {
 
     verify(repository).save(ruleUpdateCaptor.capture());
 
-    assertThat(getCache().get(TENANT_ID)).as("Cache invalidated").isNull();
     assertThat(ruleUpdateCaptor.getValue())
       .extracting(InstanceAuthorityLinkingRule::getId,
         InstanceAuthorityLinkingRule::getBibField,
@@ -181,10 +163,6 @@ class InstanceAuthorityLinkingRulesServiceTest {
     assertThatThrownBy(() -> service.updateLinkingRule(ruleId, linkingRulePatch))
       .isInstanceOf(LinkingRuleNotFoundException.class)
       .hasMessage(String.format("Linking rule with ID [%s] was not found", ruleId));
-  }
-
-  private Cache getCache() {
-    return cacheManager.getCache(AUTHORITY_LINKING_RULES_CACHE);
   }
 
   @TestConfiguration


### PR DESCRIPTION
### Purpose
Remove cache to fix outdated linking rules in case of multi-instance deployment

### Changes Checklist
- [ ] **API Changes**: Document any API paths, methods, request or response bodies changed, added, or removed.
- [ ] **Database Schema Changes**: Indicate any database schema changes and their impact. Confirm that migration scripts were created.
- [ ] **Interface Version Changes**: Indicate any changes to interface versions.
- [ ] **Interface Dependencies**: Document added or removed dependencies.
- [ ] **Permissions**: Document any changes to permissions.
- [ ] **Logging**: Confirm that logging is appropriately handled.
- [x] **Unit Testing**: Confirm that changed classes were covered by unit tests.
- [ ] **Integration Testing**: Confirm that changed logic was covered by integration tests.
- [ ] **Manual Testing**: Confirm that changes were tested on local or dev environment.
- [x] **NEWS**: Confirm that the NEWS file is updated with relevant information about the changes made in this pull request.

### Related Issues
https://folio-org.atlassian.net/browse/MODELINKS-333