### PR TITLE
Fix for Array index out of bounds

### DIFF
--- a/src/test/java/org/folio/support/TestUtils.java
+++ b/src/test/java/org/folio/support/TestUtils.java
@@ -9,6 +9,9 @@ public class TestUtils {
 
   @SuppressWarnings("unchecked")
   public static <K, V> Map<K, V> mapOf(K k1, V v1, Object... pairs) {
+    if (pairs.length % 2 != 0) {
+      throw new IllegalArgumentException("pairs must contain an even number of elements (key/value pairs)");
+    }
     Map<K, V> map = new LinkedHashMap<>();
     map.put(k1, v1);
     for (int i = 0; i < pairs.length; i += 2) {


### PR DESCRIPTION
The correct fix is to enforce the key/value-pair precondition before entering the loop.  
In `src/test/java/org/folio/support/TestUtils.java`, inside `mapOf`, add a validation that `pairs.length` is even. If it is odd, throw an `IllegalArgumentException` with a clear message. This preserves existing behavior for valid input and fails fast with a descriptive exception for invalid input instead of an `ArrayIndexOutOfBoundsException`.

No new imports are required. The loop logic can remain unchanged once input is validated.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._