### PR TITLE
feat(authority-storage): Hide relationshipType in sftHeadings for fqm

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -8,6 +8,7 @@
 
 ### Features
 * Enhance error handling for constraint violations ([MODELINKS-410](https://folio-org.atlassian.net/browse/MODELINKS-410))
+* Hide relationshipType in sftHeadings for fqm ([MODELINKS-425](https://folio-org.atlassian.net/browse/MODELINKS-425))
 
 ### Bug fixes
 * Fix FQM querying for authority see-from and see-also-from relationship types  ([MODELINKS-423](https://folio-org.atlassian.net/browse/MODELINKS-423))

--- a/src/main/resources/swagger.api/schemas/authority-storage/authorityStorageDto.yaml
+++ b/src/main/resources/swagger.api/schemas/authority-storage/authorityStorageDto.yaml
@@ -86,6 +86,7 @@ properties:
           description: Relationship type
           enum: [BROADER_TERM, NARROWER_TERM, EARLIER_HEADING, LATER_HEADING]
           x-fqm-data-type: "arrayType"
+          x-fqm-visibility: 'hidden-non-queryable'
           items:
             type: string
           x-fqm-value-getter: "(SELECT array_agg(relationship_types.value) FROM jsonb_array_elements(:sourceAlias.sft_headings) AS elems CROSS JOIN LATERAL jsonb_array_elements_text(COALESCE(elems.value->'relationshipType', '[]'::jsonb)) AS relationship_types(value))"


### PR DESCRIPTION
### Purpose
Hide relationshipType in sftHeadings for fqm

### Changes Checklist
- [ ] **API Changes**: Document any API paths, methods, request or response bodies changed, added, or removed.
- [ ] **Database Schema Changes**: Indicate any database schema changes and their impact. Confirm that migration scripts were created.
- [ ] **Interface Version Changes**: Indicate any changes to interface versions.
- [ ] **Interface Dependencies**: Document added or removed dependencies.
- [ ] **Permissions**: Document any changes to permissions.
- [ ] **Logging**: Confirm that logging is appropriately handled.
- [ ] **Unit Testing**: Confirm that changed classes were covered by unit tests.
- [ ] **Integration Testing**: Confirm that changed logic was covered by integration tests.
- [x] **Manual Testing**: Confirm that changes were tested on local or dev environment.
- [x] **NEWS**: Confirm that the NEWS file is updated with relevant information about the changes made in this pull request.

### Related Issues
[MODELINKS-425](https://folio-org.atlassian.net/browse/MODELINKS-425)

### Manual testing
Used fqm-tools to generate entity and apply changes to mod-fqm-manager, deployed mod-fqm-manager and tested the solution.
Field removed from searchable fields:
<img width="621" height="497" alt="image" src="https://github.com/user-attachments/assets/c1cf05f9-3457-4679-b20e-5866060b283f" />
Field removed from result list:
<img width="597" height="195" alt="image" src="https://github.com/user-attachments/assets/aee0911b-ff6f-4903-b090-9fc30ff7d1f7" />

