### PR TITLE
feat(authority-storage): adjust FQM authority schema to hide several fields

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -28,6 +28,7 @@
 * Support identifiers' type names for FQM ([MODELINKS-405](https://folio-org.atlassian.net/browse/MODELINKS-405))
 * Support notes' type names for FQM ([MODELINKS-406](https://folio-org.atlassian.net/browse/MODELINKS-406))
 * Add handlers for ConstraintViolationException and CqlQueryValidationException ([MODELINKS-407](https://folio-org.atlassian.net/browse/MODELINKS-407))
+* Adjust FQM authority schema to hide several fields ([MODELINKS-409](https://folio-org.atlassian.net/browse/MODELINKS-409))
 
 ### Bug fixes
 * Fix authority source file propagation to propagate all codes ([MODELINKS-315](https://folio-org.atlassian.net/browse/MODELINKS-315))

--- a/src/main/resources/swagger.api/schemas/authority-source-file/authoritySourceFileDto.yaml
+++ b/src/main/resources/swagger.api/schemas/authority-source-file/authoritySourceFileDto.yaml
@@ -6,6 +6,7 @@ properties:
     type: string
     format: uuid
     x-fqm-essential: true
+    x-fqm-visibility: hidden
     x-fqm-value-getter: ":sourceAlias.id"
   name:
     type: string

--- a/src/main/resources/swagger.api/schemas/authority-storage/authorityDtoIdentifier.yaml
+++ b/src/main/resources/swagger.api/schemas/authority-storage/authorityDtoIdentifier.yaml
@@ -10,6 +10,7 @@ properties:
     description: Resource identifier type (e.g. Control number, LCCN, Other standard identifier, System control number)
     type: string
     format: uuid
+    x-fqm-visibility: hidden
     x-fqm-value-getter: "(SELECT array_agg(elems.value->>'identifierTypeId') FROM jsonb_array_elements(:sourceAlias.identifiers) AS elems)"
   identifierType:
     description: Resource identifier type. Used only for FQM queries

--- a/src/main/resources/swagger.api/schemas/authority-storage/authorityDtoNote.yaml
+++ b/src/main/resources/swagger.api/schemas/authority-storage/authorityDtoNote.yaml
@@ -5,6 +5,7 @@ properties:
     description: Note type id
     type: string
     format: uuid
+    x-fqm-visibility: hidden
     x-fqm-value-getter: "(SELECT array_agg(elems.value->>'noteTypeId') FROM jsonb_array_elements(:sourceAlias.notes) AS elems)"
   noteType:
     description: Note type. Used only for FQM queries
@@ -30,6 +31,7 @@ properties:
   staffOnly:
     type: boolean
     description: Whether the note is visible to staff only
+    x-fqm-visibility: hidden
     x-fqm-value-getter: "(SELECT array_agg(elems.value->>'staffOnly') FROM jsonb_array_elements(:sourceAlias.notes) AS elems)"
     x-fqm-filter-value-getter: "(SELECT array_agg(lower(elems.value->>'staffOnly')) FROM jsonb_array_elements(:sourceAlias.notes) AS elems)"
 required:

--- a/src/main/resources/swagger.api/schemas/authority-storage/authorityStorageDto.yaml
+++ b/src/main/resources/swagger.api/schemas/authority-storage/authorityStorageDto.yaml
@@ -1,4 +1,4 @@
-description: An authority storage record aligned with the authority DB table
+description: An authority storage record aligned with the authority DB table (used only for FQM)
 type: object
 properties:
   id:


### PR DESCRIPTION
### Purpose
Adjust FQM authority schema to hide several fields:

- Authority — Identifiers - Identifier type UUID
- Source file — UUID
- Authority — Notes - Note type UUID
- Authority — Notes - Staff Only

### Approach
Use hidden visibility for the fields

### Changes Checklist
- [ ] **API Changes**: Document any API paths, methods, request or response bodies changed, added, or removed.
- [ ] **Database Schema Changes**: Indicate any database schema changes and their impact. Confirm that migration scripts were created.
- [ ] **Interface Version Changes**: Indicate any changes to interface versions.
- [ ] **Interface Dependencies**: Document added or removed dependencies.
- [ ] **Permissions**: Document any changes to permissions.
- [ ] **Logging**: Confirm that logging is appropriately handled.
- [ ] **Unit Testing**: Confirm that changed classes were covered by unit tests.
- [ ] **Integration Testing**: Confirm that changed logic was covered by integration tests.
- [x] **Manual Testing**: Confirm that changes were tested on local or dev environment.
- [x] **NEWS**: Confirm that the NEWS file is updated with relevant information about the changes made in this pull request.

### Related Issues
https://folio-org.atlassian.net/browse/MODELINKS-409