### PR TITLE
fix(authority-storage): Remove ambiguous FQM source/valueSourceApi field configs

### DIFF
--- a/src/main/resources/swagger.api/schemas/authority-heading-type/authorityHeadingTypeDto.yaml
+++ b/src/main/resources/swagger.api/schemas/authority-heading-type/authorityHeadingTypeDto.yaml
@@ -22,6 +22,7 @@ properties:
     type: string
     description: Code of the authority heading type
     x-fqm-value-getter: ":sourceAlias.code"
+    x-fqm-essential: true
   queryable:
     type: boolean
     description: Whether this heading type is queryable

--- a/src/main/resources/swagger.api/schemas/authority-identifier-type/authorityIdentifierTypeDto.yaml
+++ b/src/main/resources/swagger.api/schemas/authority-identifier-type/authorityIdentifierTypeDto.yaml
@@ -6,6 +6,7 @@ properties:
     type: string
     format: uuid
     x-fqm-value-getter: ":sourceAlias.id"
+    x-fqm-essential: true
   name:
     type: string
     description: Name of the authority identifier type

--- a/src/main/resources/swagger.api/schemas/authority-source-file/authoritySourceFileDto.yaml
+++ b/src/main/resources/swagger.api/schemas/authority-source-file/authoritySourceFileDto.yaml
@@ -15,10 +15,6 @@ properties:
     x-fqm-id-column-name: "id"
     x-fqm-visible-by-default: true
     x-fqm-value-getter: ":sourceAlias.name"
-    x-fqm-source: {
-      "entityTypeId": "c788d4b8-2a7e-5d6c-8d6b-c548f95455e5",
-      "columnName": "name"
-    }
     x-fqm-value-source-api: {
       "path": "authority-source-files",
       "valueJsonPath": "$.authoritySourceFiles.*.id",

--- a/src/main/resources/swagger.api/schemas/authority-storage/authorityStorageDto.yaml
+++ b/src/main/resources/swagger.api/schemas/authority-storage/authorityStorageDto.yaml
@@ -86,6 +86,8 @@ properties:
           description: Relationship type
           enum: [BROADER_TERM, NARROWER_TERM, EARLIER_HEADING, LATER_HEADING]
           x-fqm-data-type: "arrayType"
+          items:
+            type: string
           x-fqm-value-getter: "(SELECT array_agg(relationship_types.value) FROM jsonb_array_elements(:sourceAlias.sft_headings) AS elems CROSS JOIN LATERAL jsonb_array_elements_text(COALESCE(elems.value->'relationshipType', '[]'::jsonb)) AS relationship_types(value))"
           x-fqm-filter-value-getter: "(SELECT array_agg(lower(relationship_types.value)) FROM jsonb_array_elements(:sourceAlias.sft_headings) AS elems CROSS JOIN LATERAL jsonb_array_elements_text(COALESCE(elems.value->'relationshipType', '[]'::jsonb)) AS relationship_types(value))"
           x-fqm-value-function: "lower(:value)"
@@ -116,6 +118,8 @@ properties:
           description: Relationship type
           enum: [BROADER_TERM, NARROWER_TERM, EARLIER_HEADING, LATER_HEADING]
           x-fqm-data-type: "arrayType"
+          items:
+            type: string
           x-fqm-value-getter: "(SELECT array_agg(relationship_types.value) FROM jsonb_array_elements(:sourceAlias.saft_headings) AS elems CROSS JOIN LATERAL jsonb_array_elements_text(COALESCE(elems.value->'relationshipType', '[]'::jsonb)) AS relationship_types(value))"
           x-fqm-filter-value-getter: "(SELECT array_agg(lower(relationship_types.value)) FROM jsonb_array_elements(:sourceAlias.saft_headings) AS elems CROSS JOIN LATERAL jsonb_array_elements_text(COALESCE(elems.value->'relationshipType', '[]'::jsonb)) AS relationship_types(value))"
           x-fqm-value-function: "lower(:value)"

--- a/src/main/resources/swagger.api/schemas/authority-storage/authorityStorageDto.yaml
+++ b/src/main/resources/swagger.api/schemas/authority-storage/authorityStorageDto.yaml
@@ -50,11 +50,6 @@ properties:
       entityTypeId: '8629d062-2878-5803-b8bf-f08fb1b00d31',
       columnName: 'name'
     }
-    x-fqm-value-source-api: {
-      "path": "authority-heading-types",
-      "valueJsonPath": "$.headingTypes[?(@.queryable == true)].code",
-      "labelJsonPath": "$.headingTypes[?(@.queryable == true)].name"
-    }
   _version:
     type: integer
     description: Record version for optimistic locking
@@ -83,11 +78,6 @@ properties:
           x-fqm-source: {
             entityTypeId: '8629d062-2878-5803-b8bf-f08fb1b00d31',
             columnName: 'name'
-          }
-          x-fqm-value-source-api: {
-            "path": "authority-heading-types",
-            "valueJsonPath": "$.headingTypes[?(@.queryable == true)].code",
-            "labelJsonPath": "$.headingTypes[?(@.queryable == true)].name"
           }
           x-fqm-value-getter: "(SELECT array_agg(elems.value->>'headingType') FROM jsonb_array_elements(:sourceAlias.sft_headings) AS elems)"
           x-fqm-value-function: "lower(:value)"
@@ -118,11 +108,6 @@ properties:
           x-fqm-source: {
             entityTypeId: '8629d062-2878-5803-b8bf-f08fb1b00d31',
             columnName: 'name'
-          }
-          x-fqm-value-source-api: {
-            "path": "authority-heading-types",
-            "valueJsonPath": "$.headingTypes[?(@.queryable == true)].code",
-            "labelJsonPath": "$.headingTypes[?(@.queryable == true)].name"
           }
           x-fqm-value-getter: "(SELECT array_agg(elems.value->>'headingType') FROM jsonb_array_elements(:sourceAlias.saft_headings) AS elems)"
           x-fqm-value-function: "lower(:value)"


### PR DESCRIPTION
### Purpose
[MODELINKS-424](https://folio-org.atlassian.net/browse/MODELINKS-424): Remove ambiguous FQM source/valueSourceApi field configs

Does not need to be released.

### Related Issues
[MODFQMMGR-1162](https://folio-org.atlassian.net/browse/MODFQMMGR-1162)
