### PR TITLE
fix(di-create): add validation for Authority record creation during Data Import

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -10,7 +10,7 @@
 * Description ([ISSUE](https://folio-org.atlassian.net/browse/ISSUE))
 
 ### Bug fixes
-* Description ([ISSUE](https://folio-org.atlassian.net/browse/ISSUE))
+* Add validation for Authority record creation during Data Import ([MODELINKS-417](https://folio-org.atlassian.net/browse/MODELINKS-417))
 
 ### Tech Dept
 * Description ([ISSUE](https://folio-org.atlassian.net/browse/ISSUE))

--- a/src/main/java/org/folio/entlinks/controller/delegate/AuthorityServiceDelegate.java
+++ b/src/main/java/org/folio/entlinks/controller/delegate/AuthorityServiceDelegate.java
@@ -1,5 +1,6 @@
 package org.folio.entlinks.controller.delegate;
 
+import jakarta.validation.Valid;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Objects;
@@ -31,8 +32,10 @@ import org.folio.tenant.domain.dto.SettingCollection;
 import org.folio.tenant.settings.service.TenantSettingsService;
 import org.jetbrains.annotations.NotNull;
 import org.springframework.stereotype.Service;
+import org.springframework.validation.annotation.Validated;
 
 @Log4j2
+@Validated
 @Service
 public class AuthorityServiceDelegate {
 
@@ -86,6 +89,10 @@ public class AuthorityServiceDelegate {
     var created = service.create(entity);
     createConsumer().accept(created);
     return mapper.toDto(created);
+  }
+
+  public AuthorityDto createAuthorityIfValid(@Valid AuthorityDto authorityDto) {
+    return createAuthority(authorityDto);
   }
 
   public void updateAuthority(UUID id, AuthorityDto authorityDto) {

--- a/src/main/java/org/folio/entlinks/integration/di/handler/AuthorityCreateEventHandler.java
+++ b/src/main/java/org/folio/entlinks/integration/di/handler/AuthorityCreateEventHandler.java
@@ -1,8 +1,10 @@
 package org.folio.entlinks.integration.di.handler;
 
 import static org.folio.ActionProfile.FolioRecord.AUTHORITY;
+import static org.folio.entlinks.exception.type.ErrorType.VALIDATION_ERROR;
 
 import io.vertx.core.json.JsonObject;
+import jakarta.validation.ConstraintViolationException;
 import java.util.concurrent.CompletableFuture;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
@@ -16,6 +18,9 @@ import org.folio.processing.events.services.handler.EventHandler;
 import org.folio.processing.exceptions.EventProcessingException;
 import org.folio.rest.jaxrs.model.ProfileSnapshotWrapper;
 import org.folio.rest.jaxrs.model.ProfileType;
+import org.folio.tenant.domain.dto.Error;
+import org.folio.tenant.domain.dto.Errors;
+import org.folio.tenant.domain.dto.Parameter;
 import org.springframework.stereotype.Component;
 import tools.jackson.core.JacksonException;
 import tools.jackson.databind.json.JsonMapper;
@@ -34,10 +39,17 @@ public class AuthorityCreateEventHandler implements EventHandler {
 
   @Override
   public CompletableFuture<DataImportEventPayload> handle(DataImportEventPayload payload) {
-    var authority = sourceMapper.map(payload);
-    var createdAuthority = delegate.createAuthority(authority);
-    preparePayload(payload, createdAuthority);
-    return CompletableFuture.completedFuture(payload);
+    try {
+      preparePayload(payload);
+      var authority = sourceMapper.map(payload);
+      var createdAuthority = delegate.createAuthorityIfValid(authority);
+      preparePayload(payload, createdAuthority);
+      return CompletableFuture.completedFuture(payload);
+    } catch (ConstraintViolationException e) {
+      return CompletableFuture.failedFuture(
+          new EventProcessingException(jsonMapper.writeValueAsString(buildValidationError(e)))
+      );
+    }
   }
 
   @Override
@@ -68,9 +80,29 @@ public class AuthorityCreateEventHandler implements EventHandler {
     }
   }
 
+  private void preparePayload(DataImportEventPayload payload) {
+    payload.setEventType(DataImportEventTypes.DI_INVENTORY_AUTHORITY_CREATED.value());
+    payload.getEventsChain().add(payload.getEventType());
+    payload.getContext().put(AUTHORITY.value(), new JsonObject().encode());
+  }
+
   private boolean isEligibleActionProfile(ProfileSnapshotWrapper currentNode) {
     var actionProfile = JsonObject.mapFrom(currentNode.getContent()).mapTo(ActionProfile.class);
     return ActionProfile.Action.CREATE == actionProfile.getAction()
            && AUTHORITY == actionProfile.getFolioRecord();
+  }
+
+  private Errors buildValidationError(ConstraintViolationException e) {
+    var errors = e.getConstraintViolations().stream()
+        .map(violation -> {
+          var field = String.valueOf(violation.getPropertyPath());
+          var invalidValue = String.valueOf(violation.getInvalidValue());
+          return new Error("%s: %s".formatted(field, violation.getMessage()))
+              .type(violation.getClass().getSimpleName())
+              .code(VALIDATION_ERROR.getValue())
+              .addParametersItem(new Parameter(field).value(invalidValue));
+        })
+        .toList();
+    return new Errors().errors(errors).totalRecords(errors.size());
   }
 }

--- a/src/test/java/org/folio/entlinks/integration/di/handler/AuthorityCreateEventHandlerTest.java
+++ b/src/test/java/org/folio/entlinks/integration/di/handler/AuthorityCreateEventHandlerTest.java
@@ -75,7 +75,7 @@ class AuthorityCreateEventHandlerTest {
   @SneakyThrows
   void handle_positive() {
     when(sourceMapper.map(payload)).thenReturn(authorityDto);
-    when(delegate.createAuthority(authorityDto)).thenReturn(authorityDto);
+    when(delegate.createAuthorityIfValid(authorityDto)).thenReturn(authorityDto);
     when(jsonMapper.writeValueAsString(authorityDto)).thenReturn(MOCKED_AUTHORITY_DTO_AS_STRING);
 
     var future = handler.handle(payload);
@@ -91,7 +91,7 @@ class AuthorityCreateEventHandlerTest {
   void handle_negative() {
     // Arrange
     when(sourceMapper.map(payload)).thenReturn(authorityDto);
-    when(delegate.createAuthority(authorityDto)).thenReturn(authorityDto);
+    when(delegate.createAuthorityIfValid(authorityDto)).thenReturn(authorityDto);
     when(jsonMapper.writeValueAsString(authorityDto))
         .thenThrow(new StreamReadException(null, "test error"));
     // Act + Assert

--- a/src/test/java/org/folio/entlinks/integration/kafka/DataImportCreateEventListenerIT.java
+++ b/src/test/java/org/folio/entlinks/integration/kafka/DataImportCreateEventListenerIT.java
@@ -9,6 +9,7 @@ import static org.folio.support.TestDataUtils.AuthorityTestData.authority;
 import static org.folio.support.base.TestConstants.DI_AUTHORITY_CREATED_POST_PROCESSING_TOPIC;
 import static org.folio.support.base.TestConstants.DI_CREATED_TYPE;
 import static org.folio.support.base.TestConstants.DI_CREATE_AUTHORITY_PATH;
+import static org.folio.support.base.TestConstants.DI_CREATE_INVALID_AUTHORITY_PATH;
 import static org.folio.support.base.TestConstants.DI_ERROR_TOPIC;
 import static org.folio.support.base.TestConstants.TENANT_ID;
 import static org.folio.support.base.TestConstants.USER_ID;
@@ -180,7 +181,29 @@ class DataImportCreateEventListenerIT extends IntegrationTestBase {
     assertions.then(received.key()).as("key").isEqualTo(AUTHORITY_CREATE_ID.toString());
     assertions.then(received.topic()).as("topic").contains(DI_ERROR_TOPIC);
     assertions.then(received.value().getEventPayload())
-      .contains("ERROR: duplicate key value violates unique constraint");
+        .contains("ERROR: duplicate key value violates unique constraint");
+    assertions.assertAll();
+  }
+
+  @SneakyThrows
+  @Test
+  void shouldHandleDataImportAuthorityCreatedEvent_negative_validationError() {
+    // send DI authority created event
+    var eventPayload = readFile(DI_CREATE_INVALID_AUTHORITY_PATH);
+    var event = TestDataUtils.diAuthorityEvent(DI_CREATED_TYPE,
+        eventPayload, AUTHORITY_CREATE_ID.toString(), TENANT_ID);
+    sendKafkaMessage(dataImportAuthorityCreatedTopic(), AUTHORITY_CREATE_ID.toString(), event,
+        getDataImportKafkaHeaders(AUTHORITY_CREATE_ID.toString()));
+
+    // check sent DI error event
+    var received = getReceivedEvent();
+
+    var assertions = new BDDSoftAssertions();
+    assertions.then(received).isNotNull();
+    assertions.then(received.key()).as("key").isEqualTo(AUTHORITY_CREATE_ID.toString());
+    assertions.then(received.topic()).as("topic").contains(DI_ERROR_TOPIC);
+    assertions.then(received.value().getEventPayload())
+        .contains("identifiers[0].value: must not be null");
     assertions.assertAll();
   }
 

--- a/src/test/java/org/folio/support/base/TestConstants.java
+++ b/src/test/java/org/folio/support/base/TestConstants.java
@@ -55,6 +55,7 @@ public class TestConstants {
   public static final String JOB_EXECUTION_ID = "jobExecutionId";
   public static final String PATH = "classpath:di-authority/";
   public static final String DI_CREATE_AUTHORITY_PATH = PATH + "create.json";
+  public static final String DI_CREATE_INVALID_AUTHORITY_PATH = PATH + "createInvalidAuthority.json";
   public static final String DI_UPDATE_AUTHORITY_PATH = PATH + "update.json";
   public static final String DI_DELETE_AUTHORITY_PATH = PATH + "delete.json";
   public static final String TEST_STRING = "test, ";

--- a/src/test/resources/di-authority/createInvalidAuthority.json
+++ b/src/test/resources/di-authority/createInvalidAuthority.json
@@ -1,0 +1,258 @@
+{
+  "eventType": "DI_SRS_MARC_AUTHORITY_RECORD_CREATED",
+  "currentNode": {
+    "id": "659b7d01-39c8-4d66-bd05-90e81e6e9aeb",
+    "profileId": "7915c72e-c6af-4962-969d-403c7238b051",
+    "profileWrapperId": "570476c2-2309-4a66-be93-eef158882f66",
+    "contentType": "ACTION_PROFILE",
+    "content": {
+      "id": "7915c72e-c6af-4962-969d-403c7238b051",
+      "name": "Default - Create MARC Authority",
+      "action": "CREATE",
+      "hidden": false,
+      "metadata": {
+        "createdDate": "2021-10-08T14:00:00.000+00:00",
+        "updatedDate": "2021-10-08T15:00:00.462+00:00",
+        "createdByUserId": "00000000-0000-0000-0000-000000000000",
+        "updatedByUserId": "00000000-0000-0000-0000-000000000000"
+      },
+      "userInfo": {
+        "lastName": "Doe",
+        "userName": "mod-entities-links",
+        "firstName": "John"
+      },
+      "description": "This action profile is used with FOLIO's default job profile for creating a MARC authority record in source-record-storage. It cannot be edited, duplicated, or deleted.",
+      "folioRecord": "AUTHORITY",
+      "childProfiles": [],
+      "parentProfiles": [],
+      "remove9Subfields": false
+    },
+    "order": 0,
+    "childSnapshotWrappers": [
+      {
+        "id": "61dbd29d-bc9c-4a40-a413-df4fe79fb757",
+        "profileId": "6a0ec1de-68eb-4833-bdbf-0741db25c314",
+        "profileWrapperId": "b5befbad-caac-4f05-8e94-6a292a1fbe17",
+        "contentType": "MAPPING_PROFILE",
+        "content": {
+          "id": "6a0ec1de-68eb-4833-bdbf-0741db25c314",
+          "name": "Default - Create MARC Authority",
+          "hidden": false,
+          "metadata": {
+            "createdDate": "2021-10-08T14:00:00.000+00:00",
+            "updatedDate": "2021-10-08T15:00:00.462+00:00",
+            "createdByUserId": "00000000-0000-0000-0000-000000000000",
+            "updatedByUserId": "00000000-0000-0000-0000-000000000000"
+          },
+          "userInfo": {
+            "lastName": "System",
+            "userName": "System",
+            "firstName": "System"
+          },
+          "description": "This field mapping profile is used with FOLIO's default job profile for creating MARC Authority records. It cannot be edited, duplicated, deleted, or linked to additional action profiles.",
+          "childProfiles": [],
+          "mappingDetails": {
+            "name": "authority",
+            "recordType": "AUTHORITY",
+            "mappingFields": [
+              {
+                "name": "personalName",
+                "path": "authority.personalName",
+                "value": "",
+                "enabled": "false",
+                "required": false,
+                "subfields": []
+              },
+              {
+                "name": "sftPersonalName",
+                "path": "authority.sftPersonalName[]",
+                "value": "",
+                "enabled": "false",
+                "required": false,
+                "subfields": []
+              },
+              {
+                "name": "saftPersonalName",
+                "path": "authority.saftPersonalName[]",
+                "value": "",
+                "enabled": "false",
+                "required": false,
+                "subfields": []
+              },
+              {
+                "name": "corporateName",
+                "path": "authority.corporateName",
+                "value": "",
+                "enabled": "false",
+                "required": false,
+                "subfields": []
+              },
+              {
+                "name": "sftCorporateName",
+                "path": "authority.sftCorporateName[]",
+                "value": "",
+                "enabled": "false",
+                "required": false,
+                "subfields": []
+              },
+              {
+                "name": "saftCorporateName",
+                "path": "authority.saftCorporateName[]",
+                "value": "",
+                "enabled": "false",
+                "required": false,
+                "subfields": []
+              },
+              {
+                "name": "meetingName",
+                "path": "authority.meetingName[]",
+                "value": "",
+                "enabled": "false",
+                "required": false,
+                "subfields": []
+              },
+              {
+                "name": "sftMeetingName",
+                "path": "authority.sftMeetingName[]",
+                "value": "",
+                "enabled": "false",
+                "required": false,
+                "subfields": []
+              },
+              {
+                "name": "saftMeetingName",
+                "path": "authority.saftMeetingName[]",
+                "value": "",
+                "enabled": "false",
+                "required": false,
+                "subfields": []
+              },
+              {
+                "name": "uniformTitle",
+                "path": "authority.uniformTitle",
+                "value": "",
+                "enabled": "false",
+                "required": false,
+                "subfields": []
+              },
+              {
+                "name": "sftUniformTitle",
+                "path": "authority.sftUniformTitle[]",
+                "value": "",
+                "enabled": "false",
+                "required": false,
+                "subfields": []
+              },
+              {
+                "name": "saftUniformTitle",
+                "path": "authority.saftUniformTitle[]",
+                "value": "",
+                "enabled": "false",
+                "required": false,
+                "subfields": []
+              },
+              {
+                "name": "topicalTerm",
+                "path": "authority.topicalTerm",
+                "value": "",
+                "enabled": "false",
+                "required": false,
+                "subfields": []
+              },
+              {
+                "name": "sftTopicalTerm",
+                "path": "authority.sftTopicalTerm[]",
+                "value": "",
+                "enabled": "false",
+                "required": false,
+                "subfields": []
+              },
+              {
+                "name": "saftTopicalTerm",
+                "path": "authority.saftTopicalTerm[]",
+                "value": "",
+                "enabled": "false",
+                "required": false,
+                "subfields": []
+              },
+              {
+                "name": "subjectHeadings",
+                "path": "authority.subjectHeadings",
+                "value": "",
+                "enabled": "false",
+                "required": false,
+                "subfields": []
+              },
+              {
+                "name": "geographicName",
+                "path": "authority.geographicName",
+                "value": "",
+                "enabled": "false",
+                "required": false,
+                "subfields": []
+              },
+              {
+                "name": "sftGeographicTerm",
+                "path": "authority.sftGeographicTerm[]",
+                "value": "",
+                "enabled": "false",
+                "required": false,
+                "subfields": []
+              },
+              {
+                "name": "saftGeographicTerm",
+                "path": "authority.saftGeographicTerm[]",
+                "value": "",
+                "enabled": "false",
+                "required": false,
+                "subfields": []
+              },
+              {
+                "name": "genre",
+                "path": "authority.genre",
+                "value": "",
+                "enabled": "false",
+                "required": false,
+                "subfields": []
+              },
+              {
+                "name": "identifiers",
+                "path": "authority.identifiers[]",
+                "value": "",
+                "enabled": "false",
+                "required": false,
+                "subfields": []
+              },
+              {
+                "name": "notes",
+                "path": "authority.notes[]",
+                "value": "",
+                "enabled": "false",
+                "required": false,
+                "subfields": []
+              }
+            ],
+            "marcMappingDetails": []
+          },
+          "parentProfiles": [],
+          "existingRecordType": "AUTHORITY",
+          "incomingRecordType": "MARC_AUTHORITY",
+          "marcFieldProtectionSettings": []
+        },
+        "order": 0,
+        "childSnapshotWrappers": []
+      }
+    ]
+  },
+  "currentNodePath": [],
+  "eventsChain": [],
+  "jobExecutionId": "3b255ca5-6746-47a1-9bd6-45c5bb948b77",
+  "tenant": "test",
+  "token": "",
+  "okapiUrl": "http://localhost:8082",
+  "context": {
+    "MARC_AUTHORITY": "{\"id\":\"bdd611b6-4feb-4dab-9c19-da13a856045a\",\"snapshotId\":\"3b255ca5-6746-47a1-9bd6-45c5bb948b77\",\"matchedId\":\"bdd611b6-4feb-4dab-9c19-da13a856045a\",\"recordType\":\"MARC_AUTHORITY\",\"rawRecord\":{\"id\":\"bdd611b6-4feb-4dab-9c19-da13a856045a\",\"content\":\"01055cz  a2200169n  4500001000800000005001700008008004100025010001700066035002300083040003300106111005900139411006100198511007100259667009500330670012200425675033800547\\u001E8979089\\u001E20120828074806.0\\u001E120502n| acannaabn          |a ana     c\\u001E  \\u001Fano2012061368\\u001E  \\u001Fa(OCoLC)oca09186965\\u001E  \\u001FaOkS\\u001Fbeng\\u001FcOkS\\u001FdOkS\\u001FdDLC\\u001FdOkS\\u001E2 \\u001FaWestern Region Agricultural Education Research Meeting\\u001E2 \\u001FaWestern Regional Agricultural Education Research Meeting\\u001E2 \\u001Fwb\\u001FaWestern Region Agricultural Education Research Seminar (1983- )\\u001E  \\u001FaTHIS 1XX FIELD CANNOT BE USED UNDER RDA UNTIL THIS RECORD HAS BEEN REVIEWED AND/OR UPDATED\\u001E  \\u001FaFirst annual Western Region Agricultural Education Research Meeting, 1982:\\u001Fbt.p. (held April 26, 1982, Austin, Texas)\\u001E  \\u001FaSecond annual Western Region Agricultural Education Research Seminar, 1983: t.p. (held April 19, 1983, Rio Rico, Arizona) p. [3] (2nd Western Regional Research Meeting)\\u001FaResearch in agricultural education, 1993: cover (Twelfth annual Western Regional Agricultural Education Research Meeting; held in Bozeman, Montana, April 14, 1993)\\u001E\\u001D\"},\"parsedRecord\":{\"id\":\"bdd611b6-4feb-4dab-9c19-da13a856045a\",\"content\":\"{\\\"leader\\\":\\\"01146cz  a2200181n  4500\\\",\\\"fields\\\":[{\\\"001\\\":\\\"\\\"},{\\\"005\\\":\\\"20120828074806.0\\\"},{\\\"008\\\":\\\"120502n| acannaabn          |a ana     c\\\"},{\\\"010\\\":{\\\"subfields\\\":[{\\\"a\\\":\\\"codeOne\\\"}],\\\"ind1\\\":\\\" \\\",\\\"ind2\\\":\\\" \\\"}},{\\\"035\\\":{\\\"subfields\\\":[{\\\"a\\\":\\\"(OCoLC)oca09186965\\\"}],\\\"ind1\\\":\\\" \\\",\\\"ind2\\\":\\\" \\\"}},{\\\"040\\\":{\\\"subfields\\\":[{\\\"a\\\":\\\"OkS\\\"},{\\\"b\\\":\\\"eng\\\"},{\\\"c\\\":\\\"OkS\\\"},{\\\"d\\\":\\\"OkS\\\"},{\\\"d\\\":\\\"DLC\\\"},{\\\"d\\\":\\\"OkS\\\"}],\\\"ind1\\\":\\\" \\\",\\\"ind2\\\":\\\" \\\"}},{\\\"111\\\":{\\\"subfields\\\":[{\\\"a\\\":\\\"Western Region Agricultural Education Research Meeting\\\"}],\\\"ind1\\\":\\\"2\\\",\\\"ind2\\\":\\\" \\\"}},{\\\"411\\\":{\\\"subfields\\\":[{\\\"a\\\":\\\"Western Regional Agricultural Education Research Meeting\\\"}],\\\"ind1\\\":\\\"2\\\",\\\"ind2\\\":\\\" \\\"}},{\\\"511\\\":{\\\"subfields\\\":[{\\\"w\\\":\\\"b\\\"},{\\\"a\\\":\\\"Western Region Agricultural Education Research Seminar (1983- )\\\"}],\\\"ind1\\\":\\\"2\\\",\\\"ind2\\\":\\\" \\\"}},{\\\"667\\\":{\\\"subfields\\\":[{\\\"a\\\":\\\"THIS 1XX FIELD CANNOT BE USED UNDER RDA UNTIL THIS RECORD HAS BEEN REVIEWED AND/OR UPDATED\\\"}],\\\"ind1\\\":\\\" \\\",\\\"ind2\\\":\\\" \\\"}},{\\\"670\\\":{\\\"subfields\\\":[{\\\"a\\\":\\\"First annual Western Region Agricultural Education Research Meeting, 1982:\\\"},{\\\"b\\\":\\\"t.p. (held April 26, 1982, Austin, Texas)\\\"}],\\\"ind1\\\":\\\" \\\",\\\"ind2\\\":\\\" \\\"}},{\\\"675\\\":{\\\"subfields\\\":[{\\\"a\\\":\\\"Second annual Western Region Agricultural Education Research Seminar, 1983: t.p. (held April 19, 1983, Rio Rico, Arizona) p. [3] (2nd Western Regional Research Meeting)\\\"},{\\\"a\\\":\\\"Research in agricultural education, 1993: cover (Twelfth annual Western Regional Agricultural Education Research Meeting; held in Bozeman, Montana, April 14, 1993)\\\"}],\\\"ind1\\\":\\\" \\\",\\\"ind2\\\":\\\" \\\"}},{\\\"999\\\":{\\\"subfields\\\":[{\\\"i\\\":\\\"7e3745e6-2d48-4f22-825e-72f3338bfa14\\\"},{\\\"s\\\":\\\"bdd611b6-4feb-4dab-9c19-da13a856045a\\\"}],\\\"ind1\\\":\\\"f\\\",\\\"ind2\\\":\\\"f\\\"}}]}\",\"formattedContent\":\"LEADER 01146cz  a2200181n  4500\\n001 \\n005 20120828074806.0\\n008 120502n| acannaabn          |a ana     c\\n010   $ano2012061368\\n035   $a(OCoLC)oca09186965\\n040   $aOkS$beng$cOkS$dOkS$dDLC$dOkS\\n111 2 $aWestern Region Agricultural Education Research Meeting\\n411 2 $aWestern Regional Agricultural Education Research Meeting\\n511 2 $wb$aWestern Region Agricultural Education Research Seminar (1983- )\\n667   $aTHIS 1XX FIELD CANNOT BE USED UNDER RDA UNTIL THIS RECORD HAS BEEN REVIEWED AND/OR UPDATED\\n670   $aFirst annual Western Region Agricultural Education Research Meeting, 1982:$bt.p. (held April 26, 1982, Austin, Texas)\\n675   $aSecond annual Western Region Agricultural Education Research Seminar, 1983: t.p. (held April 19, 1983, Rio Rico, Arizona) p. [3] (2nd Western Regional Research Meeting)$aResearch in agricultural education, 1993: cover (Twelfth annual Western Regional Agricultural Education Research Meeting; held in Bozeman, Montana, April 14, 1993)\\n999 ff$i7e3745e6-2d48-4f22-825e-72f3338bfa14$sbdd611b6-4feb-4dab-9c19-da13a856045a\\n\\n\"},\"deleted\":false,\"order\":0,\"externalIdsHolder\":{\"authorityId\":\"7e3745e6-2d48-4f22-825e-72f3338bfa14\",\"authorityHrid\":\"8979089\"},\"additionalInfo\":{\"suppressDiscovery\":false},\"state\":\"ACTUAL\",\"metadata\":{\"createdByUserId\":\"fb218675-93c5-4843-b406-8f5a8a427bf4\",\"updatedByUserId\":\"fb218675-93c5-4843-b406-8f5a8a427bf4\"}}",
+    "INCOMING_RECORD_ID": "bdd611b6-4feb-4dab-9c19-da13a856045a",
+    "JOB_PROFILE_SNAPSHOT_ID": "ab7f0cff-1c02-4204-85ce-5917731041c1"
+  }
+}


### PR DESCRIPTION
### Purpose
When creating a MARC Authority record via a DataImport job, records with an empty `001` field are incorrectly processed as successful.
Before moving the authority DataImport logic from the `mod-inventory` module to the `mod-entities-links` module, the `mod-inventory` module called the `mod-entities-links` API endpoint to create the authority. This endpoint validated the request body and returned an error message if the authority record was invalid.
Now, `mod-entities-links` invokes the method to create the authority directly within the module and does not validate the authority record.

### Approach
- add validation for AuthorityDto record creation during Data Import.
- run `preparePayload` before authority validation.

### Changes Checklist
- [ ] **API Changes**: Document any API paths, methods, request or response bodies changed, added, or removed.
- [ ] **Database Schema Changes**: Indicate any database schema changes and their impact. Confirm that migration scripts were created.
- [ ] **Interface Version Changes**: Indicate any changes to interface versions.
- [ ] **Interface Dependencies**: Document added or removed dependencies.
- [ ] **Permissions**: Document any changes to permissions.
- [ ] **Logging**: Confirm that logging is appropriately handled.
- [ ] **Unit Testing**: Confirm that changed classes were covered by unit tests.
- [x] **Integration Testing**: Confirm that changed logic was covered by integration tests.
- [x] **Manual Testing**: Confirm that changes were tested on local or dev environment.
- [x] **NEWS**: Confirm that the NEWS file is updated with relevant information about the changes made in this pull request.

### Related Issues
[MODELINKS-417](https://folio-org.atlassian.net/browse/MODELINKS-417)

### Screenshots (if applicable)
<img width="1823" height="288" alt="image" src="https://github.com/user-attachments/assets/0e79e5e0-6014-48ca-9944-fdef9a8b10ad" />

</br>

>  Error message: `org.folio.processing.exceptions.EventProcessingException: {"errors":[{"message":"createAuthorityIfValid.authorityDto.identifiers[0].value: must not be null","code":"validation","parameters":[{"key":"createAuthorityIfValid.authorityDto.identifiers[0].value","value":"null"}],"type":"ConstraintViolationImpl"}],"total_records":1}`

<img width="1907" height="245" alt="image" src="https://github.com/user-attachments/assets/4a58484c-00a2-41da-a0a0-48c4f4522634" />

