### PR TITLE
MODELINKS-340: Upgrade dependencies fixing vulns (Ramsons)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,9 @@
+## v3.1.5
+### Bug fixes
+* Upgrade dependencies fixing vulns (Ramsons) CVE-2025-8916, CVE-2025-58056, CVE-2025-58057, CVE-2025-41249 ([MODELINKS-340](https://folio-org.atlassian.net/browse/MODELINKS-340))
+
+---
+
 ## v3.1.4 2025-06-16
 ### Features
 * Allow updating controlled subfields ([MODELINKS-326](https://folio-org.atlassian.net/browse/MODELINKS-326))

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.springframework.boot</groupId>
     <artifactId>spring-boot-starter-parent</artifactId>
-    <version>3.3.5</version>
+    <version>3.3.13</version>
     <relativePath /> <!-- lookup parent from repository -->
   </parent>
 
@@ -27,10 +27,11 @@
 
     <folio-spring-support.version>8.2.1</folio-spring-support.version>
     <folio-service-tools.version>4.1.1</folio-service-tools.version>
-    <folio-s3-client.version>2.2.0</folio-s3-client.version>
+    <folio-s3-client.version>2.2.1</folio-s3-client.version>
     <mod-record-specifications-dto.version>1.0.2</mod-record-specifications-dto.version>
     <aws-sdk-java.version>2.29.5</aws-sdk-java.version>
     <mapstruct.version>1.6.2</mapstruct.version>
+    <netty.version>4.1.127.Final</netty.version>
     <lombok.mapstruct-binding.version>0.2.0</lombok.mapstruct-binding.version>
     <marc4j.version>2.9.6</marc4j.version>
 


### PR DESCRIPTION
https://folio-org.atlassian.net/browse/MODELINKS-340

### Purpose
Fix multiple security vulnerabilities in dependencies.

### Approach
Bump patch versions in pom.xml:

Upgrade folio-s3-client.version from 2.2.0 to 2.2.1. This indirectly upgrades bcprov-jdk18on from 1.77 to 1.78.1 fixing CVE-2025-8916 Denis of Service (DoS) https://github.com/bcgit/bc-java/wiki/CVE%E2%80%902025%E2%80%908916 in the connection from mod-entities-links to minio.

Upgrade Netty from 4.1.114.Final to 4.1.127.Final fixing vulnerablities:

* CVE-2025-58056 https://github.com/advisories/GHSA-fghv-69vj-qj49 HTTP/1.1 request smuggling
* CVE-2025-58057 https://github.com/advisories/GHSA-3p8m-j85q-pgmj decompression (zip) bomb

Upgrade Spring Boot from 3.3.5 to 3.3.13. This indirectly upgrades spring-core from 6.2.10 to 6.2.11 fixing CVE-2025-41249 https://spring.io/security/cve-2025-41249  improper authorization.

### Changes Checklist
- n/a **API Changes**: Document any API paths, methods, request or response bodies changed, added, or removed.
- n/a **Database Schema Changes**: Indicate any database schema changes and their impact. Confirm that migration scripts were created.
- n/a **Interface Version Changes**: Indicate any changes to interface versions.
- n/a **Interface Dependencies**: Document added or removed dependencies.
- n/a **Permissions**: Document any changes to permissions.
- [x] **Logging**: Confirm that logging is appropriately handled.
- [x] **Unit Testing**: Confirm that changed classes were covered by unit tests.
- [x] **Integration Testing**: Confirm that changed logic was covered by integration tests.
- [x] **Manual Testing**: Confirm that changes were tested on local or dev environment.
- [x] **NEWS**: Confirm that the NEWS file is updated with relevant information about the changes made in this pull request.

### Related Issues
https://folio-org.atlassian.net/browse/MODELINKS-340