### PR TITLE
chore: change dependency on `mapping-rules-provider` interface to optional

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -23,10 +23,6 @@
       "version": "10.0 11.0"
     },
     {
-      "id": "mapping-rules-provider",
-      "version": "2.0"
-    },
-    {
       "id": "settings",
       "version": "1.0"
     },
@@ -47,6 +43,10 @@
     {
       "id": "specification-storage",
       "version": "1.0"
+    },
+    {
+      "id": "mapping-rules-provider",
+      "version": "2.0"
     }
   ],
   "provides": [


### PR DESCRIPTION
## Purpose
to accomplish the move of the mod-source-record-manager module from app-platform-complete to app-data-import application, it is necessary to temporarily change dependency on `mapping-rules-provider` interface to optional until mod-entities-links is moved to its own separate application.


## Learning
[MODELINKS-337](https://issues.folio.org/browse/MODELINKS-337)