### PR TITLE
Revert "chore: change dependency on `mapping-rules-provider` interface to optional (#397)"

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -23,6 +23,10 @@
       "version": "10.0 11.0"
     },
     {
+      "id": "mapping-rules-provider",
+      "version": "2.0"
+    },
+    {
       "id": "settings",
       "version": "1.0"
     },
@@ -43,10 +47,6 @@
     {
       "id": "specification-storage",
       "version": "1.0"
-    },
-    {
-      "id": "mapping-rules-provider",
-      "version": "2.0"
     }
   ],
   "provides": [


### PR DESCRIPTION
## Purpose
revert changes to fix the platform build since the module tries to assign SRM permissions to system user before SRM  module deployment